### PR TITLE
[Windows] Fix batchnormalization fail with CUDNN_STATUS_NOT_SUPPORTED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,8 @@ if(BUILD_CPP_LIB)
   list(APPEND NBLA_INCLUDE_DIRS
     ${PROJECT_SOURCE_DIR}/include
     ${NNABLA_DIR}/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/eigen-git-mirror-3.3.5)
+    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/eigen-git-mirror-3.3.5
+    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog-0.16.3/include)
   include_directories(${NBLA_INCLUDE_DIRS};${PROJECT_BINARY_DIR})
   
   ###############################################################################

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -36,3 +36,4 @@ if(BUILD_TEST)
 endif()
 
 download_and_extract_third_party_library(eigen-git-mirror-3.3.5 https://github.com/eigenteam/eigen-git-mirror/archive/3.3.5.zip)
+download_and_extract_third_party_library(spdlog-0.16.3 https://github.com/gabime/spdlog/archive/v0.16.3.zip)


### PR DESCRIPTION
On windows, BatchNormalization*Ex fallbacks to the normal implementation to avoid CUDNN_STATUS_NOT_SUPPORTED.