### PR TITLE
Fix binary functions

### DIFF
--- a/include/nbla/cuda/function/binary_connect_affine.hpp
+++ b/include/nbla/cuda/function/binary_connect_affine.hpp
@@ -29,8 +29,9 @@ class BinaryConnectAffineCuda : public BinaryConnectAffine<T> {
 
 public:
   typedef typename CudaType<T>::type Tc;
-  explicit BinaryConnectAffineCuda(const Context &ctx, int base_axis)
-      : BinaryConnectAffine<T>(ctx, base_axis),
+  explicit BinaryConnectAffineCuda(const Context &ctx, int base_axis,
+                                   float quantize_zero_to)
+      : BinaryConnectAffine<T>(ctx, base_axis, quantize_zero_to),
         device_(std::stoi(ctx.device_id)) {}
   virtual ~BinaryConnectAffineCuda() {}
   virtual string name() { return "BinaryConnectAffineCuda"; }

--- a/include/nbla/cuda/function/binary_connect_convolution.hpp
+++ b/include/nbla/cuda/function/binary_connect_convolution.hpp
@@ -32,9 +32,10 @@ public:
   explicit BinaryConnectConvolutionCuda(const Context &ctx, int base_axis,
                                         const vector<int> &pad,
                                         const vector<int> &stride,
-                                        const vector<int> &dilation, int group)
+                                        const vector<int> &dilation, int group,
+                                        float quantize_zero_to)
       : BinaryConnectConvolution<T>(ctx, base_axis, pad, stride, dilation,
-                                    group),
+                                    group, quantize_zero_to),
         device_(std::stoi(ctx.device_id)) {}
   virtual ~BinaryConnectConvolutionCuda() {}
   virtual string name() { return "BinaryConnectConvolutionCuda"; }

--- a/include/nbla/cuda/function/binary_weight_affine.hpp
+++ b/include/nbla/cuda/function/binary_weight_affine.hpp
@@ -27,8 +27,9 @@ class BinaryWeightAffineCuda : public BinaryWeightAffine<T> {
 public:
   typedef typename CudaType<T>::type Tc;
 
-  BinaryWeightAffineCuda(const Context &ctx, int base_axis)
-      : BinaryWeightAffine<T>(ctx, base_axis),
+  BinaryWeightAffineCuda(const Context &ctx, int base_axis,
+                         float quantize_zero_to)
+      : BinaryWeightAffine<T>(ctx, base_axis, quantize_zero_to),
         device_(std::stoi(ctx.device_id)) {}
 
   virtual ~BinaryWeightAffineCuda() {}

--- a/include/nbla/cuda/function/binary_weight_convolution.hpp
+++ b/include/nbla/cuda/function/binary_weight_convolution.hpp
@@ -29,9 +29,10 @@ public:
   typedef typename CudaType<T>::type Tc;
   BinaryWeightConvolutionCuda(const Context &ctx, int base_axis,
                               const vector<int> &pad, const vector<int> &stride,
-                              const vector<int> &dilation, int group)
-      : BinaryWeightConvolution<T>(ctx, base_axis, pad, stride, dilation,
-                                   group),
+                              const vector<int> &dilation, int group,
+                              float quantize_zero_to)
+      : BinaryWeightConvolution<T>(ctx, base_axis, pad, stride, dilation, group,
+                                   quantize_zero_to),
         device_(std::stoi(ctx.device_id)) {}
 
   virtual ~BinaryWeightConvolutionCuda() {}


### PR DESCRIPTION
This breaks the backward compatibility but add the workaround.

- Now we changed the behaviour of `F.sign` function when the input value is 0, it becomes 1 now.
- Also, we add the argument to `F.sign` function and all binary functions which use `F.sign` as the workaround to control the behaviour when the input value is 0.