### PR TITLE
FIX: Compatibility with DALI 0.18.0

### DIFF
--- a/python/src/nnabla_ext/cuda/experimental/_dali_iterator.py
+++ b/python/src/nnabla_ext/cuda/experimental/_dali_iterator.py
@@ -80,7 +80,7 @@ class DaliIterator(object):
         outputs = self.pipeline.run()
 
         # force outputs to be list object.
-        if not isinstance(outputs, list):
+        if not hasattr(outputs, '__iter__'):
             outputs = [outputs]
 
         # Get current cpu&gpu context first.


### PR DESCRIPTION
Recent version of DALI pipeline return result as a tuple.
For future-proofing, we should just check if the result is iterable.