### PR TITLE
Double Backward for ChannelLast and Half Type

### DIFF
--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -512,7 +512,7 @@ IFFT:
 #  half: [Half]
 Prune:
   float: [float]
-#  half: [Half]
+#  half: [Half] # since segfault with Half
 GatherNd:
   float: [float]
   half: [Half]

--- a/build-tools/code_generator/function_types_cudnn.yaml
+++ b/build-tools/code_generator/function_types_cudnn.yaml
@@ -23,8 +23,9 @@ MaxPooling:
 AveragePooling:
   float: [float]
   half: [Half]
-# SumPooling:
-#   float: [float]
+SumPooling:
+  float: [float]
+  half: [Half]
 # Unpooling:
 #   float: [float]
 # Embed:

--- a/include/nbla/cuda/cudnn/function/sum_pooling.hpp
+++ b/include/nbla/cuda/cudnn/function/sum_pooling.hpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_CUDNN_FUNCTION_SUM_POOLING_HPP
+#define NBLA_CUDA_CUDNN_FUNCTION_SUM_POOLING_HPP
+
+#include <nbla/function.hpp>
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+
+#include <nbla/cuda/cudnn/function/average_pooling.hpp>
+#include <nbla/function/sum_pooling.hpp>
+
+namespace nbla {
+
+template <typename T> class SumPoolingCudaCudnn : public SumPooling<T> {
+public:
+  typedef typename CudaType<T>::type Tcu;
+  // Current implementation depends on AveragePoolingCudaCudn since cudnn does
+  // not support the sumpooling.
+  // shared_ptr<Function> average_pooling_;
+
+  explicit SumPoolingCudaCudnn(const Context &ctx, const vector<int> &kernel,
+                               const vector<int> &stride, bool ignore_border,
+                               const vector<int> &pad, bool channel_last)
+      : SumPooling<T>(ctx, kernel, stride, ignore_border, pad, channel_last),
+        device_(std::stoi(ctx.device_id)),
+        average_pooling_(ctx, kernel, stride, ignore_border, pad, channel_last,
+                         true) {}
+  virtual string name() { return "SumPoolingCudaCudnn"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  int pool_size_;
+  AveragePoolingCudaCudnn<T> average_pooling_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/function/interpolate.hpp
+++ b/include/nbla/cuda/function/interpolate.hpp
@@ -34,8 +34,9 @@ public:
   typedef typename CudaType<T>::type Tcu;
 
   explicit InterpolateCuda(const Context &ctx, const vector<int> &output_size,
-                           const string &mode, bool align_corners)
-      : Interpolate<T>(ctx, output_size, mode, align_corners),
+                           const string &mode, bool align_corners,
+                           bool channel_last)
+      : Interpolate<T>(ctx, output_size, mode, align_corners, channel_last),
         device_(std::stoi(ctx.device_id)) {}
   virtual ~InterpolateCuda() {}
   virtual string name() { return "InterpolateCuda"; }

--- a/include/nbla/cuda/utils/nd_index.hpp
+++ b/include/nbla/cuda/utils/nd_index.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __NBLA_CUDA_UTILS_ND_INDEX_HPP__
+#define __NBLA_CUDA_UTILS_ND_INDEX_HPP__
+
+namespace nbla {
+
+template <int NDIM> struct NdIndex { int64_t nd_idx[NDIM]; };
+
+template <int NDIM>
+__device__ NdIndex<NDIM> device_flat2nd(int64_t idx, const int64_t *stride) {
+  NdIndex<NDIM> nd_index;
+  for (int i = 0; i < NDIM; i++) {
+    nd_index.nd_idx[i] = idx / stride[i];
+    idx -= nd_index.nd_idx[i] * stride[i];
+  }
+  return nd_index;
+}
+
+template <int NDIM>
+__device__ int64_t device_nd2flat(NdIndex<NDIM> &nd_index,
+                                  const int64_t *stride) {
+  auto idx = 0;
+  for (int i = 0; i < NDIM; i++) {
+    idx += stride[i] * nd_index.nd_idx[i];
+  }
+  return idx;
+}
+}
+
+#endif

--- a/src/nbla/cuda/cudnn/function/generic/sum_pooling.cu
+++ b/src/nbla/cuda/cudnn/function/generic/sum_pooling.cu
@@ -1,0 +1,101 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+#include <nbla/cuda/cudnn/function/sum_pooling.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+namespace sum_pooling {
+
+template <typename T>
+__global__ void pool_multiply(const int size, T *y, const float pool_size) {
+  NBLA_CUDA_KERNEL_LOOP(idx, size) { y[idx] *= pool_size; }
+}
+
+template <typename T, bool accum = true>
+__global__ void kernel_accum(const int size, T *dx, const T *dx_tmp) {
+  NBLA_CUDA_KERNEL_LOOP(idx, size) {
+    dx[idx] = accum ? dx[idx] + dx_tmp[idx] : dx_tmp[idx];
+  }
+}
+}
+
+template <typename T>
+void SumPoolingCudaCudnn<T>::setup_impl(const Variables &inputs,
+                                        const Variables &outputs) {
+  // TODO: implement
+  NBLA_CHECK(
+      this->ignore_border_, error_code::not_implemented,
+      "CudnnSumPoolingCudaCudnn with (ignore_border=False) is not supported.");
+  this->average_pooling_.setup(inputs, outputs);
+  pool_size_ = std::accumulate(this->kernel_.begin(), this->kernel_.end(), 1,
+                               std::multiplies<int>());
+}
+
+template <typename T>
+void SumPoolingCudaCudnn<T>::forward_impl(const Variables &inputs,
+                                          const Variables &outputs) {
+  // Forward of AveragePool
+  this->average_pooling_.forward(inputs, outputs);
+  // Multiply results by pool_size
+  auto size = outputs[0]->size();
+  auto y = outputs[0]->cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+  NBLA_CUDA_LAUNCH_KERNEL_SIMPLE((sum_pooling::pool_multiply<Tcu>), size, y,
+                                 pool_size_);
+}
+
+template <typename T>
+void SumPoolingCudaCudnn<T>::backward_impl(const Variables &inputs,
+                                           const Variables &outputs,
+                                           const vector<bool> &propagate_down,
+                                           const vector<bool> &accum) {
+  if (!propagate_down[0]) {
+    return;
+  }
+  // Seem to have to call the cudnn average pooling with the same pointer
+  // addresses,
+  // so the redundant logics are in here
+  auto size = inputs[0]->size();
+  if (accum[0]) {
+    // Save gradients once for accumulation case
+    auto iv_sptr = make_shared<Variable>(inputs[0]->shape());
+    auto iv = iv_sptr.get();
+    auto ig0 = iv->cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+    auto dx0 = inputs[0]->get_grad_pointer<Tcu>(this->ctx_);
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE((sum_pooling::kernel_accum<Tcu, false>),
+                                   size, ig0, dx0);
+    // Backward of AveragePool
+    this->average_pooling_.backward(inputs, outputs, propagate_down, {false});
+    // Multiply results by pool_size
+    auto dx = inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_, false);
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE((sum_pooling::pool_multiply<Tcu>), size, dx,
+                                   pool_size_);
+    // Accumulate
+    auto ig = iv->get_data_pointer<Tcu>(this->ctx_);
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE((sum_pooling::kernel_accum<Tcu, true>), size,
+                                   dx, ig);
+  } else {
+    // Backward of AveragePool
+    this->average_pooling_.backward(inputs, outputs, propagate_down, {false});
+    // Multiply results by pool_size
+    auto dx = inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_, false);
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE((sum_pooling::pool_multiply<Tcu>), size, dx,
+                                   pool_size_);
+  }
+}
+}

--- a/src/nbla/cuda/function/generic/interpolate.cu
+++ b/src/nbla/cuda/function/generic/interpolate.cu
@@ -16,6 +16,7 @@
 #include <nbla/cuda/common.hpp>
 #include <nbla/cuda/function/interpolate.hpp>
 #include <nbla/cuda/utils/atomic_add.cuh>
+#include <nbla/cuda/utils/nd_index.cuh>
 #include <nbla/variable.hpp>
 
 namespace nbla {
@@ -31,15 +32,18 @@ __device__ __forceinline__ float get_src_index(float scale, int dst_index,
                        : fmaxf(0.0f, scale * (float(dst_index) + 0.5f) - 0.5f);
 }
 
-template <typename T>
-__global__ void
-kernel_linear_interpolate_1d(const int dst_inner_size, T *dst,
-                             const int src_inner_size, const T *src,
-                             int outer_size, const int iw, const int ow,
-                             const float sx, const bool align_corners) {
+template <typename T, bool channel_last = false>
+__global__ void kernel_linear_interpolate_1d(
+    const int dst_inner_size, T *dst, const int src_inner_size, const T *src,
+    int outer_size, const int ishape, const int istride, const int ostride,
+    const float sx, const bool align_corners) {
 
   NBLA_CUDA_KERNEL_LOOP(index, dst_inner_size) {
-    const int ox = index % ow;
+    const auto nd_index = device_flat_to_2d(index, ostride);
+    const auto oc = channel_last ? nd_index.y : 0;
+    const auto ox = nd_index.x;
+
+    const auto iw = ishape;
 
     const auto fx = get_src_index(sx, ox, align_corners);
     const auto x1 = static_cast<int>(fx);
@@ -47,23 +51,34 @@ kernel_linear_interpolate_1d(const int dst_inner_size, T *dst,
     const auto lx1 = static_cast<T>(fx - x1);
     const auto lx0 = static_cast<T>(1) - lx1;
 
+    const auto nd_idx_x1 = make_int2(x1, oc);
+    const auto nd_idx_x2 = make_int2(x2, oc);
+
+    const auto idx_lx0 = device_2d_to_flat(nd_idx_x1, istride);
+    const auto idx_lx1 = device_2d_to_flat(nd_idx_x2, istride);
+
     for (; outer_size--; src += src_inner_size, dst += dst_inner_size) {
-      const T val0 = lx0 * src[x1];
-      const T val1 = lx1 * src[x2];
-      dst[ox] = val0 + val1;
+      const T val0 = lx0 * src[idx_lx0];
+      const T val1 = lx1 * src[idx_lx1];
+      dst[index] = val0 + val1;
     }
   }
 }
 
-template <typename T>
+template <typename T, bool channel_last = false>
 __global__ void kernel_linear_interpolate_2d(
     const int dst_inner_size, T *dst, const int src_inner_size, const T *src,
-    int outer_size, const int iw, const int ih, const int ow, const int oh,
+    int outer_size, const int2 ishape, const int2 istride, const int2 ostride,
     const float sx, const float sy, const bool align_corners) {
 
   NBLA_CUDA_KERNEL_LOOP(index, dst_inner_size) {
-    const int oy = index / ow;
-    const int ox = index % ow;
+    const auto nd_index = device_flat_to_3d(index, ostride);
+    const auto oc = channel_last ? nd_index.z : 0;
+    const auto oy = nd_index.x;
+    const auto ox = nd_index.y;
+
+    const auto ih = ishape.x;
+    const auto iw = ishape.y;
 
     const auto fy = get_src_index(sy, oy, align_corners);
     const auto y1 = static_cast<int>(fy);
@@ -77,29 +92,42 @@ __global__ void kernel_linear_interpolate_2d(
     const auto lx1 = static_cast<T>(fx - x1);
     const auto lx0 = static_cast<T>(1) - lx1;
 
+    const auto nd_idx_y1x1 = make_int3(y1, x1, oc);
+    const auto nd_idx_y1x2 = make_int3(y1, x2, oc);
+    const auto nd_idx_y2x1 = make_int3(y2, x1, oc);
+    const auto nd_idx_y2x2 = make_int3(y2, x2, oc);
+
+    const auto idx_ly0x0 = device_3d_to_flat(nd_idx_y1x1, istride);
+    const auto idx_ly0x1 = device_3d_to_flat(nd_idx_y1x2, istride);
+    const auto idx_ly1x0 = device_3d_to_flat(nd_idx_y2x1, istride);
+    const auto idx_ly1x1 = device_3d_to_flat(nd_idx_y2x2, istride);
+
     for (; outer_size--; src += src_inner_size, dst += dst_inner_size) {
-#define _I(y, x) ((y)*iw + (x))
-      const T val0 = lx0 * src[_I(y1, x1)];
-      const T val1 = lx1 * src[_I(y1, x2)];
-      const T val2 = lx0 * src[_I(y2, x1)];
-      const T val3 = lx1 * src[_I(y2, x2)];
-#undef _I
-      dst[oy * ow + ox] = ly0 * (val0 + val1) + ly1 * (val2 + val3);
+      const T val0 = lx0 * src[idx_ly0x0];
+      const T val1 = lx1 * src[idx_ly0x1];
+      const T val2 = lx0 * src[idx_ly1x0];
+      const T val3 = lx1 * src[idx_ly1x1];
+      dst[index] = ly0 * (val0 + val1) + ly1 * (val2 + val3);
     }
   }
 }
 
-template <typename T>
+template <typename T, bool channel_last = false>
 __global__ void kernel_linear_interpolate_3d(
     const int dst_inner_size, T *dst, const int src_inner_size, const T *src,
-    int outer_size, const int iw, const int ih, const int id, const int ow,
-    const int oh, const int od, const float sx, const float sy, const float sz,
-    const bool align_corners) {
+    int outer_size, const int3 ishape, const int3 istride, const int3 ostride,
+    const float sx, const float sy, const float sz, const bool align_corners) {
 
   NBLA_CUDA_KERNEL_LOOP(index, dst_inner_size) {
-    const int oz = index / (ow * oh);
-    const int oy = (index - oz * ow * oh) / ow;
-    const int ox = (index - oz * ow * oh) % ow;
+    const auto nd_index = device_flat_to_4d(index, ostride);
+    const auto oc = channel_last ? nd_index.w : 0;
+    const auto oz = nd_index.x;
+    const auto oy = nd_index.y;
+    const auto ox = nd_index.z;
+
+    const auto id = ishape.x;
+    const auto ih = ishape.y;
+    const auto iw = ishape.z;
 
     const auto fz = get_src_index(sz, oz, align_corners);
     const auto z1 = static_cast<int>(fz);
@@ -119,91 +147,135 @@ __global__ void kernel_linear_interpolate_3d(
     const auto lx1 = static_cast<T>(fx - x1);
     const auto lx0 = static_cast<T>(1) - lx1;
 
+    const auto nd_idx_z1y1x1 = make_int4(z1, y1, x1, oc);
+    const auto nd_idx_z1y1x2 = make_int4(z1, y1, x2, oc);
+    const auto nd_idx_z1y2x1 = make_int4(z1, y2, x1, oc);
+    const auto nd_idx_z1y2x2 = make_int4(z1, y2, x2, oc);
+    const auto nd_idx_z2y1x1 = make_int4(z2, y1, x1, oc);
+    const auto nd_idx_z2y1x2 = make_int4(z2, y1, x2, oc);
+    const auto nd_idx_z2y2x1 = make_int4(z2, y2, x1, oc);
+    const auto nd_idx_z2y2x2 = make_int4(z2, y2, x2, oc);
+
+    const auto idx_lz0y0x0 = device_4d_to_flat(nd_idx_z1y1x1, istride);
+    const auto idx_lz0y0x1 = device_4d_to_flat(nd_idx_z1y1x2, istride);
+    const auto idx_lz0y1x0 = device_4d_to_flat(nd_idx_z1y2x1, istride);
+    const auto idx_lz0y1x1 = device_4d_to_flat(nd_idx_z1y2x2, istride);
+    const auto idx_lz1y0x0 = device_4d_to_flat(nd_idx_z2y1x1, istride);
+    const auto idx_lz1y0x1 = device_4d_to_flat(nd_idx_z2y1x2, istride);
+    const auto idx_lz1y1x0 = device_4d_to_flat(nd_idx_z2y2x1, istride);
+    const auto idx_lz1y1x1 = device_4d_to_flat(nd_idx_z2y2x2, istride);
+
     for (; outer_size--; src += src_inner_size, dst += dst_inner_size) {
-#define _I(z, y, x) ((z)*ih * iw + (y)*iw + (x))
-      const T val0 = lx0 * src[_I(z1, y1, x1)];
-      const T val1 = lx1 * src[_I(z1, y1, x2)];
-      const T val2 = lx0 * src[_I(z1, y2, x1)];
-      const T val3 = lx1 * src[_I(z1, y2, x2)];
-      const T val4 = lx0 * src[_I(z2, y1, x1)];
-      const T val5 = lx1 * src[_I(z2, y1, x2)];
-      const T val6 = lx0 * src[_I(z2, y2, x1)];
-      const T val7 = lx1 * src[_I(z2, y2, x2)];
+      const T val0 = lx0 * src[idx_lz0y0x0];
+      const T val1 = lx1 * src[idx_lz0y0x1];
+      const T val2 = lx0 * src[idx_lz0y1x0];
+      const T val3 = lx1 * src[idx_lz0y1x1];
+      const T val4 = lx0 * src[idx_lz1y0x0];
+      const T val5 = lx1 * src[idx_lz1y0x1];
+      const T val6 = lx0 * src[idx_lz1y1x0];
+      const T val7 = lx1 * src[idx_lz1y1x1];
       const T val8 = ly0 * (val0 + val1) + ly1 * (val2 + val3);
       const T val9 = ly0 * (val4 + val5) + ly1 * (val6 + val7);
-#undef _I
-      dst[oz * oh * ow + oy * ow + ox] = lz0 * val8 + lz1 * val9;
+      dst[index] = lz0 * val8 + lz1 * val9;
     }
   }
 }
 
-template <typename T>
+template <typename T, bool channel_last = false>
 __global__ void kernel_linear_interpolate_1d_backward(
     const int g_y_inner_size, const T *g_y, const int g_x_inner_size, T *g_x,
-    int outer_size, const int iw, const int ow, const float sx,
-    const bool align_corners) {
+    int outer_size, const int ishape, const int istride, const int ostride,
+    const float sx, const bool align_corners) {
 
   NBLA_CUDA_KERNEL_LOOP(index, g_y_inner_size) {
-    const int ox = index % ow;
+    const auto nd_index = device_flat_to_2d(index, ostride);
+    const auto oc = channel_last ? nd_index.y : 0;
+    const auto ox = nd_index.x;
+
+    const auto iw = ishape;
 
     const auto fx = get_src_index(sx, ox, align_corners);
     const auto x1 = static_cast<int>(fx);
-    const auto x2 = (x1 < iw - 1) ? (x1 + 1) : x1;
+    const auto x2 = min(x1 + 1, iw - 1);
     const auto lx1 = static_cast<T>(fx - x1);
     const auto lx0 = static_cast<T>(1) - lx1;
 
+    const auto nd_idx_x1 = make_int2(x1, oc);
+    const auto nd_idx_x2 = make_int2(x2, oc);
+
+    const auto idx_lx1 = device_2d_to_flat(nd_idx_x1, istride);
+    const auto idx_lx2 = device_2d_to_flat(nd_idx_x2, istride);
+
     for (; outer_size--; g_x += g_x_inner_size, g_y += g_y_inner_size) {
-      atomic_add(g_x + x1, lx0 * g_y[ox]);
-      atomic_add(g_x + x2, lx1 * g_y[ox]);
+      const T g = g_y[index];
+      atomic_add(g_x + idx_lx1, lx0 * g);
+      atomic_add(g_x + idx_lx2, lx1 * g);
     }
   }
 }
 
-template <typename T>
+template <typename T, bool channel_last = false>
 __global__ void kernel_linear_interpolate_2d_backward(
     const int g_y_inner_size, const T *g_y, const int g_x_inner_size, T *g_x,
-    int outer_size, const int iw, const int ih, const int ow, const int oh,
+    int outer_size, const int2 ishape, const int2 istride, const int2 ostride,
     const float sx, const float sy, const bool align_corners) {
 
   NBLA_CUDA_KERNEL_LOOP(index, g_y_inner_size) {
-    const int oy = index / ow;
-    const int ox = index % ow;
+    const auto nd_index = device_flat_to_3d(index, ostride);
+    const auto oc = channel_last ? nd_index.z : 0;
+    const auto oy = nd_index.x;
+    const auto ox = nd_index.y;
+
+    const auto ih = ishape.x;
+    const auto iw = ishape.y;
 
     const auto fy = get_src_index(sy, oy, align_corners);
     const auto y1 = static_cast<int>(fy);
-    const auto y2 = (y1 < ih - 1) ? (y1 + 1) : y1;
+    const auto y2 = min(y1 + 1, ih - 1);
     const auto ly1 = static_cast<T>(fy - y1);
     const auto ly0 = static_cast<T>(1) - ly1;
 
     const auto fx = get_src_index(sx, ox, align_corners);
     const auto x1 = static_cast<int>(fx);
-    const auto x2 = (x1 < iw - 1) ? (x1 + 1) : x1;
+    const auto x2 = min(x1 + 1, iw - 1);
     const auto lx1 = static_cast<T>(fx - x1);
     const auto lx0 = static_cast<T>(1) - lx1;
 
+    const auto nd_idx_y1x1 = make_int3(y1, x1, oc);
+    const auto nd_idx_y1x2 = make_int3(y1, x2, oc);
+    const auto nd_idx_y2x1 = make_int3(y2, x1, oc);
+    const auto nd_idx_y2x2 = make_int3(y2, x2, oc);
+
+    const auto idx_ly0x0 = device_3d_to_flat(nd_idx_y1x1, istride);
+    const auto idx_ly0x1 = device_3d_to_flat(nd_idx_y1x2, istride);
+    const auto idx_ly1x0 = device_3d_to_flat(nd_idx_y2x1, istride);
+    const auto idx_ly1x1 = device_3d_to_flat(nd_idx_y2x2, istride);
     for (; outer_size--; g_x += g_x_inner_size, g_y += g_y_inner_size) {
-      const T g = g_y[oy * ow + ox];
-#define _I(y, x) ((y)*iw + (x))
-      atomic_add(g_x + _I(y1, x1), ly0 * lx0 * g);
-      atomic_add(g_x + _I(y1, x2), ly0 * lx1 * g);
-      atomic_add(g_x + _I(y2, x1), ly1 * lx0 * g);
-      atomic_add(g_x + _I(y2, x2), ly1 * lx1 * g);
-#undef _I
+      const T g = g_y[index];
+      atomic_add(g_x + idx_ly0x0, ly0 * lx0 * g);
+      atomic_add(g_x + idx_ly0x1, ly0 * lx1 * g);
+      atomic_add(g_x + idx_ly1x0, ly1 * lx0 * g);
+      atomic_add(g_x + idx_ly1x1, ly1 * lx1 * g);
     }
   }
 }
 
-template <typename T>
+template <typename T, bool channel_last = false>
 __global__ void kernel_linear_interpolate_3d_backward(
     const int g_y_inner_size, const T *g_y, const int g_x_inner_size, T *g_x,
-    int outer_size, const int iw, const int ih, const int id, const int ow,
-    const int oh, const int od, const float sx, const float sy, const float sz,
-    const bool align_corners) {
+    int outer_size, const int3 ishape, const int3 istride, const int3 ostride,
+    const float sx, const float sy, const float sz, const bool align_corners) {
 
   NBLA_CUDA_KERNEL_LOOP(index, g_y_inner_size) {
-    const int oz = index / (ow * oh);
-    const int oy = (index - oz * ow * oh) / ow;
-    const int ox = (index - oz * ow * oh) % ow;
+    const auto nd_index = device_flat_to_4d(index, ostride);
+    const auto oc = channel_last ? nd_index.w : 0;
+    const auto oz = nd_index.x;
+    const auto oy = nd_index.y;
+    const auto ox = nd_index.z;
+
+    const auto id = ishape.x;
+    const auto ih = ishape.y;
+    const auto iw = ishape.z;
 
     const auto fz = get_src_index(sz, oz, align_corners);
     const auto z1 = static_cast<int>(fz);
@@ -213,148 +285,197 @@ __global__ void kernel_linear_interpolate_3d_backward(
 
     const auto fy = get_src_index(sy, oy, align_corners);
     const auto y1 = static_cast<int>(fy);
-    const auto y2 = (y1 < ih - 1) ? (y1 + 1) : y1;
+    const auto y2 = min(y1 + 1, ih - 1);
     const auto ly1 = static_cast<T>(fy - y1);
     const auto ly0 = static_cast<T>(1) - ly1;
 
     const auto fx = get_src_index(sx, ox, align_corners);
     const auto x1 = static_cast<int>(fx);
-    const auto x2 = (x1 < iw - 1) ? (x1 + 1) : x1;
+    const auto x2 = min(x1 + 1, iw - 1);
     const auto lx1 = static_cast<T>(fx - x1);
     const auto lx0 = static_cast<T>(1) - lx1;
 
+    const auto nd_idx_z1y1x1 = make_int4(z1, y1, x1, oc);
+    const auto nd_idx_z1y1x2 = make_int4(z1, y1, x2, oc);
+    const auto nd_idx_z1y2x1 = make_int4(z1, y2, x1, oc);
+    const auto nd_idx_z1y2x2 = make_int4(z1, y2, x2, oc);
+    const auto nd_idx_z2y1x1 = make_int4(z2, y1, x1, oc);
+    const auto nd_idx_z2y1x2 = make_int4(z2, y1, x2, oc);
+    const auto nd_idx_z2y2x1 = make_int4(z2, y2, x1, oc);
+    const auto nd_idx_z2y2x2 = make_int4(z2, y2, x2, oc);
+
+    const auto idx_lz0y0x0 = device_4d_to_flat(nd_idx_z1y1x1, istride);
+    const auto idx_lz0y0x1 = device_4d_to_flat(nd_idx_z1y1x2, istride);
+    const auto idx_lz0y1x0 = device_4d_to_flat(nd_idx_z1y2x1, istride);
+    const auto idx_lz0y1x1 = device_4d_to_flat(nd_idx_z1y2x2, istride);
+    const auto idx_lz1y0x0 = device_4d_to_flat(nd_idx_z2y1x1, istride);
+    const auto idx_lz1y0x1 = device_4d_to_flat(nd_idx_z2y1x2, istride);
+    const auto idx_lz1y1x0 = device_4d_to_flat(nd_idx_z2y2x1, istride);
+    const auto idx_lz1y1x1 = device_4d_to_flat(nd_idx_z2y2x2, istride);
+
     for (; outer_size--; g_x += g_x_inner_size, g_y += g_y_inner_size) {
-      const T g = g_y[oz * oh * ow + oy * ow + ox];
-#define _I(z, y, x) ((z)*ih * iw + (y)*iw + (x))
-      atomic_add(g_x + _I(z1, y1, x1), lz0 * ly0 * lx0 * g);
-      atomic_add(g_x + _I(z1, y1, x2), lz0 * ly0 * lx1 * g);
-      atomic_add(g_x + _I(z1, y2, x1), lz0 * ly1 * lx0 * g);
-      atomic_add(g_x + _I(z1, y2, x2), lz0 * ly1 * lx1 * g);
-      atomic_add(g_x + _I(z2, y1, x1), lz1 * ly0 * lx0 * g);
-      atomic_add(g_x + _I(z2, y1, x2), lz1 * ly0 * lx1 * g);
-      atomic_add(g_x + _I(z2, y2, x1), lz1 * ly1 * lx0 * g);
-      atomic_add(g_x + _I(z2, y2, x2), lz1 * ly1 * lx1 * g);
-#undef _I
+      const T g = g_y[index];
+      atomic_add(g_x + idx_lz0y0x0, lz0 * ly0 * lx0 * g);
+      atomic_add(g_x + idx_lz0y0x1, lz0 * ly0 * lx1 * g);
+      atomic_add(g_x + idx_lz0y1x0, lz0 * ly1 * lx0 * g);
+      atomic_add(g_x + idx_lz0y1x1, lz0 * ly1 * lx1 * g);
+      atomic_add(g_x + idx_lz1y0x0, lz1 * ly0 * lx0 * g);
+      atomic_add(g_x + idx_lz1y0x1, lz1 * ly0 * lx1 * g);
+      atomic_add(g_x + idx_lz1y1x0, lz1 * ly1 * lx0 * g);
+      atomic_add(g_x + idx_lz1y1x1, lz1 * ly1 * lx1 * g);
     }
   }
 }
 
-template <typename T>
-__global__ void kernel_nearest_interpolate_1d(const int dst_inner_size, T *dst,
-                                              const int src_inner_size,
-                                              const T *src, int outer_size,
-                                              const int iw, const int ow,
-                                              const float sx) {
+template <typename T, bool channel_last = false>
+__global__ void kernel_nearest_interpolate_1d(
+    const int dst_inner_size, T *dst, const int src_inner_size, const T *src,
+    int outer_size, const int ishape, const int istride, const int ostride,
+    const float sx) {
 
   NBLA_CUDA_KERNEL_LOOP(index, dst_inner_size) {
-    const int ox = index % ow;
+    const auto nd_index = device_flat_to_2d(index, ostride);
+    const auto oc = channel_last ? nd_index.y : 0;
+    const auto ox = nd_index.x;
 
+    const auto iw = ishape;
     const auto ix = min(static_cast<int>(sx * (ox + 0.5f)), iw - 1);
 
+    const auto nd_idx_x = make_int2(ix, oc);
+    const auto idx_x = device_2d_to_flat(nd_idx_x, istride);
     for (; outer_size--; src += src_inner_size, dst += dst_inner_size) {
-      dst[ox] = src[ix];
+      dst[index] = src[idx_x];
     }
   }
 }
 
-template <typename T>
-__global__ void kernel_nearest_interpolate_2d(const int dst_inner_size, T *dst,
-                                              const int src_inner_size,
-                                              const T *src, int outer_size,
-                                              const int iw, const int ih,
-                                              const int ow, const int oh,
-                                              const float sx, const float sy) {
-
+template <typename T, bool channel_last = false>
+__global__ void kernel_nearest_interpolate_2d(
+    const int dst_inner_size, T *dst, const int src_inner_size, const T *src,
+    int outer_size, const int2 ishape, const int2 istride, const int2 ostride,
+    const float sx, const float sy) {
   NBLA_CUDA_KERNEL_LOOP(index, dst_inner_size) {
-    const int oy = index / ow;
-    const int ox = index % ow;
+    const auto nd_index = device_flat_to_3d(index, ostride);
+    const auto oc = channel_last ? nd_index.z : 0;
+    const auto oy = nd_index.x;
+    const auto ox = nd_index.y;
+
+    const auto ih = ishape.x;
+    const auto iw = ishape.y;
 
     const auto iy = min(static_cast<int>(sy * (oy + 0.5f)), ih - 1);
     const auto ix = min(static_cast<int>(sx * (ox + 0.5f)), iw - 1);
 
+    const auto nd_idx_yx = make_int3(iy, ix, oc);
+    const auto idx_yx = device_3d_to_flat(nd_idx_yx, istride);
     for (; outer_size--; src += src_inner_size, dst += dst_inner_size) {
-      dst[oy * ow + ox] = src[iy * iw + ix];
+      dst[index] = src[idx_yx];
     }
   }
 }
 
-template <typename T>
+template <typename T, bool channel_last = false>
 __global__ void kernel_nearest_interpolate_3d(
     const int dst_inner_size, T *dst, const int src_inner_size, const T *src,
-    int outer_size, const int iw, const int ih, const int id, const int ow,
-    const int oh, const int od, const float sx, const float sy,
-    const float sz) {
-
+    int outer_size, const int3 ishape, const int3 istride, const int3 ostride,
+    const float sx, const float sy, const float sz) {
   NBLA_CUDA_KERNEL_LOOP(index, dst_inner_size) {
-    const int oz = index / (ow * oh);
-    const int oy = (index - oz * ow * oh) / ow;
-    const int ox = (index - oz * ow * oh) % ow;
+    const auto nd_index = device_flat_to_4d(index, ostride);
+    const auto oc = channel_last ? nd_index.w : 0;
+    const auto oz = nd_index.x;
+    const auto oy = nd_index.y;
+    const auto ox = nd_index.z;
+
+    const auto id = ishape.x;
+    const auto ih = ishape.y;
+    const auto iw = ishape.z;
 
     const auto iz = min(static_cast<int>(sz * (oz + 0.5f)), id - 1);
     const auto iy = min(static_cast<int>(sy * (oy + 0.5f)), ih - 1);
     const auto ix = min(static_cast<int>(sx * (ox + 0.5f)), iw - 1);
 
+    const auto nd_idx_zyx = make_int4(iz, iy, ix, oc);
+    const auto idx_zyx = device_4d_to_flat(nd_idx_zyx, istride);
     for (; outer_size--; src += src_inner_size, dst += dst_inner_size) {
-      dst[oz * oh * ow + oy * ow + ox] = src[iz * ih * iw + iy * iw + ix];
+      dst[index] = src[idx_zyx];
     }
   }
 }
 
-template <typename T>
+template <typename T, bool channel_last = false>
 __global__ void kernel_nearest_interpolate_1d_backward(
     const int g_y_inner_size, const T *g_y, const int g_x_inner_size, T *g_x,
-    int outer_size, const int iw, const int ow, const float sx) {
+    int outer_size, const int ishape, const int istride, const int ostride,
+    const float sx) {
 
   NBLA_CUDA_KERNEL_LOOP(index, g_y_inner_size) {
-    const int ox = index % ow;
+    const auto nd_index = device_flat_to_2d(index, ostride);
+    const auto oc = channel_last ? nd_index.y : 0;
+    const auto ox = nd_index.x;
 
+    const auto iw = ishape;
     const auto ix = min(static_cast<int>(sx * (ox + 0.5f)), iw - 1);
 
+    const auto nd_idx_x = make_int2(ix, oc);
+    const auto idx_x = device_2d_to_flat(nd_idx_x, istride);
     for (; outer_size--; g_x += g_x_inner_size, g_y += g_y_inner_size) {
-      atomic_add(g_x + ix, g_y[ox]);
+      atomic_add(g_x + idx_x, g_y[index]);
     }
   }
 }
 
-template <typename T>
+template <typename T, bool channel_last = false>
 __global__ void kernel_nearest_interpolate_2d_backward(
     const int g_y_inner_size, const T *g_y, const int g_x_inner_size, T *g_x,
-    int outer_size, const int iw, const int ih, const int ow, const int oh,
+    int outer_size, const int2 ishape, const int2 istride, const int2 ostride,
     const float sx, const float sy) {
 
   NBLA_CUDA_KERNEL_LOOP(index, g_y_inner_size) {
-    const int oy = index / ow;
-    const int ox = index % ow;
+    const auto nd_index = device_flat_to_3d(index, ostride);
+    const auto oc = channel_last ? nd_index.z : 0;
+    const auto oy = nd_index.x;
+    const auto ox = nd_index.y;
+
+    const auto ih = ishape.x;
+    const auto iw = ishape.y;
 
     const auto iy = min(static_cast<int>(sy * (oy + 0.5f)), ih - 1);
     const auto ix = min(static_cast<int>(sx * (ox + 0.5f)), iw - 1);
 
+    const auto nd_idx_yx = make_int3(iy, ix, oc);
+    const auto idx_yx = device_3d_to_flat(nd_idx_yx, istride);
+
     for (; outer_size--; g_x += g_x_inner_size, g_y += g_y_inner_size) {
-      const T grad = g_y[oy * ow + ox];
-      atomic_add(g_x + iy * iw + ix, grad);
+      atomic_add(g_x + idx_yx, g_y[index]);
     }
   }
 }
 
-template <typename T>
+template <typename T, bool channel_last = false>
 __global__ void kernel_nearest_interpolate_3d_backward(
     const int g_y_inner_size, const T *g_y, const int g_x_inner_size, T *g_x,
-    int outer_size, const int iw, const int ih, const int id, const int ow,
-    const int oh, const int od, const float sx, const float sy,
-    const float sz) {
+    int outer_size, const int3 ishape, const int3 istride, const int3 ostride,
+    const float sx, const float sy, const float sz) {
 
   NBLA_CUDA_KERNEL_LOOP(index, g_y_inner_size) {
-    const int oz = index / (ow * oh);
-    const int oy = (index - oz * ow * oh) / ow;
-    const int ox = (index - oz * ow * oh) % ow;
+    const auto nd_index = device_flat_to_4d(index, ostride);
+    const auto oc = channel_last ? nd_index.w : 0;
+    const auto oz = nd_index.x;
+    const auto oy = nd_index.y;
+    const auto ox = nd_index.z;
+
+    const auto id = ishape.x;
+    const auto ih = ishape.y;
+    const auto iw = ishape.z;
 
     const auto iz = min(static_cast<int>(sz * (oz + 0.5f)), id - 1);
     const auto iy = min(static_cast<int>(sy * (oy + 0.5f)), ih - 1);
     const auto ix = min(static_cast<int>(sx * (ox + 0.5f)), iw - 1);
 
+    const auto nd_idx_zyx = make_int4(iz, iy, ix, oc);
+    const auto idx_zyx = device_4d_to_flat(nd_idx_zyx, istride);
     for (; outer_size--; g_x += g_x_inner_size, g_y += g_y_inner_size) {
-      const T grad = g_y[oz * oh * ow + oy * ow + ox];
-      atomic_add(g_x + iz * ih * iw + iy * iw + ix, grad);
+      atomic_add(g_x + idx_zyx, g_y[index]);
     }
   }
 }
@@ -370,72 +491,133 @@ void InterpolateCuda<T>::forward_impl(const Variables &inputs,
   const int ndim = inputs[0]->ndim();
 
   if (this->output_size_.size() == 1) {
-    const int iw = inputs[0]->shape()[ndim - 1];
-    const int ow = outputs[0]->shape()[ndim - 1];
-    const int src_inner_size = iw;
-    const int dst_inner_size = ow;
+    const int ic = this->channel_last_ ? inputs[0]->shape()[ndim - 1]
+                                       : inputs[0]->shape()[ndim - 2];
+    const int iw = this->channel_last_ ? inputs[0]->shape()[ndim - 2]
+                                       : inputs[0]->shape()[ndim - 1];
+    const int oc = this->channel_last_ ? outputs[0]->shape()[ndim - 1]
+                                       : outputs[0]->shape()[ndim - 2];
+    const int ow = this->channel_last_ ? outputs[0]->shape()[ndim - 2]
+                                       : outputs[0]->shape()[ndim - 1];
+
+    const int src_inner_size = this->channel_last_ ? ic * iw : iw;
+    const int dst_inner_size = this->channel_last_ ? oc * ow : ow;
     const int outer_size = inputs[0]->size() / src_inner_size;
+    const auto ishape = iw;
+    const auto istride = this->channel_last_ ? ic : 1;
+    const auto ostride = this->channel_last_ ? oc : 1;
     if (this->mode_ == "linear") {
       const float sx = compute_scale(iw, ow, this->align_corners_);
+      auto kernel = this->channel_last_
+                        ? kernel_linear_interpolate_1d<Tcu, true>
+                        : kernel_linear_interpolate_1d<Tcu, false>;
       NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
-          kernel_linear_interpolate_1d, dst_inner_size, dst, src_inner_size,
-          src, outer_size, iw, ow, sx, this->align_corners_);
+          kernel, dst_inner_size, dst, src_inner_size, src, outer_size, ishape,
+          istride, ostride, sx, this->align_corners_);
     } else if (this->mode_ == "nearest") {
       const float sx = iw / static_cast<float>(ow);
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_nearest_interpolate_1d,
-                                     dst_inner_size, dst, src_inner_size, src,
-                                     outer_size, iw, ow, sx);
+      auto kernel = this->channel_last_
+                        ? kernel_nearest_interpolate_1d<Tcu, true>
+                        : kernel_nearest_interpolate_1d<Tcu, false>;
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, dst_inner_size, dst,
+                                     src_inner_size, src, outer_size, ishape,
+                                     istride, ostride, sx);
     }
   }
 
   else if (this->output_size_.size() == 2) {
-    const int iw = inputs[0]->shape()[ndim - 1];
-    const int ih = inputs[0]->shape()[ndim - 2];
-    const int ow = outputs[0]->shape()[ndim - 1];
-    const int oh = outputs[0]->shape()[ndim - 2];
-    const int src_inner_size = iw * ih;
-    const int dst_inner_size = ow * oh;
+    const int ic = this->channel_last_ ? inputs[0]->shape()[ndim - 1]
+                                       : inputs[0]->shape()[ndim - 3];
+    const int ih = this->channel_last_ ? inputs[0]->shape()[ndim - 3]
+                                       : inputs[0]->shape()[ndim - 2];
+    const int iw = this->channel_last_ ? inputs[0]->shape()[ndim - 2]
+                                       : inputs[0]->shape()[ndim - 1];
+    const int oc = this->channel_last_ ? outputs[0]->shape()[ndim - 1]
+                                       : outputs[0]->shape()[ndim - 3];
+    const int oh = this->channel_last_ ? outputs[0]->shape()[ndim - 3]
+                                       : outputs[0]->shape()[ndim - 2];
+    const int ow = this->channel_last_ ? outputs[0]->shape()[ndim - 2]
+                                       : outputs[0]->shape()[ndim - 1];
+
+    const int src_inner_size = this->channel_last_ ? ic * iw * ih : iw * ih;
+    const int dst_inner_size = this->channel_last_ ? oc * ow * oh : ow * oh;
     const int outer_size = inputs[0]->size() / src_inner_size;
+    const auto ishape = make_int2(ih, iw);
+    const auto istride =
+        this->channel_last_ ? make_int2(iw * ic, ic) : make_int2(iw, 1);
+    const auto ostride =
+        this->channel_last_ ? make_int2(ow * oc, oc) : make_int2(ow, 1);
     if (this->mode_ == "linear") {
       const float sx = compute_scale(iw, ow, this->align_corners_);
       const float sy = compute_scale(ih, oh, this->align_corners_);
+      auto kernel = this->channel_last_
+                        ? kernel_linear_interpolate_2d<Tcu, true>
+                        : kernel_linear_interpolate_2d<Tcu, false>;
       NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
-          kernel_linear_interpolate_2d, dst_inner_size, dst, src_inner_size,
-          src, outer_size, iw, ih, ow, oh, sx, sy, this->align_corners_);
+          kernel, dst_inner_size, dst, src_inner_size, src, outer_size, ishape,
+          istride, ostride, sx, sy, this->align_corners_);
     } else if (this->mode_ == "nearest") {
       const float sx = iw / static_cast<float>(ow);
       const float sy = ih / static_cast<float>(oh);
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_nearest_interpolate_2d,
-                                     dst_inner_size, dst, src_inner_size, src,
-                                     outer_size, iw, ih, ow, oh, sx, sy);
+      auto kernel = this->channel_last_
+                        ? kernel_nearest_interpolate_2d<Tcu, true>
+                        : kernel_nearest_interpolate_2d<Tcu, false>;
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, dst_inner_size, dst,
+                                     src_inner_size, src, outer_size, ishape,
+                                     istride, ostride, sx, sy);
     }
   }
 
   else if (this->output_size_.size() == 3) {
-    const int iw = inputs[0]->shape()[ndim - 1];
-    const int ih = inputs[0]->shape()[ndim - 2];
-    const int id = inputs[0]->shape()[ndim - 3];
-    const int ow = outputs[0]->shape()[ndim - 1];
-    const int oh = outputs[0]->shape()[ndim - 2];
-    const int od = outputs[0]->shape()[ndim - 3];
-    const int src_inner_size = iw * ih * id;
-    const int dst_inner_size = ow * oh * od;
+    const int ic = this->channel_last_ ? inputs[0]->shape()[ndim - 1]
+                                       : inputs[0]->shape()[ndim - 4];
+    const int id = this->channel_last_ ? inputs[0]->shape()[ndim - 4]
+                                       : inputs[0]->shape()[ndim - 3];
+    const int ih = this->channel_last_ ? inputs[0]->shape()[ndim - 3]
+                                       : inputs[0]->shape()[ndim - 2];
+    const int iw = this->channel_last_ ? inputs[0]->shape()[ndim - 2]
+                                       : inputs[0]->shape()[ndim - 1];
+    const int oc = this->channel_last_ ? outputs[0]->shape()[ndim - 1]
+                                       : outputs[0]->shape()[ndim - 4];
+    const int od = this->channel_last_ ? outputs[0]->shape()[ndim - 4]
+                                       : outputs[0]->shape()[ndim - 3];
+    const int oh = this->channel_last_ ? outputs[0]->shape()[ndim - 3]
+                                       : outputs[0]->shape()[ndim - 2];
+    const int ow = this->channel_last_ ? outputs[0]->shape()[ndim - 2]
+                                       : outputs[0]->shape()[ndim - 1];
+
+    const int src_inner_size =
+        this->channel_last_ ? ic * iw * ih * id : iw * ih * id;
+    const int dst_inner_size =
+        this->channel_last_ ? oc * ow * oh * od : ow * oh * od;
     const int outer_size = inputs[0]->size() / src_inner_size;
+    const auto ishape = make_int3(id, ih, iw);
+    const auto istride = this->channel_last_
+                             ? make_int3(ih * iw * ic, iw * ic, ic)
+                             : make_int3(ih * iw, iw, 1);
+    const auto ostride = this->channel_last_
+                             ? make_int3(oh * ow * oc, ow * oc, oc)
+                             : make_int3(oh * ow, ow, 1);
     if (this->mode_ == "linear") {
       const float sx = compute_scale(iw, ow, this->align_corners_);
       const float sy = compute_scale(ih, oh, this->align_corners_);
       const float sz = compute_scale(id, od, this->align_corners_);
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_linear_interpolate_3d,
-                                     dst_inner_size, dst, src_inner_size, src,
-                                     outer_size, iw, ih, id, ow, oh, od, sx, sy,
-                                     sz, this->align_corners_);
+      auto kernel = this->channel_last_
+                        ? kernel_linear_interpolate_3d<Tcu, true>
+                        : kernel_linear_interpolate_3d<Tcu, false>;
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+          kernel, dst_inner_size, dst, src_inner_size, src, outer_size, ishape,
+          istride, ostride, sx, sy, sz, this->align_corners_);
     } else if (this->mode_ == "nearest") {
       const float sx = iw / static_cast<float>(ow);
       const float sy = ih / static_cast<float>(oh);
       const float sz = id / static_cast<float>(od);
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
-          kernel_nearest_interpolate_3d, dst_inner_size, dst, src_inner_size,
-          src, outer_size, iw, ih, id, ow, oh, od, sx, sy, sz);
+      auto kernel = this->channel_last_
+                        ? kernel_nearest_interpolate_3d<Tcu, true>
+                        : kernel_nearest_interpolate_3d<Tcu, false>;
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, dst_inner_size, dst,
+                                     src_inner_size, src, outer_size, ishape,
+                                     istride, ostride, sx, sy, sz);
     }
   }
 }
@@ -456,73 +638,132 @@ void InterpolateCuda<T>::backward_impl(const Variables &inputs,
   const int ndim = inputs[0]->ndim();
 
   if (this->output_size_.size() == 1) {
-    const int iw = inputs[0]->shape()[ndim - 1];
-    const int ow = outputs[0]->shape()[ndim - 1];
-    const int g_x_inner_size = iw;
-    const int g_y_inner_size = ow;
+    const int ic = this->channel_last_ ? inputs[0]->shape()[ndim - 1]
+                                       : inputs[0]->shape()[ndim - 2];
+    const int iw = this->channel_last_ ? inputs[0]->shape()[ndim - 2]
+                                       : inputs[0]->shape()[ndim - 1];
+    const int oc = this->channel_last_ ? outputs[0]->shape()[ndim - 1]
+                                       : outputs[0]->shape()[ndim - 2];
+    const int ow = this->channel_last_ ? outputs[0]->shape()[ndim - 2]
+                                       : outputs[0]->shape()[ndim - 1];
+
+    const int g_x_inner_size = this->channel_last_ ? ic * iw : iw;
+    const int g_y_inner_size = this->channel_last_ ? oc * ow : ow;
     const int outer_size = inputs[0]->size() / g_x_inner_size;
+    const auto ishape = iw;
+    const auto istride = this->channel_last_ ? ic : 1;
+    const auto ostride = this->channel_last_ ? oc : 1;
     if (this->mode_ == "linear") {
       const float sx = compute_scale(iw, ow, this->align_corners_);
+      auto kernel = this->channel_last_
+                        ? kernel_linear_interpolate_1d_backward<Tcu, true>
+                        : kernel_linear_interpolate_1d_backward<Tcu, false>;
       NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
-          kernel_linear_interpolate_1d_backward, g_y_inner_size, g_y,
-          g_x_inner_size, g_x, outer_size, iw, ow, sx, this->align_corners_);
+          kernel, g_y_inner_size, g_y, g_x_inner_size, g_x, outer_size, ishape,
+          istride, ostride, sx, this->align_corners_);
     } else if (this->mode_ == "nearest") {
       const float sx = iw / static_cast<float>(ow);
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_nearest_interpolate_1d_backward,
-                                     g_y_inner_size, g_y, g_x_inner_size, g_x,
-                                     outer_size, iw, ow, sx);
+      auto kernel = this->channel_last_
+                        ? kernel_nearest_interpolate_1d_backward<Tcu, true>
+                        : kernel_nearest_interpolate_1d_backward<Tcu, false>;
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, g_y_inner_size, g_y,
+                                     g_x_inner_size, g_x, outer_size, ishape,
+                                     istride, ostride, sx);
     }
   }
 
   else if (this->output_size_.size() == 2) {
-    const int iw = inputs[0]->shape()[ndim - 1];
-    const int ih = inputs[0]->shape()[ndim - 2];
-    const int ow = outputs[0]->shape()[ndim - 1];
-    const int oh = outputs[0]->shape()[ndim - 2];
-    const int g_x_inner_size = iw * ih;
-    const int g_y_inner_size = ow * oh;
+    const int ic = this->channel_last_ ? inputs[0]->shape()[ndim - 1]
+                                       : inputs[0]->shape()[ndim - 3];
+    const int ih = this->channel_last_ ? inputs[0]->shape()[ndim - 3]
+                                       : inputs[0]->shape()[ndim - 2];
+    const int iw = this->channel_last_ ? inputs[0]->shape()[ndim - 2]
+                                       : inputs[0]->shape()[ndim - 1];
+    const int oc = this->channel_last_ ? outputs[0]->shape()[ndim - 1]
+                                       : outputs[0]->shape()[ndim - 3];
+    const int oh = this->channel_last_ ? outputs[0]->shape()[ndim - 3]
+                                       : outputs[0]->shape()[ndim - 2];
+    const int ow = this->channel_last_ ? outputs[0]->shape()[ndim - 2]
+                                       : outputs[0]->shape()[ndim - 1];
+    const int g_x_inner_size = this->channel_last_ ? ic * iw * ih : iw * ih;
+    const int g_y_inner_size = this->channel_last_ ? oc * ow * oh : ow * oh;
     const int outer_size = inputs[0]->size() / g_x_inner_size;
+    const auto ishape = make_int2(ih, iw);
+    const auto istride =
+        this->channel_last_ ? make_int2(iw * ic, ic) : make_int2(iw, 1);
+    const auto ostride =
+        this->channel_last_ ? make_int2(ow * oc, oc) : make_int2(ow, 1);
     if (this->mode_ == "linear") {
       const float sx = compute_scale(iw, ow, this->align_corners_);
       const float sy = compute_scale(ih, oh, this->align_corners_);
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_linear_interpolate_2d_backward,
-                                     g_y_inner_size, g_y, g_x_inner_size, g_x,
-                                     outer_size, iw, ih, ow, oh, sx, sy,
-                                     this->align_corners_);
+      auto kernel = this->channel_last_
+                        ? kernel_linear_interpolate_2d_backward<Tcu, true>
+                        : kernel_linear_interpolate_2d_backward<Tcu, false>;
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+          kernel, g_y_inner_size, g_y, g_x_inner_size, g_x, outer_size, ishape,
+          istride, ostride, sx, sy, this->align_corners_);
     } else if (this->mode_ == "nearest") {
       const float sx = iw / static_cast<float>(ow);
       const float sy = ih / static_cast<float>(oh);
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_nearest_interpolate_2d_backward,
-                                     g_y_inner_size, g_y, g_x_inner_size, g_x,
-                                     outer_size, iw, ih, ow, oh, sx, sy);
+      auto kernel = this->channel_last_
+                        ? kernel_nearest_interpolate_2d_backward<Tcu, true>
+                        : kernel_nearest_interpolate_2d_backward<Tcu, false>;
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, g_y_inner_size, g_y,
+                                     g_x_inner_size, g_x, outer_size, ishape,
+                                     istride, ostride, sx, sy);
     }
   }
 
   else if (this->output_size_.size() == 3) {
-    const int iw = inputs[0]->shape()[ndim - 1];
-    const int ih = inputs[0]->shape()[ndim - 2];
-    const int id = inputs[0]->shape()[ndim - 3];
-    const int ow = outputs[0]->shape()[ndim - 1];
-    const int oh = outputs[0]->shape()[ndim - 2];
-    const int od = outputs[0]->shape()[ndim - 3];
-    const int g_x_inner_size = iw * ih * id;
-    const int g_y_inner_size = ow * oh * od;
+    const int ic = this->channel_last_ ? inputs[0]->shape()[ndim - 1]
+                                       : inputs[0]->shape()[ndim - 4];
+    const int id = this->channel_last_ ? inputs[0]->shape()[ndim - 4]
+                                       : inputs[0]->shape()[ndim - 3];
+    const int ih = this->channel_last_ ? inputs[0]->shape()[ndim - 3]
+                                       : inputs[0]->shape()[ndim - 2];
+    const int iw = this->channel_last_ ? inputs[0]->shape()[ndim - 2]
+                                       : inputs[0]->shape()[ndim - 1];
+    const int oc = this->channel_last_ ? outputs[0]->shape()[ndim - 1]
+                                       : outputs[0]->shape()[ndim - 4];
+    const int od = this->channel_last_ ? outputs[0]->shape()[ndim - 4]
+                                       : outputs[0]->shape()[ndim - 3];
+    const int oh = this->channel_last_ ? outputs[0]->shape()[ndim - 3]
+                                       : outputs[0]->shape()[ndim - 2];
+    const int ow = this->channel_last_ ? outputs[0]->shape()[ndim - 2]
+                                       : outputs[0]->shape()[ndim - 1];
+
+    const int g_x_inner_size =
+        this->channel_last_ ? ic * iw * ih * id : iw * ih * id;
+    const int g_y_inner_size =
+        this->channel_last_ ? oc * ow * oh * od : ow * oh * od;
     const int outer_size = inputs[0]->size() / g_x_inner_size;
+    const auto ishape = make_int3(id, ih, iw);
+    const auto istride = this->channel_last_
+                             ? make_int3(ih * iw * ic, iw * ic, ic)
+                             : make_int3(ih * iw, iw, 1);
+    const auto ostride = this->channel_last_
+                             ? make_int3(oh * ow * oc, ow * oc, oc)
+                             : make_int3(oh * ow, ow, 1);
     if (this->mode_ == "linear") {
       const float sx = compute_scale(iw, ow, this->align_corners_);
       const float sy = compute_scale(ih, oh, this->align_corners_);
       const float sz = compute_scale(id, od, this->align_corners_);
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_linear_interpolate_3d_backward,
-                                     g_y_inner_size, g_y, g_x_inner_size, g_x,
-                                     outer_size, iw, ih, id, ow, oh, od, sx, sy,
-                                     sz, this->align_corners_);
+      auto kernel = this->channel_last_
+                        ? kernel_linear_interpolate_3d_backward<Tcu, true>
+                        : kernel_linear_interpolate_3d_backward<Tcu, false>;
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+          kernel, g_y_inner_size, g_y, g_x_inner_size, g_x, outer_size, ishape,
+          istride, ostride, sx, sy, sz, this->align_corners_);
     } else if (this->mode_ == "nearest") {
       const float sx = iw / static_cast<float>(ow);
       const float sy = ih / static_cast<float>(oh);
       const float sz = id / static_cast<float>(od);
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
-          kernel_nearest_interpolate_3d_backward, g_y_inner_size, g_y,
-          g_x_inner_size, g_x, outer_size, iw, ih, id, ow, oh, od, sx, sy, sz);
+      auto kernel = this->channel_last_
+                        ? kernel_nearest_interpolate_3d_backward<Tcu, true>
+                        : kernel_nearest_interpolate_3d_backward<Tcu, false>;
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, g_y_inner_size, g_y,
+                                     g_x_inner_size, g_x, outer_size, ishape,
+                                     istride, ostride, sx, sy, sz);
     }
   }
 }


### PR DESCRIPTION
Double backward (aka grad of grad) supports the following functions with the channel last tensor format and the half data type for utilizing NVIDIA TensorCore: 
- Convolution
- Deconvolution
- MaxPooling
- AveragePooling
- SumPooling
- Interpolate (linear and nearest)