### PR TITLE
Add DaliIterator

### DIFF
--- a/build-tools/make/build-with-docker.mk
+++ b/build-tools/make/build-with-docker.mk
@@ -39,6 +39,7 @@ endif
 NVIDIA_DOCKER_WRAPPER=$(NNABLA_EXT_CUDA_DIRECTORY)/build-tools/scripts/nvidia-docker.sh
 
 CUDA_SUFFIX = $(CUDA_VERSION_MAJOR)$(CUDA_VERSION_MINOR)-cudnn$(CUDNN_VERSION)
+CUDA_VERSION_MAJOR_MINOR = $(CUDA_VERSION_MAJOR).$(CUDA_VERSION_MINOR)
 
 DOCKER_IMAGE_ID_BUILD_NNABLA_EXT_CUDA = $(shell md5sum $(NNABLA_EXT_CUDA_DIRECTORY)/docker/development/Dockerfile.build$(ARCH_SUFFIX) |cut -d \  -f 1)
 DOCKER_IMAGE_BUILD_NNABLA_EXT_CUDA ?= $(DOCKER_IMAGE_NAME_BASE)-build-cuda$(CUDA_SUFFIX)$(ARCH_SUFFIX):$(DOCKER_IMAGE_ID_BUILD_NNABLA_EXT_CUDA)
@@ -67,6 +68,8 @@ docker_image_build_cuda$(DOCKER_IMAGE_TARGET_SUFFIX):
 		docker pull $(DOCKER_IMAGE_BUILD_CUDA_BASE) && \
 		(cd $(NNABLA_EXT_CUDA_DIRECTORY) && docker build $(DOCKER_BUILD_ARGS)\
 			--build-arg BASE=$(DOCKER_IMAGE_BUILD_CUDA_BASE) \
+			--build-arg CUDA_VERSION_MAJOR_MINOR=$(CUDA_VERSION_MAJOR_MINOR) \
+			--build-arg ARCH_SUFFIX=$(ARCH_SUFFIX) \
 			-t $(DOCKER_IMAGE_BUILD_NNABLA_EXT_CUDA) \
 			-f docker/development/Dockerfile.build$(ARCH_SUFFIX) \
 			.) \
@@ -78,6 +81,8 @@ docker_image_build_cuda_multi_gpu$(DOCKER_IMAGE_TARGET_SUFFIX):
 		docker pull $(DOCKER_IMAGE_BUILD_CUDA_MULTI_GPU_BASE) && \
 		(cd $(NNABLA_EXT_CUDA_DIRECTORY) && docker build $(DOCKER_BUILD_ARGS) \
 			--build-arg BASE=$(DOCKER_IMAGE_BUILD_CUDA_MULTI_GPU_BASE) \
+			--build-arg CUDA_VERSION_MAJOR_MINOR=$(CUDA_VERSION_MAJOR_MINOR) \
+			--build-arg ARCH_SUFFIX=$(ARCH_SUFFIX) \
 			-t $(DOCKER_IMAGE_BUILD_NNABLA_EXT_CUDA_MULTI_GPU) \
 			-f docker/development/Dockerfile.build-multi-gpu$(ARCH_SUFFIX) \
 			.) \
@@ -176,7 +181,10 @@ docker_image_nnabla_ext_cuda:
 	&& cp $(BUILD_EXT_CUDA_DIRECTORY_WHEEL)/dist/*.whl . \
 	&& echo ADD $(shell basename $(BUILD_EXT_CUDA_DIRECTORY_WHEEL)/dist/*.whl) /tmp/ >>Dockerfile \
 	&& echo RUN pip install /tmp/$(shell basename $(BUILD_EXT_CUDA_DIRECTORY_WHEEL)/dist/*.whl) >>Dockerfile \
-	&& docker build --build-arg BASE=$${BASE} $(DOCKER_BUILD_ARGS) -t $(DOCKER_IMAGE_NNABLA_EXT_CUDA) . \
+	&& docker build --build-arg BASE=$${BASE} $(DOCKER_BUILD_ARGS) \
+		--build-arg CUDA_VERSION_MAJOR_MINOR=$(CUDA_VERSION_MAJOR_MINOR) \
+		--build-arg ARCH_SUFFIX=$(ARCH_SUFFIX) \
+		-t $(DOCKER_IMAGE_NNABLA_EXT_CUDA) . \
 	&& rm -f $(shell basename $(BUILD_DIRECTORY_WHEEL)/dist/*.whl) \
 	&& rm -f $(shell basename $(BUILD_EXT_CUDA_DIRECTORY_WHEEL_MULTI_GPU)/dist/*.whl) \
 	&& rm -f Dockerfile
@@ -194,7 +202,10 @@ docker_image_nnabla_ext_cuda_multi_gpu: bwd-nnabla-ext-cuda-wheel-multi-gpu
 	&& cp $(BUILD_EXT_CUDA_DIRECTORY_WHEEL_MULTI_GPU)/dist/*.whl . \
 	&& echo ADD $(shell basename $(BUILD_EXT_CUDA_DIRECTORY_WHEEL_MULTI_GPU)/dist/*.whl) /tmp/ >>Dockerfile \
 	&& echo RUN pip install /tmp/$(shell basename $(BUILD_EXT_CUDA_DIRECTORY_WHEEL_MULTI_GPU)/dist/*.whl) >>Dockerfile \
-	&& docker build --build-arg BASE=$${BASE} $(DOCKER_BUILD_ARGS) -t $(DOCKER_IMAGE_NNABLA_EXT_CUDA_MULTI_GPU) . \
+	&& docker build --build-arg BASE=$${BASE} $(DOCKER_BUILD_ARGS) \
+		--build-arg CUDA_VERSION_MAJOR_MINOR=$(CUDA_VERSION_MAJOR_MINOR) \
+		--build-arg ARCH_SUFFIX=$(ARCH_SUFFIX) \
+		-t $(DOCKER_IMAGE_NNABLA_EXT_CUDA_MULTI_GPU) . \
 	&& rm -f $(shell basename $(BUILD_DIRECTORY_WHEEL)/dist/*.whl) \
 	&& rm -f $(shell basename $(BUILD_EXT_CUDA_DIRECTORY_WHEEL_MULTI_GPU)/dist/*.whl) \
 	&& rm -f Dockerfile

--- a/build-tools/make/build.mk
+++ b/build-tools/make/build.mk
@@ -181,7 +181,8 @@ nnabla-ext-cuda-test:
 nnabla-ext-cuda-test-local: nnabla-install nnabla-ext-cuda-install
 	cd $(BUILD_EXT_CUDA_DIRECTORY_WHEEL) \
 	&& PYTHONPATH=$(NNABLA_EXT_CUDA_DIRECTORY)/python/test \
-	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh $(NNABLA_DIRECTORY)/python/test
+	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh $(NNABLA_DIRECTORY)/python/test \
+	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh $(NNABLA_EXT_CUDA_DIRECTORY)/python/test
 
 .PHONY: nnabla-ext-cuda-multi-gpu-test-local
 nnabla-ext-cuda-multi-gpu-test-local: nnabla-ext-cuda-multi-gpu-install
@@ -192,4 +193,5 @@ nnabla-ext-cuda-multi-gpu-test-local: nnabla-ext-cuda-multi-gpu-install
 			--communicator-gpus=0,1 \
 			$(NNABLA_DIRECTORY)/python/test/communicator
 	cd $(BUILD_EXT_CUDA_DIRECTORY_WHEEL_MULTI_GPU) \
-	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh $(NNABLA_DIRECTORY)/python/test
+	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh $(NNABLA_DIRECTORY)/python/test \
+	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh $(NNABLA_EXT_CUDA_DIRECTORY)/python/test

--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -149,6 +149,8 @@ ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 # Limitation: numpy>=1.17 does not support python2.7
 ADD python/requirements.txt /tmp/deps/
 
+ARG CUDA_VERSION_MAJOR_MINOR
+ARG ARCH_SUFFIX
 RUN umask 0 \
     && cd /tmp/deps \
     && wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
@@ -159,6 +161,10 @@ RUN umask 0 \
     && conda activate nnabla-build \
     && pip install numpy\<1.17 \
     && pip install --only-binary -U -r /tmp/deps/requirements.txt \
+    && ( [ "$CUDA_VERSION_MAJOR_MINOR" = "10.0" ] || [ "$CUDA_VERSION_MAJOR_MINOR" = "9.0" ] \
+        && [ "x$ARCH_SUFFIX" = "x" ] \
+        && pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/cuda/${CUDA_VERSION_MAJOR_MINOR} nvidia-dali \
+        || echo "Skip DALI installation (CUDA=$CUDA_VERSION_MAJOR_MINOR ARCH=$ARCH_SUFFIX)" ) \
     && conda clean -y --all \
     && cd / \
     && rm -rf /tmp/*

--- a/docker/development/Dockerfile.build-multi-gpu
+++ b/docker/development/Dockerfile.build-multi-gpu
@@ -79,6 +79,8 @@ ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 # Limitation: numpy>=1.17 does not support python2.7
 ADD python/requirements.txt /tmp/deps/
 
+ARG CUDA_VERSION_MAJOR_MINOR
+ARG ARCH_SUFFIX
 RUN umask 0 \
     && cd /tmp/deps \
     && wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
@@ -89,6 +91,10 @@ RUN umask 0 \
     && conda activate nnabla-build \
     && pip install numpy\<1.17 \
     && pip install --only-binary -U -r /tmp/deps/requirements.txt \
+    && ( [ "$CUDA_VERSION_MAJOR_MINOR" = "10.0" ] || [ "$CUDA_VERSION_MAJOR_MINOR" = "9.0" ] \
+        && [ "x$ARCH_SUFFIX" = "x" ] \
+        && pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/cuda/${CUDA_VERSION_MAJOR_MINOR} nvidia-dali \
+        || echo "Skip DALI installation (CUDA=$CUDA_VERSION_MAJOR_MINOR ARCH=$ARCH_SUFFIX)" ) \
     && conda clean -y --all \
     && cd / \
     && rm -rf /tmp/*

--- a/docker/runtime/Dockerfile.runtime
+++ b/docker/runtime/Dockerfile.runtime
@@ -13,6 +13,8 @@ ARG PYTHON_VERSION_MAJOR
 ARG PYTHON_VERSION_MINOR
 ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
+ARG CUDA_VERSION_MAJOR_MINOR
+ARG ARCH_SUFFIX
 RUN umask 0 \
     && cd /tmp/deps \
     && wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
@@ -21,6 +23,10 @@ RUN umask 0 \
     && . /opt/miniconda3/bin/activate \
     && conda create -n nnabla-build python=${PYVERNAME} \
     && conda activate nnabla-build \
+    && ( [ "$CUDA_VERSION_MAJOR_MINOR" = "10.0" ] || [ "$CUDA_VERSION_MAJOR_MINOR" = "9.0" ] \
+        && [ "x$ARCH_SUFFIX" = "x" ] \
+        && pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/cuda/${CUDA_VERSION_MAJOR_MINOR} nvidia-dali \
+        || echo "Skip DALI installation (CUDA=$CUDA_VERSION_MAJOR_MINOR ARCH=$ARCH_SUFFIX)" ) \
     && conda clean -y --all \
     && cd / \
     && rm -rf /tmp/*

--- a/docker/runtime/Dockerfile.runtime-multi-gpu
+++ b/docker/runtime/Dockerfile.runtime-multi-gpu
@@ -15,6 +15,8 @@ ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
 ADD python/requirements.txt /tmp/deps/
 
+ARG CUDA_VERSION_MAJOR_MINOR
+ARG ARCH_SUFFIX
 RUN umask 0 \
     && cd /tmp/deps \
     && wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
@@ -23,6 +25,10 @@ RUN umask 0 \
     && . /opt/miniconda3/bin/activate \
     && conda create -n nnabla-build python=${PYVERNAME} \
     && conda activate nnabla-build \
+    && ( [ "$CUDA_VERSION_MAJOR_MINOR" = "10.0" ] || [ "$CUDA_VERSION_MAJOR_MINOR" = "9.0" ] \
+        && [ "x$ARCH_SUFFIX" = "x" ] \
+        && pip install --extra-index-url https://developer.download.nvidia.com/compute/redist/cuda/${CUDA_VERSION_MAJOR_MINOR} nvidia-dali \
+        || echo "Skip DALI installation (CUDA=$CUDA_VERSION_MAJOR_MINOR ARCH=$ARCH_SUFFIX)" ) \
     && pip install --only-binary -U -r /tmp/deps/requirements.txt \
     && conda clean -y --all \
     && cd / \

--- a/python/setup.py
+++ b/python/setup.py
@@ -129,7 +129,10 @@ def cuda_config(root_dir, cuda_lib, ext_opts, lib_dirs):
     path_cuda_pkg = join(src_dir, 'nnabla_ext', 'cuda')
     cuda_pkg = "nnabla_ext.cuda"
     package_dir = {cuda_pkg: path_cuda_pkg}
-    packages = [cuda_pkg]
+    packages = [
+        cuda_pkg,
+        cuda_pkg + '.experimental',
+    ]
 
     cuda_lib_out = join(path_cuda_pkg, cuda_lib.file_name)
     shutil.copyfile(cuda_lib.path, cuda_lib_out)

--- a/python/src/nnabla_ext/cuda/experimental/__init__.py
+++ b/python/src/nnabla_ext/cuda/experimental/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2019 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import

--- a/python/src/nnabla_ext/cuda/experimental/_dali_iterator.py
+++ b/python/src/nnabla_ext/cuda/experimental/_dali_iterator.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import nvidia.dali
+from nvidia.dali.pipeline import Pipeline
+
 
 def feed_ndarray(dali_tensor, arr, ctx, non_blocking=False):
     """
@@ -108,3 +111,135 @@ class DaliIterator(object):
 
     def __next__(self):
         return self.next()
+
+
+class DataIteratorPipeline(Pipeline):
+
+    '''Creates a DALI pipeline from nnabla DataIterator.
+
+    During computation, it asynchronously transfers data for next mini-batch
+    from DataIterator to GPU memory on a device specified by device_id.
+
+    Example:
+
+        .. code-block:: python
+
+            import numpy as np
+            from nnabla.utils.data_iterator import data_iterator_simple
+            from nnabla_ext.cuda.experimental import dali_iterator
+
+            # Create an data iterator which yeilds two `numpy.ndarray`s.
+            nn_it = data_iterator_simple(
+                lambda i: (np.full((2, 3), 0, dtype=np.float32),
+                           np.full((2, 3), i, dtype=np.int32)),
+                512, 32, shuffle=True)
+
+            # Create a pipeline from data iterator
+            p = dali_iterator.DataIteratorPipeline(nn_it, device_id=0)
+            dali_it = dali_iterator.DaliIterator(p)
+
+            # In a training loop
+            for i in range(args.max_iter):
+
+                # .next() returns two `nnabla.NdArray`s
+                a1, a2 = dali_it.next()
+
+                # Suppose we have two input `Variable`s
+                x1.data = a1
+                x2.data = a2
+
+                loss.forward()
+                ...
+
+    Args:
+        it (:obj:`~nnabla.utils.data_iterator.DataIterator` like object):
+            An iterator returns a tuple of data by `.next()` method.
+        num_threads (int): Fed into Pipeline. See DALI's doc.
+        device_id (int): Fed into Pipeline. See DALI's doc.
+        seed (int): Fed into Pipeline. See DALI's doc.
+        batch_size (int, optional):
+            The batchsize fed into Pipeline class. If None (default),
+            is determined by a first dimension of a first element
+            in a tuple returned by a data iterator.
+
+    '''
+
+    def __init__(self, it, num_threads=2, device_id=0, seed=726, batch_size=None):
+        import nvidia.dali.ops as ops
+        # Use first mini-batch to see how iterator returns arrays
+        values = it.next()
+        self.initial_values = values  # Use it at first batch
+        # Assuming batch size is at first dimension
+        if batch_size is None:
+            batch_size = values[0].shape[0]
+        super(DataIteratorPipeline, self).__init__(
+            batch_size,
+            num_threads,
+            device_id,
+            seed=seed)
+        self.it = it
+        self.inputs = []
+        for _ in range(len(values)):
+            self.inputs.append(ops.ExternalSource())
+
+    def define_graph(self):
+        self.graph_inputs = []
+        ret = tuple()
+        for i in self.inputs:
+            g = i()
+            self.graph_inputs.append(g)
+            # Prefetch to GPU
+            ret += (g.gpu(),)
+        return ret
+
+    def iter_setup(self):
+        if self.initial_values is not None:
+            values = self.initial_values
+            self.initial_values = None
+        else:
+            values = self.it.next()
+        for g, v in zip(self.graph_inputs, values):
+            self.feed_input(g, v)
+
+
+def create_dali_iterator_from_data_iterator(
+        it, num_threads=2, device_id=0, seed=726, batch_size=None, non_blocking=False):
+    '''
+    A helper function which creates a `DaliIterator` from a data iterator.
+
+    See `DataIteratorPipeline` and `DaliIterator` for argument definitions.
+
+    Example:
+
+        .. code-block:: python
+
+            import numpy as np
+            from nnabla.utils.data_iterator import data_iterator_simple
+            from nnabla_ext.cuda.experimental import dali_iterator
+
+            # Create an data iterator which yeilds two `numpy.ndarray`s.
+            nn_it = data_iterator_simple(
+                lambda i: (np.full((2, 3), 0, dtype=np.float32),
+                           np.full((2, 3), i, dtype=np.int32)),
+                512, 32, shuffle=True)
+
+            # Create a pipeline from data iterator
+            dali_it = dali_iterator.create_dali_iterator_from_data_iterator(
+                nn_it, device_id=0, non_blocking=False)
+
+            # In a training loop
+            for i in range(args.max_iter):
+
+                # .next() returns two `nnabla.NdArray`s
+                a1, a2 = dali_it.next()
+
+                # Suppose we have two input `Variable`s
+                x1.data = a1
+                x2.data = a2
+
+                loss.forward()
+                ...
+
+    '''
+    p = DataIteratorPipeline(it, num_threads, device_id, seed)
+    return DaliIterator(p, non_blocking=non_blocking)

--- a/python/src/nnabla_ext/cuda/experimental/_dali_iterator.py
+++ b/python/src/nnabla_ext/cuda/experimental/_dali_iterator.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2019 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def feed_ndarray(dali_tensor, arr, ctx, non_blocking=False):
+    """
+    Copy contents of DALI tensor to NNabla's NdArray.
+
+    Args:
+        dali_tensor(nvidia.dali.backend.TensorCPU or nvidia.dali.backend.TensorGPU) : 
+            Tensor from which to copy
+        arr (nnabla.NdArray):
+            Destination of the copy
+        ctx (nnabla.Context):
+            CPU context or GPU context. It must match dali tensor device.
+        non_blocking (bool, optional):
+            If True, copy from a DALI tensor to a nnabla tensor is performed
+            asynchronously wrt host.
+    """
+    import ctypes
+    import numpy as np
+    assert dali_tensor.shape() == list(arr.shape), \
+        ("Shapes do not match: DALI tensor has size {0}"
+         ", but NNabla Tensor has size {1}".format(dali_tensor.shape(), list(arr.size)))
+    dtype = np.dtype(dali_tensor.dtype())
+    # turn raw int to a c void pointer
+    c_type_pointer = ctypes.c_void_p(arr.data_ptr(dtype, ctx))
+    kw = {}
+    if non_blocking:
+        kw.update(dict(non_blocking=non_blocking))
+    dali_tensor.copy_to_external(c_type_pointer, **kw)
+    return arr
+
+
+class DaliIterator(object):
+    '''A simple DALI iterator from a DALI pipeline.
+
+    Args:
+        pipeline (~nvidia.dali.pipeline.Pipeline):
+            A DALI pipeline. A member method `.build()` is called in
+            initialization of this class.
+
+        non_blocking (bool, optional):
+            If True, copy from a DALI tensor to a nnabla tensor is performed
+            asynchronously wrt host. Default is False (synchronous).
+            Do not use True if you are not sure what happens.
+            It should be safe if device null stream is always synchronized to
+            host thread between two `.next()` calls.
+
+    '''
+
+    def __init__(self, pipeline, non_blocking=False):
+
+        # TODO: Enable non_blocking option when it's in DALI.
+        assert not non_blocking,\
+            "The option `non_blocking` is not in DALI yet (https://github.com/NVIDIA/DALI/pull/1254)."
+        self.pipeline = pipeline
+        self.pipeline.build()
+        self.non_blocking = non_blocking
+
+    def next(self):
+        from nnabla.ext_utils import get_extension_context
+        from nnabla import NdArray
+        from nvidia.dali.backend import TensorCPU
+
+        outputs = self.pipeline.run()
+
+        # force outputs to be list object.
+        if not isinstance(outputs, list):
+            outputs = [outputs]
+
+        # Get current cpu&gpu context first.
+        cpu_ctx = get_extension_context("cpu")
+        device_id = self.pipeline.device_id
+        assert device_id >= 0, "Negative device_id is set in pipeline."
+        gpu_ctx = get_extension_context('cuda', device_id=str(device_id))
+
+        ret = []
+        for output in outputs:
+            # check all outputs are dense tensor. (= Each Output has the same shape along batch axis.)
+            if not output.is_dense_tensor:
+                raise ValueError(
+                    "Different shape of data are included in a single batch.")
+
+            tensor = output.as_tensor()
+            arr = NdArray(tensor.shape())
+            ctx = gpu_ctx
+            non_blocking = self.non_blocking
+            if isinstance(tensor, TensorCPU):
+                ctx = cpu_ctx
+                non_blocking = False
+
+            ret.append(feed_ndarray(
+                tensor, arr, ctx, non_blocking))
+
+        return ret
+
+    def __next__(self):
+        return self.next()

--- a/python/src/nnabla_ext/cuda/experimental/dali_iterator.py
+++ b/python/src/nnabla_ext/cuda/experimental/dali_iterator.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2019 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+enabled = False
+try:
+    import nvidia.dali
+    from ._dali_iterator import *
+    enabled = True
+except ImportError as e:
+    print(e)
+    from nnabla.logger import logger
+    logger.error("Skip importing nnabla daliIterator wrapper because nvidia.dali is not found."
+                 " Please make sure you've installed nvidia.dali.")

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2019 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption('--disable-test-large-blocks', action='store_true', default=False,
+                     help='Whether to run test_cuda_large_blocks which consumes quite large memory.')
+
+
+@pytest.fixture(scope='session')
+def cuda_test_opts(request):
+    """Parse options and expose as a fixture.
+
+    Returns: NNablaOpts
+        An  object which has ext, ext_kwargs, benchmark_output_dir and
+        function_benchmark_writer as attributes.
+    """
+    from collections import namedtuple
+    getoption = request.config.getoption
+    disable_test_large_blocks = getoption("--disable-test-large-blocks")
+    NNablaExtCudaTestOpts = namedtuple("NNablaExtCudaTestOpts",
+                                       [
+                                           'disable_test_large_blocks',
+                                           ])
+    return NNablaExtCudaTestOpts(disable_test_large_blocks)

--- a/python/test/cuda/test_dali_iterator.py
+++ b/python/test/cuda/test_dali_iterator.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2019 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import pytest
+import numpy as np
+import nnabla as nn
+
+from nnabla_ext.cuda.experimental import dali_iterator
+
+if dali_iterator.enabled:
+    from nvidia.dali.pipeline import Pipeline
+
+    class IteratorPipeline(Pipeline):
+        def __init__(self, it, num_threads=2, device_id=0, seed=12):
+            import nvidia.dali.ops as ops
+            # Use first mini-batch to see how iterator returns arrays
+            values = it.next()
+            self.initial_values = values  # Use it at first batch
+            # Assuming batch size is at first dimension
+            batch_size = values[0].shape[0]
+            super(IteratorPipeline, self).__init__(
+                batch_size,
+                num_threads,
+                device_id,
+                seed=seed)
+            self.it = it
+            self.inputs = []
+            for _ in range(len(values)):
+                self.inputs.append(ops.ExternalSource())
+
+        def define_graph(self):
+            self.graph_inputs = []
+            ret = tuple()
+            for i in self.inputs:
+                g = i()
+                self.graph_inputs.append(g)
+                # Prefetch to GPU
+                ret += (g.gpu(),)
+            return ret
+
+        def iter_setup(self):
+            if self.initial_values is not None:
+                values = self.initial_values
+                self.initial_values = None
+            else:
+                values = self.it.next()
+            for g, v in zip(self.graph_inputs, values):
+                self.feed_input(g, v)
+
+
+@pytest.mark.skipif("not dali_iterator.enabled")
+def test_dali_iterator():
+
+    class Iterator1(object):
+        def __init__(self, shape1, shape2):
+            self.i = 0
+            self.shape1 = shape1
+            self.shape2 = shape2
+
+        def next(self):
+            df = np.full(self.shape1, self.i, dtype=np.float32)
+            di = np.full(self.shape2, self.i, dtype=np.int32)
+            self.i += 1
+            return df, di
+
+    shape1 = (2, 3)
+    shape2 = (2, 2)
+    it = Iterator1(shape1, shape2)
+    for i in range(5):
+        df, di = it.next()
+        assert df.shape == shape1
+        assert di.shape == shape2
+
+    it = Iterator1(shape1, shape2)
+    p = IteratorPipeline(it)
+    # Testing non_blocking=True because we know it's safe in the following loop.
+    # --> TODO: Noticed that non_blocking option is not suppported as of 2019/10/11.
+    dali_it = dali_iterator.DaliIterator(p, False)
+
+    for i in range(5):
+        ddf, ddi = dali_it.next()
+        assert isinstance(ddf, nn.NdArray)
+        assert isinstance(ddi, nn.NdArray)
+        assert ddf.dtype == np.float32
+        assert ddi.dtype == np.int32
+        # The following synchronizes null stream to host.
+        # So, it's safe in non_blocking mode.
+        np.testing.assert_allclose(ddf.get_data('r'), i)
+        np.testing.assert_equal(ddi.get_data('r'), i)

--- a/python/test/cuda/test_large_blocks.py
+++ b/python/test/cuda/test_large_blocks.py
@@ -20,9 +20,10 @@ import nnabla as nn
 import nnabla.functions as F
 
 
-@pytest.mark.skipif("not hasattr(nn.extensions, 'cuda')")
 @pytest.mark.parametrize("m", [1, 2, 3])
-def test_cuda_large_blocks(m):
+def test_cuda_large_blocks(cuda_test_opts, m):
+    if cuda_test_opts.disable_test_large_blocks:
+        pytest.skip('`--disable-test-large-blocks` is passed')
     CUDA_THREAD_PER_BLOCK = 512
     CUDA_MAX_BLOCKS = 65536
     size = CUDA_MAX_BLOCKS * CUDA_THREAD_PER_BLOCK * m + 3
@@ -30,5 +31,7 @@ def test_cuda_large_blocks(m):
     x = np.zeros((size,), np.float32)
     v = nn.Variable(x.shape)
     v.d = x
-    ctx = nn.Context(backend='cuda')
-    y = F.relu(v)
+    from nnabla.ext_utils import get_extension_context
+    with nn.context_scope(get_extension_context('cuda')):
+        y = F.relu(v)
+        y.forward()


### PR DESCRIPTION
This PR adds a capability of using NVIDIA's data loading library [DALI](https://developer.nvidia.com/DALI) in nnabla.

The following example creates a DALI iterator from nnabla's data iterator. You can also create your own DALI pipeline fed into `DaliIterator`. 

```python
import numpy as np
import nnabla as nn

from nnabla.ext_utils import get_extension_context
nn.set_default_context(get_extension_context('cudnn', device_id='0'))

# Create a dummy data iterator which yeilds two `numpy.ndarray`s.
from nnabla.utils.data_iterator import data_iterator_simple
batch_size = 32
data_shape = (4, 256, 256)
nn_it = data_iterator_simple(
    lambda i: (np.full(data_shape, 0, dtype=np.float32),
                np.full(data_shape, i, dtype=np.int32)),
    512, batch_size, shuffle=True)

# Create a pipeline from data iterator
from nnabla_ext.cuda.experimental import dali_iterator
p = dali_iterator.DataIteratorPipeline(nn_it, device_id=0)
dali_it = dali_iterator.DaliIterator(p)
```
`DaliIterator` can be used as following.

```python
# Create a whatever network
v1 = nn.Variable((batch_size,) + data_shape)
v2 = nn.Variable((batch_size,) + data_shape)
y = 0
for i in range(500):
    y += v1 + v2
    y -= v1 + v2
    
# In a data processing loop
for i in range(5):
    # Set inputs from nnabla data iterator, which is slower
    # because it transfers the data to GPU synchronously.
    # v1.d, v2.d = nn_it.next()
    
    # Set inputs from DALI iterator
    # This automatically transfers array values
    # to GPU asynchronously to computation
    v1.data, v2.data = dali_it.next()
    y.forward(clear_buffer=True)
```