### PR TITLE
Add all_reduce interface

### DIFF
--- a/include/nbla/cuda/communicator/data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/data_parallel_communicator.hpp
@@ -86,6 +86,10 @@ public:
 
   virtual void reduce(bool division = false);
   virtual void allreduce(bool division = false, bool inplace = false);
+  virtual void all_reduce(vector<NdArrayPtr> ndarray_list,
+                          bool division = false, bool inplace = false);
+  virtual void all_reduce(NdArrayPtr data, bool division = false,
+                          bool inplace = false);
   virtual void reducescatter(bool division = false);
   virtual void bcast();
   virtual void allgather();

--- a/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
@@ -92,6 +92,12 @@ public:
 
   virtual void reduce(bool division = false);
   virtual void allreduce(bool division = false, bool inplace = false);
+  virtual void all_reduce(vector<NdArrayPtr> ndarray_list,
+                          bool division = false, bool inplace = false);
+  virtual void all_reduce(NdArrayPtr data, bool division = false,
+                          bool inplace = false);
+  virtual void all_reduce(NdArrayPtr data, cudaStream_t stream,
+                          bool division = false, bool inplace = false);
   virtual void reducescatter(bool division = false);
   virtual void bcast();
   virtual void allgather();

--- a/src/nbla/cuda/communicator/data_parallel_communicator.cu
+++ b/src/nbla/cuda/communicator/data_parallel_communicator.cu
@@ -205,6 +205,20 @@ void DataParallelCommunicatorNccl<T>::allreduce(bool division, bool inplace) {
 }
 
 template <typename T>
+void DataParallelCommunicatorNccl<T>::all_reduce(
+    vector<NdArrayPtr> ndarray_list, bool division, bool inplace) {
+  NBLA_ERROR(error_code::not_implemented,
+             "CUDA GPU all_reduce is not implemented.")
+}
+
+template <typename T>
+void DataParallelCommunicatorNccl<T>::all_reduce(NdArrayPtr data, bool division,
+                                                 bool inplace) {
+  NBLA_ERROR(error_code::not_implemented,
+             "CUDA GPU all_reduce is not implemented.")
+}
+
+template <typename T>
 void DataParallelCommunicatorNccl<T>::reducescatter(bool division) {
   NBLA_ERROR(error_code::not_implemented,
              "CUDA GPU reducescatter is not implemented.")


### PR DESCRIPTION
We add `all_reduce(ndarray, ...)` interface. With this feature, one can do
- the distributed validation over multiple nodes
- the data parallel distributed training with dynamic neural network

For details, see [CIFAR-10 example](https://github.com/sony/nnabla-examples/blob/master/distributed/cifar10-100/multi_device_multi_process_classification.py)