### PR TITLE
Properly check architecture in cublas gemm and batched gemm

### DIFF
--- a/include/nbla/cuda/common.hpp
+++ b/include/nbla/cuda/common.hpp
@@ -210,5 +210,9 @@ int cuda_set_device(int device);
 @return index of device
 */
 int cuda_get_device();
+
+/** Get device properties of current CUDA device.
+ */
+cudaDeviceProp cuda_get_current_device_properties();
 }
 #endif

--- a/src/nbla/cuda/common.cpp
+++ b/src/nbla/cuda/common.cpp
@@ -29,4 +29,11 @@ int cuda_get_device() {
   NBLA_CUDA_CHECK(cudaGetDevice(&current_device));
   return current_device;
 }
+
+cudaDeviceProp cuda_get_current_device_properties() {
+  cudaDeviceProp prop;
+  int device = cuda_get_device(); // Note: Assuming device is properly set.
+  NBLA_CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
+  return prop;
+}
 }


### PR DESCRIPTION
The issue was GEMM functions didn't work due to CUBLAS_ARCH_MISMATCH if GPU is older than Maxwell (e.g. Kepler). Fixed by properly checking architecture dynamically.