### PR TITLE
New collectives and MPI-like group concept

### DIFF
--- a/include/nbla/cuda/communicator/data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/data_parallel_communicator.hpp
@@ -87,22 +87,22 @@ public:
   virtual void reduce(const vector<NdArrayPtr> &ndarray_list, int dst,
                       bool division = false, bool inplace = false,
                       const string &group = "world");
-  virtual void reduce(const NdArrayPtr &data, int dst, bool division = false,
+  virtual void reduce(NdArrayPtr ndarray, int dst, bool division = false,
                       bool inplace = false, const string &group = "world");
   virtual void allreduce(bool division = false, bool inplace = false);
   virtual void all_reduce(const vector<NdArrayPtr> &ndarray_list,
                           bool division = false, bool inplace = false,
                           const string &group = "world");
-  virtual void all_reduce(const NdArrayPtr &data, bool division = false,
+  virtual void all_reduce(NdArrayPtr ndarray, bool division = false,
                           bool inplace = false, const string &group = "world");
   virtual void reduce_scatter(const vector<NdArrayPtr> &ndarray_list,
-                              const NdArrayPtr &ndarray, bool division = false,
+                              NdArrayPtr ndarray, bool division = false,
                               const string &group = "world");
   virtual void bcast(const vector<NdArrayPtr> &ndarray_list, int src,
                      bool inplace = false, const string &group = "world");
-  virtual void bcast(const NdArrayPtr &ndarray, int src, bool inplace = false,
+  virtual void bcast(NdArrayPtr ndarray, int src, bool inplace = false,
                      const string &group = "world");
-  virtual void all_gather(const NdArrayPtr &ndarray,
+  virtual void all_gather(NdArrayPtr ndarray,
                           const vector<NdArrayPtr> &ndarray_list,
                           const string &group = "world");
 

--- a/include/nbla/cuda/communicator/data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/data_parallel_communicator.hpp
@@ -84,15 +84,27 @@ public:
   */
   virtual void init();
 
-  virtual void reduce(bool division = false);
+  virtual void reduce(const vector<NdArrayPtr> &ndarray_list, int dst,
+                      bool division = false, bool inplace = false,
+                      const string &group = "world");
+  virtual void reduce(const NdArrayPtr &data, int dst, bool division = false,
+                      bool inplace = false, const string &group = "world");
   virtual void allreduce(bool division = false, bool inplace = false);
-  virtual void all_reduce(vector<NdArrayPtr> ndarray_list,
-                          bool division = false, bool inplace = false);
-  virtual void all_reduce(NdArrayPtr data, bool division = false,
-                          bool inplace = false);
-  virtual void reducescatter(bool division = false);
-  virtual void bcast();
-  virtual void allgather();
+  virtual void all_reduce(const vector<NdArrayPtr> &ndarray_list,
+                          bool division = false, bool inplace = false,
+                          const string &group = "world");
+  virtual void all_reduce(const NdArrayPtr &data, bool division = false,
+                          bool inplace = false, const string &group = "world");
+  virtual void reduce_scatter(const vector<NdArrayPtr> &ndarray_list,
+                              const NdArrayPtr &ndarray, bool division = false,
+                              const string &group = "world");
+  virtual void bcast(const vector<NdArrayPtr> &ndarray_list, int src,
+                     bool inplace = false, const string &group = "world");
+  virtual void bcast(const NdArrayPtr &ndarray, int src, bool inplace = false,
+                     const string &group = "world");
+  virtual void all_gather(const NdArrayPtr &ndarray,
+                          const vector<NdArrayPtr> &ndarray_list,
+                          const string &group = "world");
 
   virtual void reduce_async(bool division = false);
   virtual void allreduce_async(bool division = false, bool inplace = false);

--- a/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
@@ -94,35 +94,35 @@ public:
   copy_inside_device(const vector<NdArrayPtr> &ndarray_list);
   virtual void
   copy_back_inside_device(const vector<NdArrayPtr> &ndarray_list,
-                          const shared_ptr<NdArray> &large_ndarray);
+                          NdArrayPtr large_ndarray);
 
   virtual void reduce(const vector<NdArrayPtr> &ndarray_list, int dst,
                       bool division = false, bool inplace = false,
                       const string &group = "world");
-  virtual void reduce(const NdArrayPtr &data, int dst, bool division = false,
+  virtual void reduce(NdArrayPtr ndarray, int dst, bool division = false,
                       bool inplace = false, const string &group = "world");
-  virtual void reduce(const NdArrayPtr &data, cudaStream_t stream, int dst,
+  virtual void reduce(NdArrayPtr ndarray, cudaStream_t stream, int dst,
                       bool division = false, bool inplace = false,
                       const string &group = "world");
   virtual void allreduce(bool division = false, bool inplace = false);
   virtual void all_reduce(const vector<NdArrayPtr> &ndarray_list,
                           bool division = false, bool inplace = false,
                           const string &group = "world");
-  virtual void all_reduce(const NdArrayPtr &data, bool division = false,
+  virtual void all_reduce(NdArrayPtr ndarray, bool division = false,
                           bool inplace = false, const string &group = "world");
-  virtual void all_reduce(const NdArrayPtr &data, cudaStream_t stream,
+  virtual void all_reduce(NdArrayPtr ndarray, cudaStream_t stream,
                           bool division = false, bool inplace = false,
                           const string &group = "world");
   virtual void reduce_scatter(const vector<NdArrayPtr> &ndarray_list,
-                              const NdArrayPtr &ndarray, bool division = false,
+                              NdArrayPtr ndarray, bool division = false,
                               const string &group = "world");
   virtual void bcast(const vector<NdArrayPtr> &ndarray_list, int src,
                      bool inplace = false, const string &group = "world");
-  virtual void bcast(const NdArrayPtr &ndarray, int src, bool inplace = false,
+  virtual void bcast(NdArrayPtr ndarray, int src, bool inplace = false,
                      const string &group = "world");
-  virtual void bcast(const NdArrayPtr &ndarray, cudaStream_t stream, int src,
+  virtual void bcast(NdArrayPtr ndarray, cudaStream_t stream, int src,
                      bool inplace = false, const string &group = "world");
-  virtual void all_gather(const NdArrayPtr &ndarray,
+  virtual void all_gather(NdArrayPtr ndarray,
                           const vector<NdArrayPtr> &ndarray_list,
                           const string &group = "world");
 

--- a/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
@@ -55,15 +55,13 @@ protected:
 
   static bool mpi_initialized_;
 
-  ncclUniqueId comm_id_;
-
-  // MPI-like MultiProcessDataParallelCommunicators initialized in init method
-  ncclComm_t comm_;
-
   // Device streams initialized in init method
   cudaStream_t stream_;
   int num_streams_ = 10; // TODO: hard-codded.
   vector<cudaStream_t> streams_ = vector<cudaStream_t>(num_streams_);
+
+  // Groups
+  unordered_map<string, ncclComm_t> comms_;
 
 public:
   MultiProcessDataParallelCommunicatorNccl(const Context &ctx);
@@ -90,17 +88,43 @@ public:
   */
   virtual void init();
 
-  virtual void reduce(bool division = false);
+  virtual string new_group(pair<string, vector<int>> name_ranks_pair);
+
+  virtual shared_ptr<NdArray>
+  copy_inside_device(const vector<NdArrayPtr> &ndarray_list);
+  virtual void
+  copy_back_inside_device(const vector<NdArrayPtr> &ndarray_list,
+                          const shared_ptr<NdArray> &large_ndarray);
+
+  virtual void reduce(const vector<NdArrayPtr> &ndarray_list, int dst,
+                      bool division = false, bool inplace = false,
+                      const string &group = "world");
+  virtual void reduce(const NdArrayPtr &data, int dst, bool division = false,
+                      bool inplace = false, const string &group = "world");
+  virtual void reduce(const NdArrayPtr &data, cudaStream_t stream, int dst,
+                      bool division = false, bool inplace = false,
+                      const string &group = "world");
   virtual void allreduce(bool division = false, bool inplace = false);
-  virtual void all_reduce(vector<NdArrayPtr> ndarray_list,
-                          bool division = false, bool inplace = false);
-  virtual void all_reduce(NdArrayPtr data, bool division = false,
-                          bool inplace = false);
-  virtual void all_reduce(NdArrayPtr data, cudaStream_t stream,
-                          bool division = false, bool inplace = false);
-  virtual void reducescatter(bool division = false);
-  virtual void bcast();
-  virtual void allgather();
+  virtual void all_reduce(const vector<NdArrayPtr> &ndarray_list,
+                          bool division = false, bool inplace = false,
+                          const string &group = "world");
+  virtual void all_reduce(const NdArrayPtr &data, bool division = false,
+                          bool inplace = false, const string &group = "world");
+  virtual void all_reduce(const NdArrayPtr &data, cudaStream_t stream,
+                          bool division = false, bool inplace = false,
+                          const string &group = "world");
+  virtual void reduce_scatter(const vector<NdArrayPtr> &ndarray_list,
+                              const NdArrayPtr &ndarray, bool division = false,
+                              const string &group = "world");
+  virtual void bcast(const vector<NdArrayPtr> &ndarray_list, int src,
+                     bool inplace = false, const string &group = "world");
+  virtual void bcast(const NdArrayPtr &ndarray, int src, bool inplace = false,
+                     const string &group = "world");
+  virtual void bcast(const NdArrayPtr &ndarray, cudaStream_t stream, int src,
+                     bool inplace = false, const string &group = "world");
+  virtual void all_gather(const NdArrayPtr &ndarray,
+                          const vector<NdArrayPtr> &ndarray_list,
+                          const string &group = "world");
 
   virtual void reduce_async(bool division = false);
   virtual void allreduce_async(bool division = false, bool inplace = false);

--- a/src/nbla/cuda/communicator/data_parallel_communicator.cu
+++ b/src/nbla/cuda/communicator/data_parallel_communicator.cu
@@ -85,7 +85,7 @@ void DataParallelCommunicatorNccl<T>::reduce(
 }
 
 template <typename T>
-void DataParallelCommunicatorNccl<T>::reduce(const NdArrayPtr &data, int dst,
+void DataParallelCommunicatorNccl<T>::reduce(NdArrayPtr ndarray, int dst,
                                              bool division, bool inplace,
                                              const string &group) {
   NBLA_ERROR(error_code::not_implemented, "CUDA GPU reduce is not implemented.")
@@ -222,7 +222,7 @@ void DataParallelCommunicatorNccl<T>::all_reduce(
 }
 
 template <typename T>
-void DataParallelCommunicatorNccl<T>::all_reduce(const NdArrayPtr &data,
+void DataParallelCommunicatorNccl<T>::all_reduce(NdArrayPtr ndarray,
                                                  bool division, bool inplace,
                                                  const string &group) {
   NBLA_ERROR(error_code::not_implemented,
@@ -231,7 +231,7 @@ void DataParallelCommunicatorNccl<T>::all_reduce(const NdArrayPtr &data,
 
 template <typename T>
 void DataParallelCommunicatorNccl<T>::reduce_scatter(
-    const vector<NdArrayPtr> &ndarray_list, const NdArrayPtr &ndarray,
+    const vector<NdArrayPtr> &ndarray_list, NdArrayPtr ndarray,
     bool division, const string &group) {
   NBLA_ERROR(error_code::not_implemented,
              "CUDA GPU reduce_scatter is not implemented.")
@@ -245,14 +245,14 @@ void DataParallelCommunicatorNccl<T>::bcast(
 }
 
 template <typename T>
-void DataParallelCommunicatorNccl<T>::bcast(const NdArrayPtr &ndarray, int src,
+void DataParallelCommunicatorNccl<T>::bcast(NdArrayPtr ndarray, int src,
                                             bool inplace, const string &group) {
   NBLA_ERROR(error_code::not_implemented, "CUDA GPU bcast is not implemented.")
 }
 
 template <typename T>
 void DataParallelCommunicatorNccl<T>::all_gather(
-    const NdArrayPtr &ndarray, const vector<NdArrayPtr> &ndarray_list,
+    NdArrayPtr ndarray, const vector<NdArrayPtr> &ndarray_list,
     const string &group) {
   NBLA_ERROR(error_code::not_implemented,
              "CUDA GPU all_gather is not implemented.")

--- a/src/nbla/cuda/communicator/data_parallel_communicator.cu
+++ b/src/nbla/cuda/communicator/data_parallel_communicator.cu
@@ -78,7 +78,16 @@ template <typename T> void DataParallelCommunicatorNccl<T>::init() {
 }
 
 template <typename T>
-void DataParallelCommunicatorNccl<T>::reduce(bool division) {
+void DataParallelCommunicatorNccl<T>::reduce(
+    const vector<NdArrayPtr> &ndarray_list, int dst, bool division,
+    bool inplace, const string &group) {
+  NBLA_ERROR(error_code::not_implemented, "CUDA GPU reduce is not implemented.")
+}
+
+template <typename T>
+void DataParallelCommunicatorNccl<T>::reduce(const NdArrayPtr &data, int dst,
+                                             bool division, bool inplace,
+                                             const string &group) {
   NBLA_ERROR(error_code::not_implemented, "CUDA GPU reduce is not implemented.")
 }
 
@@ -206,31 +215,47 @@ void DataParallelCommunicatorNccl<T>::allreduce(bool division, bool inplace) {
 
 template <typename T>
 void DataParallelCommunicatorNccl<T>::all_reduce(
-    vector<NdArrayPtr> ndarray_list, bool division, bool inplace) {
+    const vector<NdArrayPtr> &ndarray_list, bool division, bool inplace,
+    const string &group) {
   NBLA_ERROR(error_code::not_implemented,
              "CUDA GPU all_reduce is not implemented.")
 }
 
 template <typename T>
-void DataParallelCommunicatorNccl<T>::all_reduce(NdArrayPtr data, bool division,
-                                                 bool inplace) {
+void DataParallelCommunicatorNccl<T>::all_reduce(const NdArrayPtr &data,
+                                                 bool division, bool inplace,
+                                                 const string &group) {
   NBLA_ERROR(error_code::not_implemented,
              "CUDA GPU all_reduce is not implemented.")
 }
 
 template <typename T>
-void DataParallelCommunicatorNccl<T>::reducescatter(bool division) {
+void DataParallelCommunicatorNccl<T>::reduce_scatter(
+    const vector<NdArrayPtr> &ndarray_list, const NdArrayPtr &ndarray,
+    bool division, const string &group) {
   NBLA_ERROR(error_code::not_implemented,
-             "CUDA GPU reducescatter is not implemented.")
+             "CUDA GPU reduce_scatter is not implemented.")
 }
 
-template <typename T> void DataParallelCommunicatorNccl<T>::bcast() {
+template <typename T>
+void DataParallelCommunicatorNccl<T>::bcast(
+    const vector<NdArrayPtr> &ndarray_list, int src, bool inplace,
+    const string &group) {
   NBLA_ERROR(error_code::not_implemented, "CUDA GPU bcast is not implemented.")
 }
 
-template <typename T> void DataParallelCommunicatorNccl<T>::allgather() {
+template <typename T>
+void DataParallelCommunicatorNccl<T>::bcast(const NdArrayPtr &ndarray, int src,
+                                            bool inplace, const string &group) {
+  NBLA_ERROR(error_code::not_implemented, "CUDA GPU bcast is not implemented.")
+}
+
+template <typename T>
+void DataParallelCommunicatorNccl<T>::all_gather(
+    const NdArrayPtr &ndarray, const vector<NdArrayPtr> &ndarray_list,
+    const string &group) {
   NBLA_ERROR(error_code::not_implemented,
-             "CUDA GPU allgather is not implemented.")
+             "CUDA GPU all_gather is not implemented.")
 }
 
 template <typename T>

--- a/src/nbla/cuda/communicator/multi_process_data_parallel_communicator.cu
+++ b/src/nbla/cuda/communicator/multi_process_data_parallel_communicator.cu
@@ -70,7 +70,9 @@ MultiProcessDataParallelCommunicatorNccl<
     for (int i = 0; i < streams_.size(); ++i) {
       NBLA_CUDA_CHECK(cudaStreamDestroy(streams_[i]));
     }
-    ncclCommDestroy(comm_);
+    for (auto e : this->comms_) {
+      ncclCommDestroy(e.second);
+    }
   }
   if (mpi_initialized_) {
     MPI_Finalize();
@@ -99,10 +101,8 @@ template <typename T> void MultiProcessDataParallelCommunicatorNccl<T>::init() {
       mpi_initialized_ = true;
     }
     // Create comm, set size, and rank
-    MPI_Comm mpi_comm;
-    MPI_Comm_dup(MPI_COMM_WORLD, &mpi_comm);
-    MPI_Comm_size(mpi_comm, &this->size_);
-    MPI_Comm_rank(mpi_comm, &this->rank_);
+    MPI_Comm_size(MPI_COMM_WORLD, &this->size_);
+    MPI_Comm_rank(MPI_COMM_WORLD, &this->rank_);
 
     // Set local rank and device id
     uint64_t host_hashs[this->size_];
@@ -111,8 +111,8 @@ template <typename T> void MultiProcessDataParallelCommunicatorNccl<T>::init() {
     host_hashs[this->rank_] = get_host_hash(hostname);
 
     MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, host_hashs,
-                  sizeof(uint64_t), MPI_BYTE, mpi_comm);
-    MPI_Barrier(mpi_comm);
+                  sizeof(uint64_t), MPI_BYTE, MPI_COMM_WORLD);
+    MPI_Barrier(MPI_COMM_WORLD);
 
     int local_rank = 0;
     for (int i = 0; i < this->size_; ++i) {
@@ -127,19 +127,19 @@ template <typename T> void MultiProcessDataParallelCommunicatorNccl<T>::init() {
     this->local_rank_ = local_rank;
     this->ctx_.device_id = std::to_string(local_rank);
 
-    // Exchange comm_id_ among processes
+    // Exchange comm_id among processes
+    ncclUniqueId comm_id;
     if (this->rank_ == 0) {
-      ncclGetUniqueId(&this->comm_id_);
+      ncclGetUniqueId(&comm_id);
     }
-
-    MPI_Bcast(&comm_id_, sizeof(this->comm_id_), MPI_BYTE, 0, mpi_comm);
-    MPI_Barrier(mpi_comm);
-    MPI_Comm_free(&mpi_comm);
+    MPI_Bcast(&comm_id, sizeof(comm_id), MPI_BYTE, 0, MPI_COMM_WORLD);
+    MPI_Barrier(MPI_COMM_WORLD);
 
     // NCCL Init
     cuda_set_device(device_id_);
+    ncclComm_t comm;
     ncclResult_t ret =
-        ncclCommInitRank(&comm_, this->size_, comm_id_, this->rank_);
+        ncclCommInitRank(&comm, this->size_, comm_id, this->rank_);
     if (ret != ncclSuccess) {
       NBLA_ERROR(error_code::target_specific, "ncclCommInitRank failed.");
     }
@@ -151,6 +151,12 @@ template <typename T> void MultiProcessDataParallelCommunicatorNccl<T>::init() {
       streams_[i] = stream;
     }
 
+    // Create world group
+    this->comms_["world"] = comm;
+    vector<int> ranks(this->size_);
+    std::iota(ranks.begin(), ranks.end(), 0);
+    this->groups_["world"] = ranks;
+
     this->initialized_ = true;
   } catch (...) {
     NBLA_ERROR(error_code::unclassified, "Communicator init failed.");
@@ -158,9 +164,184 @@ template <typename T> void MultiProcessDataParallelCommunicatorNccl<T>::init() {
 }
 
 template <typename T>
-void MultiProcessDataParallelCommunicatorNccl<T>::reduce(bool division) {
-  NBLA_ERROR(error_code::not_implemented,
-             "CUDA GPU ireduce is not implemented.")
+string MultiProcessDataParallelCommunicatorNccl<T>::new_group(
+    pair<string, vector<int>> name_ranks_pair) {
+  string group_name = name_ranks_pair.first;
+  vector<int> ranks = name_ranks_pair.second;
+
+  // Checks
+  if (this->groups_.find(group_name) !=
+      this->groups_.end()) { // group name already exists.
+    NBLA_ERROR(error_code::value, "group_name = %s already exists",
+               group_name.c_str());
+  }
+  int max = *std::max_element(ranks.begin(), ranks.end());
+  NBLA_CHECK(max < this->size_, error_code::value,
+             "Max value of the specified ranks should be less than the size () "
+             "of the communicator.",
+             this->size_);
+  int min = *std::min_element(ranks.begin(), ranks.end());
+  NBLA_CHECK(min >= 0, error_code::value,
+             "Min value of the specified ranks is greater than or equal to 0.");
+
+  // Create new group
+  MPI_Group world_group;
+  MPI_Comm_group(MPI_COMM_WORLD, &world_group);
+  MPI_Group new_group;
+  MPI_Group_incl(world_group, ranks.size(), ranks.data(), &new_group);
+
+  // Create mpi communicator
+  MPI_Comm mpi_comm;
+  MPI_Comm_create(MPI_COMM_WORLD, new_group,
+                  &mpi_comm); // have to call in all processes
+
+  // Add group name in all ranks
+  this->groups_[group_name] = ranks;
+
+  // Leave if self is not in ranks
+  auto result = std::find(ranks.begin(), ranks.end(), this->rank_);
+  if (result == ranks.end()) { // self is not found in ranks.
+    return group_name;
+  }
+
+  // Create nccl unique id and bcast it
+  ncclUniqueId comm_id;
+  if (this->rank_ == ranks[0]) {
+    ncclGetUniqueId(&comm_id);
+  }
+  int rank;
+  MPI_Comm_rank(mpi_comm, &rank);
+  MPI_Bcast(&comm_id, sizeof(comm_id), MPI_BYTE, 0, mpi_comm);
+  MPI_Barrier(mpi_comm);
+  MPI_Comm_free(&mpi_comm);
+
+  // NCCL Comm Init
+  cuda_set_device(device_id_);
+  ncclComm_t comm;
+  ncclResult_t ret = ncclCommInitRank(&comm, ranks.size(), comm_id, rank);
+  if (ret != ncclSuccess) {
+    NBLA_ERROR(error_code::target_specific, "ncclCommInitRank failed with %d",
+               ret);
+  }
+  this->comms_[group_name] = comm;
+
+  return group_name;
+}
+
+template <typename T>
+shared_ptr<NdArray>
+MultiProcessDataParallelCommunicatorNccl<T>::copy_inside_device(
+    const vector<NdArrayPtr> &ndarray_list) {
+  // preparation
+  Size_t total_params = 0;
+  for (auto ndarray : ndarray_list) {
+    auto n_param = ndarray->size();
+    total_params += n_param;
+  }
+  dtypes dtype = get_dtype<T>();
+  NdArrayPtr large_ndarray = make_shared<NdArray>(Shape_t{total_params});
+  T *buff = large_ndarray->cast(dtype, this->ctx_)->pointer<T>();
+  Size_t type_size = sizeof(T);
+  int k = 0;
+
+  // copy inside device
+  for (auto ndarray : ndarray_list) {
+    const T *dw = ndarray->cast(dtype, this->ctx_)->const_pointer<T>();
+    auto n_param = ndarray->size();
+    int stream_id = k % num_streams_;
+    cudaMemcpyAsync(buff, dw, type_size * n_param, cudaMemcpyDeviceToDevice,
+                    streams_[stream_id]);
+    buff += n_param;
+    k++;
+  }
+  return large_ndarray;
+}
+
+template <typename T>
+void MultiProcessDataParallelCommunicatorNccl<T>::copy_back_inside_device(
+    const vector<NdArrayPtr> &ndarray_list,
+    const shared_ptr<NdArray> &large_ndarray) {
+  dtypes dtype = get_dtype<T>();
+  T *buff = large_ndarray->cast(dtype, this->ctx_)->pointer<T>();
+  Size_t type_size = sizeof(T);
+  int k = 0;
+  for (auto ndarray : ndarray_list) {
+    T *dw = ndarray->cast(dtype, this->ctx_)->pointer<T>();
+    auto n_param = ndarray->size();
+    int stream_id = k % num_streams_;
+    cudaMemcpyAsync(dw, buff, type_size * n_param, cudaMemcpyDeviceToDevice,
+                    streams_[stream_id]);
+    buff += n_param;
+    k++;
+  }
+}
+
+template <typename T>
+void MultiProcessDataParallelCommunicatorNccl<T>::reduce(
+    const vector<NdArrayPtr> &ndarray_list, int dst, bool division,
+    bool inplace, const string &group) {
+  if (!this->find_self(group)) {
+    NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",
+               this->rank_, group.c_str());
+  }
+
+  // TODO: currently nnabla uses default stream for computation.
+  // The following logic relies on that, so if nnabla uses another stream for
+  // computation,
+  // we have to issue null kernel to the default stream at the beginning of this
+  // method
+  // and at the end of this method for using the implicit synchronization
+  // technique for
+  // main thread not to wait for a result of a kernel call.
+
+  // TODO: the usage of multi streams is round-robin fashion, it may not be
+  // optimal.
+
+  if (inplace) { // in-place
+    int k = 0;
+    dtypes dtype = get_dtype<T>();
+    for (auto ndarray : ndarray_list) { // ndarray loop
+      int stream_id = k % num_streams_;
+      reduce(ndarray, streams_[stream_id], dst, division, inplace);
+      k++;
+    }
+  } else { // out-of-place. use a large array.
+    NdArrayPtr large_ndarray = copy_inside_device(ndarray_list);
+    reduce(large_ndarray, nullptr, dst, division, inplace, group);
+    copy_back_inside_device(ndarray_list, large_ndarray);
+  }
+  // no need to call null kernel since nnabla uses default stream currently.
+}
+
+template <typename T>
+void MultiProcessDataParallelCommunicatorNccl<T>::reduce(
+    const NdArrayPtr &ndarray, int dst, bool division, bool inplace,
+    const string &group) {
+  if (!this->find_self(group)) {
+    NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",
+               this->rank_, group.c_str());
+  }
+  reduce(ndarray, nullptr, dst, division, inplace, group);
+}
+
+template <typename T>
+void MultiProcessDataParallelCommunicatorNccl<T>::reduce(
+    const NdArrayPtr &ndarray, cudaStream_t stream, int dst, bool division,
+    bool inplace, const string &group) {
+  auto n_param = ndarray->size();
+  dtypes dtype = get_dtype<T>();
+  const T *dw0 = ndarray->get(dtype, this->ctx_)->const_pointer<T>();
+  T *dw1 = ndarray->cast(dtype, this->ctx_)->pointer<T>();
+  ncclResult_t ret = ncclReduce(dw0, dw1, n_param,
+                                ncclFloat, // TODO: address ncclFloat
+                                ncclSum, dst, comms_[group], stream);
+  if (ret != ncclSuccess) {
+    NBLA_ERROR(error_code::target_specific, "ncclReduce fails with %d.", ret);
+  }
+  if (division) {
+    NBLA_CUDA_LAUNCH_KERNEL_IN_STREAM(kernel_divide_inplace, stream, n_param,
+                                      this->size_, dw1);
+  }
 }
 
 template <typename T>
@@ -194,9 +375,9 @@ void MultiProcessDataParallelCommunicatorNccl<T>::allreduce(bool division,
       T *dw1 = vp->cast_grad_and_get_pointer<T>(ctx);
       int stream_id = k % num_streams_;
       // AllReduce
-      ncclResult_t ret = ncclAllReduce(dw0, dw1, n_param, ncclFloat,
-                                       ncclSum, // TODO: address ncclFloat
-                                       comm_, streams_[stream_id]);
+      ncclResult_t ret =
+          ncclAllReduce(dw0, dw1, n_param, ncclFloat, // TODO: address ncclFloat
+                        ncclSum, comms_["world"], streams_[stream_id]);
       if (ret != ncclSuccess) {
         NBLA_ERROR(error_code::target_specific, "ncclAllReduce fails with %d.",
                    ret);
@@ -234,8 +415,8 @@ void MultiProcessDataParallelCommunicatorNccl<T>::allreduce(bool division,
     // 2. all reduce
     ncclResult_t ret =
         ncclAllReduce(buff_start, buff_start, this->total_params_,
-                      ncclFloat,          // TODO: address ncclFloat
-                      ncclSum, comm_, 0); // use default stream
+                      ncclFloat,                    // TODO: address ncclFloat
+                      ncclSum, comms_["world"], 0); // use default stream
 
     if (ret != ncclSuccess) {
       NBLA_ERROR(error_code::target_specific, "ncclAllReduce fails with %d.",
@@ -269,7 +450,13 @@ void MultiProcessDataParallelCommunicatorNccl<T>::allreduce(bool division,
 
 template <typename T>
 void MultiProcessDataParallelCommunicatorNccl<T>::all_reduce(
-    vector<NdArrayPtr> ndarray_list, bool division, bool inplace) {
+    const vector<NdArrayPtr> &ndarray_list, bool division, bool inplace,
+    const string &group) {
+  if (!this->find_self(group)) {
+    NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",
+               this->rank_, group.c_str());
+  }
+
   // TODO: currently nnabla uses default stream for computation.
   // The following logic relies on that, so if nnabla uses another stream for
   // computation,
@@ -287,70 +474,39 @@ void MultiProcessDataParallelCommunicatorNccl<T>::all_reduce(
     dtypes dtype = get_dtype<T>();
     for (auto ndarray : ndarray_list) { // ndarray loop
       int stream_id = k % num_streams_;
-      all_reduce(ndarray, streams_[stream_id], division, inplace);
+      all_reduce(ndarray, streams_[stream_id], division, inplace, group);
       k++;
     }
   } else { // out-of-place. use a large array.
-    // preparation
-    Size_t total_params = 0;
-    for (auto ndarray : ndarray_list) {
-      auto n_param = ndarray->size();
-      total_params += n_param;
-    }
-    dtypes dtype = get_dtype<T>();
-    auto large_ndarray = make_shared<NdArray>(Shape_t{total_params});
-    T *buff = large_ndarray->cast(dtype, this->ctx_)->pointer<T>();
-    T *buff_start = buff;
-    Size_t type_size = sizeof(T);
-    int k = 0;
-
-    // 1. copy inside device
-    for (auto ndarray : ndarray_list) {
-      const T *dw = ndarray->cast(dtype, this->ctx_)->const_pointer<T>();
-      auto n_param = ndarray->size();
-      int stream_id = k % num_streams_;
-      cudaMemcpyAsync(buff, dw, type_size * n_param, cudaMemcpyDeviceToDevice,
-                      streams_[stream_id]);
-      buff += n_param;
-      k++;
-    }
-
-    // all reduce
-    all_reduce(large_ndarray, nullptr, division, inplace);
-
-    // copy back inside device
-    buff = buff_start;
-    k = 0;
-    for (auto ndarray : ndarray_list) {
-      T *dw = ndarray->cast(dtype, this->ctx_)->pointer<T>();
-      auto n_param = ndarray->size();
-      int stream_id = k % num_streams_;
-      cudaMemcpyAsync(dw, buff, type_size * n_param, cudaMemcpyDeviceToDevice,
-                      streams_[stream_id]);
-      buff += n_param;
-      k++;
-    }
+    NdArrayPtr large_ndarray = copy_inside_device(ndarray_list);
+    all_reduce(large_ndarray, nullptr, division, inplace, group);
+    copy_back_inside_device(ndarray_list, large_ndarray);
   }
   // no need to call null kernel since nnabla uses default stream currently.
 }
 
 template <typename T>
-void MultiProcessDataParallelCommunicatorNccl<T>::all_reduce(NdArrayPtr ndarray,
-                                                             bool division,
-                                                             bool inplace) {
-  all_reduce(ndarray, nullptr, division, inplace);
+void MultiProcessDataParallelCommunicatorNccl<T>::all_reduce(
+    const NdArrayPtr &ndarray, bool division, bool inplace,
+    const string &group) {
+  if (!this->find_self(group)) {
+    NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",
+               this->rank_, group.c_str());
+  }
+  all_reduce(ndarray, nullptr, division, inplace, group);
 }
 
 template <typename T>
 void MultiProcessDataParallelCommunicatorNccl<T>::all_reduce(
-    NdArrayPtr ndarray, cudaStream_t stream, bool division, bool inplace) {
+    const NdArrayPtr &ndarray, cudaStream_t stream, bool division, bool inplace,
+    const string &group) {
   auto n_param = ndarray->size();
   dtypes dtype = get_dtype<T>();
   const T *dw0 = ndarray->get(dtype, this->ctx_)->const_pointer<T>();
   T *dw1 = ndarray->cast(dtype, this->ctx_)->pointer<T>();
   ncclResult_t ret = ncclAllReduce(dw0, dw1, n_param,
                                    ncclFloat, // TODO: address ncclFloat
-                                   ncclSum, comm_, stream);
+                                   ncclSum, comms_[group], stream);
   if (ret != ncclSuccess) {
     NBLA_ERROR(error_code::target_specific, "ncclAllReduce fails with %d.",
                ret);
@@ -363,20 +519,141 @@ void MultiProcessDataParallelCommunicatorNccl<T>::all_reduce(
 }
 
 template <typename T>
-void MultiProcessDataParallelCommunicatorNccl<T>::reducescatter(bool division) {
-  NBLA_ERROR(error_code::not_implemented,
-             "CUDA GPU reducescatter is not implemented.")
+void MultiProcessDataParallelCommunicatorNccl<T>::reduce_scatter(
+    const vector<NdArrayPtr> &ndarray_list, const NdArrayPtr &ndarray,
+    bool division, const string &group) {
+  if (!this->find_self(group)) {
+    NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",
+               this->rank_, group.c_str());
+  }
+
+  // TODO: currently nnabla uses default stream for computation.
+  // The following logic relies on that, so if nnabla uses another stream for
+  // computation,
+  // we have to issue null kernel to the default stream at the beginning of this
+  // method
+  // and at the end of this method for using the implicit synchronization
+  // technique for
+  // main thread not to wait for a result of a kernel call.
+
+  NdArrayPtr large_ndarray = copy_inside_device(ndarray_list);
+  dtypes dtype = get_dtype<T>();
+  const T *sendbuff = large_ndarray->get(dtype, this->ctx_)->const_pointer<T>();
+  T *recvbuff = ndarray->cast(dtype, this->ctx_)->pointer<T>();
+  Size_t recvcount = ndarray->size();
+  ncclResult_t ret =
+      ncclReduceScatter(sendbuff, recvbuff, recvcount,
+                        ncclFloat,                  // TODO: address ncclFloat
+                        ncclSum, comms_[group], 0); // use default stream
+  if (ret != ncclSuccess) {
+    NBLA_ERROR(error_code::target_specific, "ncclBcast fails with %d.", ret);
+  }
+
+  // divide
+  if (division) {
+    // use default stream
+    NBLA_CUDA_LAUNCH_KERNEL_IN_STREAM(kernel_divide_inplace, 0, recvcount,
+                                      this->size_, recvbuff);
+  }
+  // no need to call null kernel since nnabla uses default stream currently.
 }
 
 template <typename T>
-void MultiProcessDataParallelCommunicatorNccl<T>::bcast() {
-  NBLA_ERROR(error_code::not_implemented, "CUDA GPU bcast is not implemented.")
+void MultiProcessDataParallelCommunicatorNccl<T>::bcast(
+    const vector<NdArrayPtr> &ndarray_list, int src, bool inplace,
+    const string &group) {
+  if (!this->find_self(group)) {
+    NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",
+               this->rank_, group.c_str());
+  }
+
+  // TODO: currently nnabla uses default stream for computation.
+  // The following logic relies on that, so if nnabla uses another stream for
+  // computation,
+  // we have to issue null kernel to the default stream at the beginning of this
+  // method
+  // and at the end of this method for using the implicit synchronization
+  // technique for
+  // main thread not to wait for a result of a kernel call.
+
+  // TODO: the usage of multi streams is round-robin fashion, it may not be
+  // optimal.
+
+  if (inplace) { // in-place
+    int k = 0;
+    dtypes dtype = get_dtype<T>();
+    for (auto ndarray : ndarray_list) { // ndarray loop
+      int stream_id = k % num_streams_;
+      bcast(ndarray, streams_[stream_id], src, inplace, group);
+      k++;
+    }
+  } else { // out-of-place. use a large array.
+    NdArrayPtr large_ndarray = copy_inside_device(ndarray_list);
+    bcast(large_ndarray, nullptr, src, inplace, group);
+    copy_back_inside_device(ndarray_list, large_ndarray);
+  }
+  // no need to call null kernel since nnabla uses default stream currently.
 }
 
 template <typename T>
-void MultiProcessDataParallelCommunicatorNccl<T>::allgather() {
-  NBLA_ERROR(error_code::not_implemented,
-             "CUDA GPU allgather is not implemented.")
+void MultiProcessDataParallelCommunicatorNccl<T>::bcast(
+    const NdArrayPtr &ndarray, int src, bool inplace, const string &group) {
+  if (!this->find_self(group)) {
+    NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",
+               this->rank_, group.c_str());
+  }
+  bcast(ndarray, nullptr, src, inplace, group);
+}
+
+template <typename T>
+void MultiProcessDataParallelCommunicatorNccl<T>::bcast(
+    const NdArrayPtr &ndarray, cudaStream_t stream, int src, bool inplace,
+    const string &group) {
+  auto n_param = ndarray->size();
+  dtypes dtype = get_dtype<T>();
+  T *dw0 = ndarray->cast(dtype, this->ctx_)->pointer<T>();
+  ncclResult_t ret =
+      ncclBcast(dw0, n_param, ncclFloat, src, comms_[group], stream);
+  if (ret != ncclSuccess) {
+    NBLA_ERROR(error_code::target_specific, "ncclBcast fails with %d.", ret);
+  }
+}
+
+template <typename T>
+void MultiProcessDataParallelCommunicatorNccl<T>::all_gather(
+    const NdArrayPtr &ndarray, const vector<NdArrayPtr> &ndarray_list,
+    const string &group) {
+  if (!this->find_self(group)) {
+    NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",
+               this->rank_, group.c_str());
+  }
+
+  // TODO: currently nnabla uses default stream for computation.
+  // The following logic relies on that, so if nnabla uses another stream for
+  // computation,
+  // we have to issue null kernel to the default stream at the beginning of this
+  // method
+  // and at the end of this method for using the implicit synchronization
+  // technique for
+  // main thread not to wait for a result of a kernel call.
+
+  // TODO: the usage of multi streams is round-robin fashion, it may not be
+  // optimal.
+
+  NdArrayPtr large_ndarray = copy_inside_device(ndarray_list);
+  dtypes dtype = get_dtype<T>();
+  const T *sendbuff = ndarray->get(dtype, this->ctx_)->const_pointer<T>();
+  T *recvbuff = large_ndarray->cast(dtype, this->ctx_)->pointer<T>();
+  Size_t sendcount = ndarray->size();
+  ncclResult_t ret = ncclAllGather(sendbuff, recvbuff, sendcount,
+                                   ncclFloat,         // TODO: address ncclFloat
+                                   comms_[group], 0); // use default stream
+  if (ret != ncclSuccess) {
+    NBLA_ERROR(error_code::target_specific, "ncclAllGather fails with %d.",
+               ret);
+  }
+  copy_back_inside_device(ndarray_list, large_ndarray);
+  // no need to call null kernel since nnabla uses default stream currently.
 }
 
 template <typename T>

--- a/src/nbla/cuda/communicator/multi_process_data_parallel_communicator.cu
+++ b/src/nbla/cuda/communicator/multi_process_data_parallel_communicator.cu
@@ -260,7 +260,7 @@ MultiProcessDataParallelCommunicatorNccl<T>::copy_inside_device(
 template <typename T>
 void MultiProcessDataParallelCommunicatorNccl<T>::copy_back_inside_device(
     const vector<NdArrayPtr> &ndarray_list,
-    const shared_ptr<NdArray> &large_ndarray) {
+    NdArrayPtr large_ndarray) {
   dtypes dtype = get_dtype<T>();
   T *buff = large_ndarray->cast(dtype, this->ctx_)->pointer<T>();
   Size_t type_size = sizeof(T);
@@ -315,7 +315,7 @@ void MultiProcessDataParallelCommunicatorNccl<T>::reduce(
 
 template <typename T>
 void MultiProcessDataParallelCommunicatorNccl<T>::reduce(
-    const NdArrayPtr &ndarray, int dst, bool division, bool inplace,
+    NdArrayPtr ndarray, int dst, bool division, bool inplace,
     const string &group) {
   if (!this->find_self(group)) {
     NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",
@@ -326,7 +326,7 @@ void MultiProcessDataParallelCommunicatorNccl<T>::reduce(
 
 template <typename T>
 void MultiProcessDataParallelCommunicatorNccl<T>::reduce(
-    const NdArrayPtr &ndarray, cudaStream_t stream, int dst, bool division,
+    NdArrayPtr ndarray, cudaStream_t stream, int dst, bool division,
     bool inplace, const string &group) {
   auto n_param = ndarray->size();
   dtypes dtype = get_dtype<T>();
@@ -487,7 +487,7 @@ void MultiProcessDataParallelCommunicatorNccl<T>::all_reduce(
 
 template <typename T>
 void MultiProcessDataParallelCommunicatorNccl<T>::all_reduce(
-    const NdArrayPtr &ndarray, bool division, bool inplace,
+    NdArrayPtr ndarray, bool division, bool inplace,
     const string &group) {
   if (!this->find_self(group)) {
     NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",
@@ -498,7 +498,7 @@ void MultiProcessDataParallelCommunicatorNccl<T>::all_reduce(
 
 template <typename T>
 void MultiProcessDataParallelCommunicatorNccl<T>::all_reduce(
-    const NdArrayPtr &ndarray, cudaStream_t stream, bool division, bool inplace,
+    NdArrayPtr ndarray, cudaStream_t stream, bool division, bool inplace,
     const string &group) {
   auto n_param = ndarray->size();
   dtypes dtype = get_dtype<T>();
@@ -520,7 +520,7 @@ void MultiProcessDataParallelCommunicatorNccl<T>::all_reduce(
 
 template <typename T>
 void MultiProcessDataParallelCommunicatorNccl<T>::reduce_scatter(
-    const vector<NdArrayPtr> &ndarray_list, const NdArrayPtr &ndarray,
+    const vector<NdArrayPtr> &ndarray_list, NdArrayPtr ndarray,
     bool division, const string &group) {
   if (!this->find_self(group)) {
     NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",
@@ -597,7 +597,7 @@ void MultiProcessDataParallelCommunicatorNccl<T>::bcast(
 
 template <typename T>
 void MultiProcessDataParallelCommunicatorNccl<T>::bcast(
-    const NdArrayPtr &ndarray, int src, bool inplace, const string &group) {
+    NdArrayPtr ndarray, int src, bool inplace, const string &group) {
   if (!this->find_self(group)) {
     NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",
                this->rank_, group.c_str());
@@ -607,7 +607,7 @@ void MultiProcessDataParallelCommunicatorNccl<T>::bcast(
 
 template <typename T>
 void MultiProcessDataParallelCommunicatorNccl<T>::bcast(
-    const NdArrayPtr &ndarray, cudaStream_t stream, int src, bool inplace,
+    NdArrayPtr ndarray, cudaStream_t stream, int src, bool inplace,
     const string &group) {
   auto n_param = ndarray->size();
   dtypes dtype = get_dtype<T>();
@@ -621,7 +621,7 @@ void MultiProcessDataParallelCommunicatorNccl<T>::bcast(
 
 template <typename T>
 void MultiProcessDataParallelCommunicatorNccl<T>::all_gather(
-    const NdArrayPtr &ndarray, const vector<NdArrayPtr> &ndarray_list,
+    NdArrayPtr ndarray, const vector<NdArrayPtr> &ndarray_list,
     const string &group) {
   if (!this->find_self(group)) {
     NBLA_ERROR(error_code::value, "self (rank=%d) is not included in %s.",


### PR DESCRIPTION
Now we support two features: 

- other collectives other than `all_reduce`
- group concept

The following new collectives are added, 

- all_gather
- bcast
- reduce
- reduce_scatter

MPI-like `group` concept is also added to support collectives only inside a `group`.

With these features, you can e.g., do `all_reduce` inside each node, do some computation based on the result, do `all_gather` over all devices to exchange the result of the computation, then back it into each device, meaning you can do flexible communication patterns over multiple nodes.