### PR TITLE
BatchNorm backward in test mode

### DIFF
--- a/src/nbla/cuda/cudnn/function/generic/batch_normalization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/batch_normalization.cu
@@ -239,7 +239,7 @@ void BatchNormalizationCudaCudnn<T>::backward_impl(
   if (this->batch_stat_) { // Training mode.
     backward_impl_batch(inputs, outputs, propagate_down, accum);
   } else { // Testing mode.
-    NBLA_ERROR(error_code::not_implemented, "");
+    this->backward_impl_global(inputs, outputs, propagate_down, accum);
   }
 }
 

--- a/src/nbla/cuda/function/generic/batch_normalization.cu
+++ b/src/nbla/cuda/function/generic/batch_normalization.cu
@@ -173,7 +173,7 @@ void BatchNormalizationCuda<T>::backward_impl(
   if (this->batch_stat_) { // Training mode.
     backward_impl_batch(inputs, outputs, propagate_down, accum);
   } else { // Testing mode.
-    NBLA_ERROR(error_code::not_implemented, "");
+    this->backward_impl_global(inputs, outputs, propagate_down, accum);
   }
 }
 


### PR DESCRIPTION
The backward of the batch normalization is now implemented by function composite so supported in every device.