### PR TITLE
More efficient workspace memory allocation than cached array

### DIFF
--- a/include/nbla/cuda/cuda.hpp
+++ b/include/nbla/cuda/cuda.hpp
@@ -67,6 +67,21 @@ public:
    */
   MemoryCache<CudaMemory> &memcache();
 
+  /** Get workspace memory.
+
+      @param[in] size_in_bytes Size of CUDA device memory requested.
+      @param[in] device GPU ID.
+
+      @note It internally holds workspace memory with maximum size over
+            sizes previously requested. Every time the requested size exceeds
+            the maximum size, it will reallocate a new memory region, which
+            will cause memory allocation overhead and device synchronization.
+
+      @todo This function is not thread-safe.
+
+   */
+  void *get_workspace(Size_t size_in_bytes, int device);
+
 protected:
   std::mutex mtx_cublas_;
   std::mutex mtx_curand_;
@@ -75,6 +90,7 @@ protected:
   unordered_map<int, curandGenerator_t> curand_generators_;
   vector<string> array_classes_;     ///< Available array classes
   MemoryCache<CudaMemory> memcache_; ///< CUDA memory cache.
+  unordered_map<int, shared_ptr<CudaMemory>> workspace_; ///< Workspace memory.
 
 private:
   friend SingletonManager;

--- a/src/nbla/cuda/cuda.cpp
+++ b/src/nbla/cuda/cuda.cpp
@@ -78,5 +78,20 @@ void Cuda::register_array_class(const string &name) {
 
 MemoryCache<CudaMemory> &Cuda::memcache() { return memcache_; }
 
+void *Cuda::get_workspace(Size_t size_in_bytes, int device) {
+  // TODO: Make this function thread-safe with mutex.
+  auto it = workspace_.find(device);
+  if (it == workspace_.end()) {
+    workspace_[device] =
+        make_shared<CudaMemory>(size_in_bytes, std::to_string(device));
+  } else if (it->second->size() < size_in_bytes) {
+    workspace_.erase(it);
+    workspace_[device] =
+        make_shared<CudaMemory>(size_in_bytes, std::to_string(device));
+  }
+  it = workspace_.find(device);
+  return it->second->ptr();
+}
+
 NBLA_INSTANTIATE_SINGLETON(NBLA_CUDA_API, Cuda);
 }

--- a/src/nbla/cuda/cudnn/function/convolution.cu
+++ b/src/nbla/cuda/cudnn/function/convolution.cu
@@ -121,9 +121,8 @@ void ConvolutionCudaCudnn<T>::forward_impl(const Variables &inputs,
     b = inputs[2]->get_data_pointer<T>(this->ctx_);
   }
 #ifdef NBLA_CUDNN_USE_WORKSPACE
-  shared_ptr<CudaCachedArray> mem_workspace(
-      new CudaCachedArray(rsc2d_->workspace_size(), dtypes::BYTE, this->ctx_));
-  void *workspace = mem_workspace->pointer();
+  void *workspace = SingletonManager::get<Cuda>()->get_workspace(
+      rsc2d_->workspace_size(), this->device_);
 #endif
   for (int g = 0; g < this->group_; ++g) {
 #ifdef NBLA_CUDNN_USE_WORKSPACE
@@ -176,9 +175,8 @@ void ConvolutionCudaCudnn<T>::backward_impl(const Variables &inputs,
   }
   T alpha = 1;
 #ifdef NBLA_CUDNN_USE_WORKSPACE
-  shared_ptr<CudaCachedArray> mem_workspace(
-      new CudaCachedArray(rsc2d_->workspace_size(), dtypes::BYTE, this->ctx_));
-  void *workspace = mem_workspace->pointer();
+  void *workspace = SingletonManager::get<Cuda>()->get_workspace(
+      rsc2d_->workspace_size(), this->device_);
 #endif
   for (int g = 0; g < this->group_; ++g) {
     if (propagate_down[0]) {

--- a/src/nbla/cuda/cudnn/function/deconvolution.cu
+++ b/src/nbla/cuda/cudnn/function/deconvolution.cu
@@ -102,9 +102,8 @@ void DeconvolutionCudaCudnn<T>::forward_impl(const Variables &inputs,
     b = inputs[2]->get_data_pointer<T>(this->ctx_);
   }
 #ifdef NBLA_CUDNN_USE_WORKSPACE
-  shared_ptr<CudaCachedArray> mem_workspace(
-      new CudaCachedArray(rsc2d_->workspace_size(), dtypes::BYTE, this->ctx_));
-  void *workspace = mem_workspace->pointer();
+  void *workspace = SingletonManager::get<Cuda>()->get_workspace(
+      rsc2d_->workspace_size(), this->device_);
 #endif
   for (int g = 0; g < this->group_; ++g) {
 #ifdef NBLA_CUDNN_USE_WORKSPACE
@@ -157,9 +156,8 @@ void DeconvolutionCudaCudnn<T>::backward_impl(
   }
   T alpha = 1;
 #ifdef NBLA_CUDNN_USE_WORKSPACE
-  shared_ptr<CudaCachedArray> mem_workspace(
-      new CudaCachedArray(rsc2d_->workspace_size(), dtypes::BYTE, this->ctx_));
-  void *workspace = mem_workspace->pointer();
+  void *workspace = SingletonManager::get<Cuda>()->get_workspace(
+      rsc2d_->workspace_size(), this->device_);
 #endif
   for (int g = 0; g < this->group_; ++g) {
     if (propagate_down[0]) {


### PR DESCRIPTION
It reduces memory usage in YOLO v2 from >4GB to ~790MB.