### PR TITLE
Fix a race condition when using thrust::async::sort

### DIFF
--- a/src/nbla/cuda/function/generic/sort.cu
+++ b/src/nbla/cuda/function/generic/sort.cu
@@ -107,30 +107,23 @@ void SortCuda<T>::forward_impl(const Variables &inputs,
   auto outer_i_raw = sort_index_raw;
   auto stride = this->inner_size;
 
-  cudaStream_t stream;
-  NBLA_CUDA_CHECK(cudaStreamCreate(&stream));
-
   while (outer_x_raw < x_data + this->total_size) {
     auto inner_x_raw = outer_x_raw;
     auto inner_i_raw = outer_i_raw;
 
     while (inner_x_raw < outer_x_raw + this->inner_size) {
       auto size = temp_index_var.size();
-      auto compare = Compare<Tcu>(inner_x_raw, stride, this->reverse);
-      NBLA_CUDA_LAUNCH_KERNEL_IN_STREAM(make_sequence, stream, size,
-                                        temp_index_raw);
-      (void)sort(thrust::cuda::par.on(stream), temp_index_ptr,
-                 temp_index_ptr + size, compare);
-      NBLA_CUDA_LAUNCH_KERNEL_IN_STREAM(copy_index, stream, shape[this->axis],
-                                        stride, temp_index_raw, inner_i_raw);
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(make_sequence, size, temp_index_raw);
+      (void)sort(thrust::cuda::par.on(0), temp_index_ptr, temp_index_ptr + size,
+                 Compare<Tcu>(inner_x_raw, stride, this->reverse));
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(copy_index, shape[this->axis], stride,
+                                     temp_index_raw, inner_i_raw);
       inner_x_raw++;
       inner_i_raw++;
     }
     outer_x_raw += this->outer_size;
     outer_i_raw += this->outer_size;
   }
-
-  NBLA_CUDA_CHECK(cudaStreamDestroy(stream));
 
   if (!this->only_index) {
     auto y_data = outputs[0]->cast_data_and_get_pointer<Tcu>(ctx, true);


### PR DESCRIPTION
Thrust asynchronous sort uses a non-blocking CUDA stream that may start to work on data created on default stream before that is completely done. This PR forces the use of the default stream with the main difference compared to synchronous sort now that there is `cudaStreamSynchronize` instead of `cudaDeviceSynchronize` after each sort.