### PR TITLE
Fix CuDNN reduction for output shape equal input shape.

### DIFF
--- a/include/nbla/cuda/cudnn/function/mean.hpp
+++ b/include/nbla/cuda/cudnn/function/mean.hpp
@@ -54,6 +54,7 @@ protected:
   cudnnTensorDescriptor_t x_desc_;
   cudnnTensorDescriptor_t y_desc_;
   size_t workspace_size_;
+  bool same_in_out_shape_;
 
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);

--- a/include/nbla/cuda/cudnn/function/prod.hpp
+++ b/include/nbla/cuda/cudnn/function/prod.hpp
@@ -54,6 +54,7 @@ protected:
   cudnnTensorDescriptor_t x_desc_;
   cudnnTensorDescriptor_t y_desc_;
   size_t workspace_size_;
+  bool same_in_out_shape_;
 
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);

--- a/include/nbla/cuda/cudnn/function/sum.hpp
+++ b/include/nbla/cuda/cudnn/function/sum.hpp
@@ -54,6 +54,7 @@ protected:
   cudnnTensorDescriptor_t x_desc_;
   cudnnTensorDescriptor_t y_desc_;
   size_t workspace_size_;
+  bool same_in_out_shape_;
 
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);

--- a/src/nbla/cuda/cudnn/function/generic/prod.cu
+++ b/src/nbla/cuda/cudnn/function/generic/prod.cu
@@ -42,14 +42,18 @@ void ProdCudaCudnn<T>::setup_impl(const Variables &inputs,
   for (auto axis : this->axes_)
     y_shape.at(axis) = 1;
 
-  cudnn_set_tensor_descriptor<T>(this->x_desc_, x_shape);
-  cudnn_set_tensor_descriptor<T>(this->y_desc_, y_shape);
+  this->same_in_out_shape_ = (y_shape == x_shape) ? true : false;
 
-  auto cudnn_handle_manager = SingletonManager::get<CudnnHandleManager>();
-  auto cudnn_handle = cudnn_handle_manager->handle(this->device_);
-  NBLA_CUDNN_CHECK(cudnnGetReductionWorkspaceSize(
-      cudnn_handle, this->reduce_desc_, this->x_desc_, this->y_desc_,
-      &this->workspace_size_));
+  if (!this->same_in_out_shape_) {
+    cudnn_set_tensor_descriptor<T>(this->x_desc_, x_shape);
+    cudnn_set_tensor_descriptor<T>(this->y_desc_, y_shape);
+
+    auto cudnn_handle_manager = SingletonManager::get<CudnnHandleManager>();
+    auto cudnn_handle = cudnn_handle_manager->handle(this->device_);
+    NBLA_CUDNN_CHECK(cudnnGetReductionWorkspaceSize(
+        cudnn_handle, this->reduce_desc_, this->x_desc_, this->y_desc_,
+        &this->workspace_size_));
+  }
 }
 
 template <typename T>
@@ -57,6 +61,12 @@ void ProdCudaCudnn<T>::forward_impl(const Variables &inputs,
                                     const Variables &outputs) {
   if ((!this->f_transpose_) || (inputs[0]->shape().size() > CUDNN_DIM_MAX)) {
     ProdCuda<T>::forward_impl(inputs, outputs);
+    return;
+  }
+  if (this->same_in_out_shape_) {
+    const Array *x = inputs[0]->data()->get(get_dtype<Tcu>(), this->ctx_);
+    Array *y = outputs[0]->data()->cast(get_dtype<Tcu>(), this->ctx_, true);
+    y->copy_from(x);
     return;
   }
   cuda_set_device(this->device_);

--- a/src/nbla/cuda/cudnn/function/generic/sum.cu
+++ b/src/nbla/cuda/cudnn/function/generic/sum.cu
@@ -42,14 +42,18 @@ void SumCudaCudnn<T>::setup_impl(const Variables &inputs,
   for (auto axis : this->axes_)
     y_shape.at(axis) = 1;
 
-  cudnn_set_tensor_descriptor<T>(this->x_desc_, x_shape);
-  cudnn_set_tensor_descriptor<T>(this->y_desc_, y_shape);
+  this->same_in_out_shape_ = (y_shape == x_shape) ? true : false;
 
-  auto cudnn_handle_manager = SingletonManager::get<CudnnHandleManager>();
-  auto cudnn_handle = cudnn_handle_manager->handle(this->device_);
-  NBLA_CUDNN_CHECK(cudnnGetReductionWorkspaceSize(
-      cudnn_handle, this->reduce_desc_, this->x_desc_, this->y_desc_,
-      &this->workspace_size_));
+  if (!this->same_in_out_shape_) {
+    cudnn_set_tensor_descriptor<T>(this->x_desc_, x_shape);
+    cudnn_set_tensor_descriptor<T>(this->y_desc_, y_shape);
+
+    auto cudnn_handle_manager = SingletonManager::get<CudnnHandleManager>();
+    auto cudnn_handle = cudnn_handle_manager->handle(this->device_);
+    NBLA_CUDNN_CHECK(cudnnGetReductionWorkspaceSize(
+        cudnn_handle, this->reduce_desc_, this->x_desc_, this->y_desc_,
+        &this->workspace_size_));
+  }
 }
 
 template <typename T>
@@ -57,6 +61,12 @@ void SumCudaCudnn<T>::forward_impl(const Variables &inputs,
                                    const Variables &outputs) {
   if ((!this->f_transpose_) || (inputs[0]->shape().size() > CUDNN_DIM_MAX)) {
     SumCuda<T>::forward_impl(inputs, outputs);
+    return;
+  }
+  if (this->same_in_out_shape_) {
+    const Array *x = inputs[0]->data()->get(get_dtype<Tcu>(), this->ctx_);
+    Array *y = outputs[0]->data()->cast(get_dtype<Tcu>(), this->ctx_, true);
+    y->copy_from(x);
     return;
   }
   cuda_set_device(this->device_);


### PR DESCRIPTION
This PR corrects an an error raised by CuDNN when calling a reduction method with equal input / output shape (where no reduction is needed). The implementation now catches that case and makes a simple copy.