### PR TITLE
Use CUDNN in dilated convolution/deconvolution when CUDNN>=6

### DIFF
--- a/include/nbla/cuda/cudnn/cudnn.hpp
+++ b/include/nbla/cuda/cudnn/cudnn.hpp
@@ -94,19 +94,21 @@ struct NBLA_CUDA_API CudnnConv2dDesc {
   int device;            ///< Device ID.
   cudnnDataType_t dtype; ///< Data type.
   cudnnConvolutionMode_t
-      mode;    ///< CUDNN_CONVOLUTION or CUDNN_CROSS_CORRELATION;
-  int n;       ///< Batch size.
-  int c;       ///< Channels of input.
-  int h;       ///< Height of input.
-  int w;       ///< Width of input.
-  int o;       ///< Channels of output
-  int kh;      ///< Height of kernel.
-  int kw;      ///< Width of kernel.
-  int padh;    ///< Padding height of input.
-  int padw;    ///< Padding width of input.
-  int strideh; ///< Padding height of input.
-  int stridew; ///< Padding width of input.
-  int group;   ///< Number of groups.
+      mode;      ///< CUDNN_CONVOLUTION or CUDNN_CROSS_CORRELATION;
+  int n;         ///< Batch size.
+  int c;         ///< Channels of input.
+  int h;         ///< Height of input.
+  int w;         ///< Width of input.
+  int o;         ///< Channels of output
+  int kh;        ///< Height of kernel.
+  int kw;        ///< Width of kernel.
+  int padh;      ///< Padding height of input.
+  int padw;      ///< Padding width of input.
+  int strideh;   ///< Padding height of input.
+  int stridew;   ///< Padding width of input.
+  int group;     ///< Number of groups.
+  int dilationh; ///< Dilation height of filter.
+  int dilationw; ///< Dilation width of filter.
 
   /// Operator == compares all elements.
   bool operator==(const CudnnConv2dDesc &right) const;
@@ -131,6 +133,8 @@ struct NBLA_CUDA_API CudnnConv2dDesc {
       hash_combine(h, x.strideh);
       hash_combine(h, x.stridew);
       hash_combine(h, x.group);
+      hash_combine(h, x.dilationw);
+      hash_combine(h, x.dilationh);
       return h;
     }
   };

--- a/include/nbla/cuda/cudnn/function/convolution.hpp
+++ b/include/nbla/cuda/cudnn/function/convolution.hpp
@@ -33,6 +33,7 @@ public:
                                 const vector<int> &dilation, int group)
       : Convolution<T>(ctx, base_axis, pad, stride, dilation, group),
         device_(std::stoi(ctx.device_id)) {
+#if CUDNN_VERSION < 6000
     // NOTE: dilation > 1 is not supported by cudnn. (2016.10.19)
     for (int i = 0; i < dilation.size(); ++i) {
       if (dilation[i] > 1) {
@@ -47,6 +48,7 @@ public:
         return;
       }
     }
+#endif
   }
   virtual ~ConvolutionCudaCudnn() {
     if (this->fall_back_func_)

--- a/include/nbla/cuda/cudnn/function/deconvolution.hpp
+++ b/include/nbla/cuda/cudnn/function/deconvolution.hpp
@@ -36,6 +36,7 @@ public:
                                   const vector<int> &dilation, int group)
       : Deconvolution<T>(ctx, base_axis, pad, stride, dilation, group),
         device_(std::stoi(ctx.device_id)) {
+#if CUDNN_VERSION < 6000
     // NOTE: dilation > 1 is not supported by cudnn. (2016.10.19)
     for (int i = 0; i < dilation.size(); ++i) {
       if (dilation[i] > 1) {
@@ -50,6 +51,7 @@ public:
         return;
       }
     }
+#endif
   }
   virtual ~DeconvolutionCudaCudnn() {}
   virtual string name() { return "DeconvolutionCudaCudnn"; }

--- a/src/nbla/cuda/cudnn/function/convolution.cu
+++ b/src/nbla/cuda/cudnn/function/convolution.cu
@@ -83,7 +83,9 @@ void ConvolutionCudaCudnn<T>::setup_impl_2d(const Variables &inputs,
                        this->pad_[1],
                        this->stride_[0],
                        this->stride_[1],
-                       this->group_};
+                       this->group_,
+                       this->dilation_[0],
+                       this->dilation_[1]};
   auto &rsc = SingletonManager::get<CudnnHandleManager>()->conv2d_resource;
   auto it = rsc.find(desc);
   if (it != rsc.end()) {

--- a/src/nbla/cuda/cudnn/function/deconvolution.cu
+++ b/src/nbla/cuda/cudnn/function/deconvolution.cu
@@ -64,7 +64,9 @@ void DeconvolutionCudaCudnn<T>::setup_impl_2d(const Variables &inputs,
                        this->pad_[1],
                        this->stride_[0],
                        this->stride_[1],
-                       this->group_};
+                       this->group_,
+                       this->dilation_[0],
+                       this->dilation_[1]};
   auto &rsc = SingletonManager::get<CudnnHandleManager>()->conv2d_resource;
   auto it = rsc.find(desc);
   if (it != rsc.end()) {


### PR DESCRIPTION
This change enables ConvolutionCudaCudnn to use cuDNN in dilated convolution/deconvolution when CUDNN_VERSION=>6. Previously it fall-backed into ConvolutionCuda. In the offline benchmark, it shows near 2x speedup.