### PR TITLE
Communicator with Half Precision

### DIFF
--- a/include/nbla/cuda/communicator/data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/data_parallel_communicator.hpp
@@ -19,6 +19,7 @@
 #include <nbla/array.hpp>
 #include <nbla/communicator/data_parallel_communicator.hpp>
 #include <nbla/context.hpp>
+#include <nbla/cuda/communicator/nccl_utils.hpp>
 #include <nbla/variable.hpp>
 
 #include <memory>
@@ -50,6 +51,7 @@ class NBLA_API DataParallelCommunicatorNccl
     : public DataParallelCommunicator<T> {
 
 protected:
+  typedef typename CudaType<T>::type Tc;
   int n_devices_;
   vector<int> device_ids_;
 

--- a/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
@@ -20,6 +20,7 @@
 #include <nbla/communicator/multi_process_data_parallel_communicator.hpp>
 #include <nbla/context.hpp>
 #include <nbla/cuda/array/cuda_array.hpp>
+#include <nbla/cuda/communicator/nccl_utils.hpp>
 #include <nbla/variable.hpp>
 
 #include <memory>
@@ -64,6 +65,7 @@ protected:
   unordered_map<string, ncclComm_t> comms_;
 
 public:
+  typedef typename CudaType<T>::type Tc;
   MultiProcessDataParallelCommunicatorNccl(const Context &ctx);
   virtual ~MultiProcessDataParallelCommunicatorNccl();
   virtual string name() { return "MultiProcessDataParallelCommunicatorNccl"; }

--- a/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
@@ -36,16 +36,6 @@ using std::shared_ptr;
 using std::unordered_map;
 using std::pair;
 
-#define NBLA_NCCL_CHECK(EXPRESSION)                                            \
-  do {                                                                         \
-    ncclResult_t ret = EXPRESSION;                                             \
-    if (ret != ncclSuccess) {                                                  \
-      NBLA_ERROR(error_code::target_specific,                                  \
-                 "`" #EXPRESSION "` failed with %s.",                          \
-                 ncclGetErrorString(ret));                                     \
-    }                                                                          \
-  } while (0)
-
 /** \addtogroup NNablaCoreGrp */
 /*@{*/
 

--- a/include/nbla/cuda/communicator/nccl_utils.hpp
+++ b/include/nbla/cuda/communicator/nccl_utils.hpp
@@ -1,0 +1,60 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** Communicator interface class
+ */
+#ifndef __NBLA_NCCL_NCCLUTILS_HPP__
+#define __NBLA_NCCL_NCCLUTILS_HPP__
+#include <nbla/array.hpp>
+#include <nbla/context.hpp>
+#include <nbla/variable.hpp>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "nccl.h"
+
+namespace nbla {
+
+using std::string;
+using std::vector;
+using std::shared_ptr;
+using std::unordered_map;
+using std::pair;
+
+#define NBLA_NCCL_CHECK(EXPRESSION)                                            \
+  do {                                                                         \
+    ncclResult_t ret = EXPRESSION;                                             \
+    if (ret != ncclSuccess) {                                                  \
+      NBLA_ERROR(error_code::target_specific,                                  \
+                 "`" #EXPRESSION "` failed with %s.",                          \
+                 ncclGetErrorString(ret));                                     \
+    }                                                                          \
+  } while (0)
+
+template <typename Tc> inline ncclDataType_t get_nccl_dtype() {
+  std::type_info const &type = typeid(Tc);
+  if (type == typeid(float)) {
+    return ncclFloat;
+  } else if (type == typeid(CudaType<HalfCuda>::type)) {
+    return ncclHalf;
+  } else {
+    NBLA_ERROR(error_code::not_implemented,
+               "DataType of the communicator for %s is not supported not.",
+               type.name());
+  }
+}
+}
+#endif

--- a/include/nbla/cuda/communicator/nccl_utils.hpp
+++ b/include/nbla/cuda/communicator/nccl_utils.hpp
@@ -44,17 +44,12 @@ using std::pair;
     }                                                                          \
   } while (0)
 
-template <typename Tc> inline ncclDataType_t get_nccl_dtype() {
-  std::type_info const &type = typeid(Tc);
-  if (type == typeid(float)) {
-    return ncclFloat;
-  } else if (type == typeid(CudaType<HalfCuda>::type)) {
-    return ncclHalf;
-  } else {
-    NBLA_ERROR(error_code::not_implemented,
-               "DataType of the communicator for %s is not supported not.",
-               type.name());
-  }
+template <typename Tc> ncclDataType_t get_nccl_dtype();
+
+template <> inline ncclDataType_t get_nccl_dtype<float>() { return ncclFloat; }
+template <> inline ncclDataType_t get_nccl_dtype<Half>() { return ncclHalf; }
+template <> inline ncclDataType_t get_nccl_dtype<HalfCuda>() {
+  return ncclHalf;
 }
 }
 #endif

--- a/src/nbla/cuda/CMakeLists.txt
+++ b/src/nbla/cuda/CMakeLists.txt
@@ -73,7 +73,9 @@ if(MSVC)
   set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Xcompiler /W0")
 else()
   set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-std=c++11")
-  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}; --default-stream per-thread")
+  # Do not use `--default-stream per-thread` since some kernel calls are executed strangely in blocking streams other than default stream
+  #set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}; --default-stream per-thread")
+  set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};")
 endif()
 
 file(GLOB CU_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} */*.cu cudnn/*/*.cu)

--- a/src/nbla/cuda/init.cpp.tmpl
+++ b/src/nbla/cuda/init.cpp.tmpl
@@ -122,6 +122,12 @@ void init_cuda() {
   NBLA_REGISTER_COMMUNICATOR_IMPL(DataParallelCommunicator, DataParallelCommunicatorNcclf, "cuda:float");
   typedef MultiProcessDataParallelCommunicatorNccl<float> MultiProcessDataParallelCommunicatorNcclf;
   NBLA_REGISTER_COMMUNICATOR_IMPL(MultiProcessDataParallelCommunicator, MultiProcessDataParallelCommunicatorNcclf, "cuda:float");
+
+  typedef DataParallelCommunicatorNccl<Half> DataParallelCommunicatorNcclh;
+  NBLA_REGISTER_COMMUNICATOR_IMPL(DataParallelCommunicator, DataParallelCommunicatorNcclh, "cuda:half");
+  typedef MultiProcessDataParallelCommunicatorNccl<Half> MultiProcessDataParallelCommunicatorNcclh;
+  NBLA_REGISTER_COMMUNICATOR_IMPL(MultiProcessDataParallelCommunicator, MultiProcessDataParallelCommunicatorNcclh, "cuda:half");
+
 #endif
 
   is_initialized = true;


### PR DESCRIPTION
Now, the communicator can take data with the half precision in the same way to do a single GPU training with the half precision like

```python
ctx = get_extension_context("cudnn", type_config="half")
```

See the `nnabla-example/distributed/cifar10-100/multi_device_multi_process_classification.py` for more details.

