### PR TITLE
Interpolation with half_pixel and half_pixel_for_nn

### DIFF
--- a/include/nbla/cuda/function/interpolate.hpp
+++ b/include/nbla/cuda/function/interpolate.hpp
@@ -26,8 +26,10 @@ public:
 
   explicit InterpolateCuda(const Context &ctx, const vector<int> &output_size,
                            const string &mode, bool align_corners,
+                           bool half_pixel, bool half_pixel_for_nn,
                            bool channel_last)
-      : Interpolate<T>(ctx, output_size, mode, align_corners, channel_last),
+      : Interpolate<T>(ctx, output_size, mode, align_corners, half_pixel,
+                       half_pixel_for_nn, channel_last),
         device_(std::stoi(ctx.device_id)) {}
   virtual ~InterpolateCuda() {}
   virtual string name() { return "InterpolateCuda"; }

--- a/src/nbla/cuda/function/generic/interpolate.cu
+++ b/src/nbla/cuda/function/generic/interpolate.cu
@@ -26,17 +26,31 @@ inline float compute_scale(int isize, int osize, bool align_corners) {
                                               : float(isize) / osize);
 }
 
+inline float compute_scale_for_nn(int isize, int osize, bool align_corners,
+                                  bool half_pixel_for_nn) {
+  return half_pixel_for_nn ? isize / static_cast<float>(osize)
+                           : compute_scale(isize, osize, align_corners);
+}
+
 __device__ __forceinline__ float get_src_index(float scale, int dst_index,
-                                               bool align_corners) {
-  return align_corners ? scale * dst_index
-                       : fmaxf(0.0f, scale * (float(dst_index) + 0.5f) - 0.5f);
+                                               bool half_pixel) {
+  return half_pixel ? fmaxf(0.0f, scale * (float(dst_index) + 0.5f) - 0.5f)
+                    : scale * dst_index;
+}
+
+__device__ __forceinline__ float get_src_index_for_nn(float scale,
+                                                      int dst_index,
+                                                      bool half_pixel,
+                                                      bool half_pixel_for_nn) {
+  return half_pixel_for_nn ? scale * (dst_index + 0.5f)
+                           : get_src_index(scale, dst_index, half_pixel);
 }
 
 template <typename T, bool channel_last = false>
 __global__ void kernel_linear_interpolate_1d(
     const int dst_inner_size, T *dst, const int src_inner_size, const T *src,
     int outer_size, const int ishape, const int istride, const int ostride,
-    const float sx, const bool align_corners) {
+    const float sx, const bool half_pixel) {
 
   NBLA_CUDA_KERNEL_LOOP(index, dst_inner_size) {
     const auto nd_index = device_flat_to_2d(index, ostride);
@@ -45,7 +59,7 @@ __global__ void kernel_linear_interpolate_1d(
 
     const auto iw = ishape;
 
-    const auto fx = get_src_index(sx, ox, align_corners);
+    const auto fx = get_src_index(sx, ox, half_pixel);
     const auto x1 = static_cast<int>(fx);
     const auto x2 = min(x1 + 1, iw - 1);
     const auto lx1 = static_cast<T>(fx - x1);
@@ -69,7 +83,7 @@ template <typename T, bool channel_last = false>
 __global__ void kernel_linear_interpolate_2d(
     const int dst_inner_size, T *dst, const int src_inner_size, const T *src,
     int outer_size, const int2 ishape, const int2 istride, const int2 ostride,
-    const float sx, const float sy, const bool align_corners) {
+    const float sx, const float sy, const bool half_pixel) {
 
   NBLA_CUDA_KERNEL_LOOP(index, dst_inner_size) {
     const auto nd_index = device_flat_to_3d(index, ostride);
@@ -80,13 +94,13 @@ __global__ void kernel_linear_interpolate_2d(
     const auto ih = ishape.x;
     const auto iw = ishape.y;
 
-    const auto fy = get_src_index(sy, oy, align_corners);
+    const auto fy = get_src_index(sy, oy, half_pixel);
     const auto y1 = static_cast<int>(fy);
     const auto y2 = min(y1 + 1, ih - 1);
     const auto ly1 = static_cast<T>(fy - y1);
     const auto ly0 = static_cast<T>(1) - ly1;
 
-    const auto fx = get_src_index(sx, ox, align_corners);
+    const auto fx = get_src_index(sx, ox, half_pixel);
     const auto x1 = static_cast<int>(fx);
     const auto x2 = min(x1 + 1, iw - 1);
     const auto lx1 = static_cast<T>(fx - x1);
@@ -116,7 +130,7 @@ template <typename T, bool channel_last = false>
 __global__ void kernel_linear_interpolate_3d(
     const int dst_inner_size, T *dst, const int src_inner_size, const T *src,
     int outer_size, const int3 ishape, const int3 istride, const int3 ostride,
-    const float sx, const float sy, const float sz, const bool align_corners) {
+    const float sx, const float sy, const float sz, const bool half_pixel) {
 
   NBLA_CUDA_KERNEL_LOOP(index, dst_inner_size) {
     const auto nd_index = device_flat_to_4d(index, ostride);
@@ -129,19 +143,19 @@ __global__ void kernel_linear_interpolate_3d(
     const auto ih = ishape.y;
     const auto iw = ishape.z;
 
-    const auto fz = get_src_index(sz, oz, align_corners);
+    const auto fz = get_src_index(sz, oz, half_pixel);
     const auto z1 = static_cast<int>(fz);
     const auto z2 = min(z1 + 1, id - 1);
     const auto lz1 = static_cast<T>(fz - z1);
     const auto lz0 = static_cast<T>(1) - lz1;
 
-    const auto fy = get_src_index(sy, oy, align_corners);
+    const auto fy = get_src_index(sy, oy, half_pixel);
     const auto y1 = static_cast<int>(fy);
     const auto y2 = min(y1 + 1, ih - 1);
     const auto ly1 = static_cast<T>(fy - y1);
     const auto ly0 = static_cast<T>(1) - ly1;
 
-    const auto fx = get_src_index(sx, ox, align_corners);
+    const auto fx = get_src_index(sx, ox, half_pixel);
     const auto x1 = static_cast<int>(fx);
     const auto x2 = min(x1 + 1, iw - 1);
     const auto lx1 = static_cast<T>(fx - x1);
@@ -185,7 +199,7 @@ template <typename T, bool channel_last = false>
 __global__ void kernel_linear_interpolate_1d_backward(
     const int g_y_inner_size, const T *g_y, const int g_x_inner_size, T *g_x,
     int outer_size, const int ishape, const int istride, const int ostride,
-    const float sx, const bool align_corners) {
+    const float sx, const bool half_pixel) {
 
   NBLA_CUDA_KERNEL_LOOP(index, g_y_inner_size) {
     const auto nd_index = device_flat_to_2d(index, ostride);
@@ -194,7 +208,7 @@ __global__ void kernel_linear_interpolate_1d_backward(
 
     const auto iw = ishape;
 
-    const auto fx = get_src_index(sx, ox, align_corners);
+    const auto fx = get_src_index(sx, ox, half_pixel);
     const auto x1 = static_cast<int>(fx);
     const auto x2 = min(x1 + 1, iw - 1);
     const auto lx1 = static_cast<T>(fx - x1);
@@ -218,7 +232,7 @@ template <typename T, bool channel_last = false>
 __global__ void kernel_linear_interpolate_2d_backward(
     const int g_y_inner_size, const T *g_y, const int g_x_inner_size, T *g_x,
     int outer_size, const int2 ishape, const int2 istride, const int2 ostride,
-    const float sx, const float sy, const bool align_corners) {
+    const float sx, const float sy, const bool half_pixel) {
 
   NBLA_CUDA_KERNEL_LOOP(index, g_y_inner_size) {
     const auto nd_index = device_flat_to_3d(index, ostride);
@@ -229,13 +243,13 @@ __global__ void kernel_linear_interpolate_2d_backward(
     const auto ih = ishape.x;
     const auto iw = ishape.y;
 
-    const auto fy = get_src_index(sy, oy, align_corners);
+    const auto fy = get_src_index(sy, oy, half_pixel);
     const auto y1 = static_cast<int>(fy);
     const auto y2 = min(y1 + 1, ih - 1);
     const auto ly1 = static_cast<T>(fy - y1);
     const auto ly0 = static_cast<T>(1) - ly1;
 
-    const auto fx = get_src_index(sx, ox, align_corners);
+    const auto fx = get_src_index(sx, ox, half_pixel);
     const auto x1 = static_cast<int>(fx);
     const auto x2 = min(x1 + 1, iw - 1);
     const auto lx1 = static_cast<T>(fx - x1);
@@ -264,7 +278,7 @@ template <typename T, bool channel_last = false>
 __global__ void kernel_linear_interpolate_3d_backward(
     const int g_y_inner_size, const T *g_y, const int g_x_inner_size, T *g_x,
     int outer_size, const int3 ishape, const int3 istride, const int3 ostride,
-    const float sx, const float sy, const float sz, const bool align_corners) {
+    const float sx, const float sy, const float sz, const bool half_pixel) {
 
   NBLA_CUDA_KERNEL_LOOP(index, g_y_inner_size) {
     const auto nd_index = device_flat_to_4d(index, ostride);
@@ -277,19 +291,19 @@ __global__ void kernel_linear_interpolate_3d_backward(
     const auto ih = ishape.y;
     const auto iw = ishape.z;
 
-    const auto fz = get_src_index(sz, oz, align_corners);
+    const auto fz = get_src_index(sz, oz, half_pixel);
     const auto z1 = static_cast<int>(fz);
     const auto z2 = min(z1 + 1, id - 1);
     const auto lz1 = static_cast<T>(fz - z1);
     const auto lz0 = static_cast<T>(1) - lz1;
 
-    const auto fy = get_src_index(sy, oy, align_corners);
+    const auto fy = get_src_index(sy, oy, half_pixel);
     const auto y1 = static_cast<int>(fy);
     const auto y2 = min(y1 + 1, ih - 1);
     const auto ly1 = static_cast<T>(fy - y1);
     const auto ly0 = static_cast<T>(1) - ly1;
 
-    const auto fx = get_src_index(sx, ox, align_corners);
+    const auto fx = get_src_index(sx, ox, half_pixel);
     const auto x1 = static_cast<int>(fx);
     const auto x2 = min(x1 + 1, iw - 1);
     const auto lx1 = static_cast<T>(fx - x1);
@@ -331,7 +345,7 @@ template <typename T, bool channel_last = false>
 __global__ void kernel_nearest_interpolate_1d(
     const int dst_inner_size, T *dst, const int src_inner_size, const T *src,
     int outer_size, const int ishape, const int istride, const int ostride,
-    const float sx) {
+    const float sx, const bool half_pixel, const bool half_pixel_for_nn) {
 
   NBLA_CUDA_KERNEL_LOOP(index, dst_inner_size) {
     const auto nd_index = device_flat_to_2d(index, ostride);
@@ -339,7 +353,8 @@ __global__ void kernel_nearest_interpolate_1d(
     const auto ox = nd_index.x;
 
     const auto iw = ishape;
-    const auto ix = min(static_cast<int>(sx * (ox + 0.5f)), iw - 1);
+    const auto fx = get_src_index_for_nn(sx, ox, half_pixel, half_pixel_for_nn);
+    const auto ix = min(static_cast<int>(fx), iw - 1);
 
     const auto nd_idx_x = make_int2(ix, oc);
     const auto idx_x = device_2d_to_flat(nd_idx_x, istride);
@@ -353,7 +368,8 @@ template <typename T, bool channel_last = false>
 __global__ void kernel_nearest_interpolate_2d(
     const int dst_inner_size, T *dst, const int src_inner_size, const T *src,
     int outer_size, const int2 ishape, const int2 istride, const int2 ostride,
-    const float sx, const float sy) {
+    const float sx, const float sy, const bool half_pixel,
+    const bool half_pixel_for_nn) {
   NBLA_CUDA_KERNEL_LOOP(index, dst_inner_size) {
     const auto nd_index = device_flat_to_3d(index, ostride);
     const auto oc = channel_last ? nd_index.z : 0;
@@ -363,8 +379,10 @@ __global__ void kernel_nearest_interpolate_2d(
     const auto ih = ishape.x;
     const auto iw = ishape.y;
 
-    const auto iy = min(static_cast<int>(sy * (oy + 0.5f)), ih - 1);
-    const auto ix = min(static_cast<int>(sx * (ox + 0.5f)), iw - 1);
+    const auto fy = get_src_index_for_nn(sy, oy, half_pixel, half_pixel_for_nn);
+    const auto fx = get_src_index_for_nn(sx, ox, half_pixel, half_pixel_for_nn);
+    const auto iy = min(static_cast<int>(fy), ih - 1);
+    const auto ix = min(static_cast<int>(fx), iw - 1);
 
     const auto nd_idx_yx = make_int3(iy, ix, oc);
     const auto idx_yx = device_3d_to_flat(nd_idx_yx, istride);
@@ -378,7 +396,8 @@ template <typename T, bool channel_last = false>
 __global__ void kernel_nearest_interpolate_3d(
     const int dst_inner_size, T *dst, const int src_inner_size, const T *src,
     int outer_size, const int3 ishape, const int3 istride, const int3 ostride,
-    const float sx, const float sy, const float sz) {
+    const float sx, const float sy, const float sz, const bool half_pixel,
+    const bool half_pixel_for_nn) {
   NBLA_CUDA_KERNEL_LOOP(index, dst_inner_size) {
     const auto nd_index = device_flat_to_4d(index, ostride);
     const auto oc = channel_last ? nd_index.w : 0;
@@ -390,9 +409,12 @@ __global__ void kernel_nearest_interpolate_3d(
     const auto ih = ishape.y;
     const auto iw = ishape.z;
 
-    const auto iz = min(static_cast<int>(sz * (oz + 0.5f)), id - 1);
-    const auto iy = min(static_cast<int>(sy * (oy + 0.5f)), ih - 1);
-    const auto ix = min(static_cast<int>(sx * (ox + 0.5f)), iw - 1);
+    const auto fz = get_src_index_for_nn(sz, oz, half_pixel, half_pixel_for_nn);
+    const auto fy = get_src_index_for_nn(sy, oy, half_pixel, half_pixel_for_nn);
+    const auto fx = get_src_index_for_nn(sx, ox, half_pixel, half_pixel_for_nn);
+    const auto iz = min(static_cast<int>(fz), id - 1);
+    const auto iy = min(static_cast<int>(fy), ih - 1);
+    const auto ix = min(static_cast<int>(fx), iw - 1);
 
     const auto nd_idx_zyx = make_int4(iz, iy, ix, oc);
     const auto idx_zyx = device_4d_to_flat(nd_idx_zyx, istride);
@@ -406,7 +428,7 @@ template <typename T, bool channel_last = false>
 __global__ void kernel_nearest_interpolate_1d_backward(
     const int g_y_inner_size, const T *g_y, const int g_x_inner_size, T *g_x,
     int outer_size, const int ishape, const int istride, const int ostride,
-    const float sx) {
+    const float sx, const bool half_pixel, const bool half_pixel_for_nn) {
 
   NBLA_CUDA_KERNEL_LOOP(index, g_y_inner_size) {
     const auto nd_index = device_flat_to_2d(index, ostride);
@@ -414,7 +436,8 @@ __global__ void kernel_nearest_interpolate_1d_backward(
     const auto ox = nd_index.x;
 
     const auto iw = ishape;
-    const auto ix = min(static_cast<int>(sx * (ox + 0.5f)), iw - 1);
+    const auto fx = get_src_index_for_nn(sx, ox, half_pixel, half_pixel_for_nn);
+    const auto ix = min(static_cast<int>(fx), iw - 1);
 
     const auto nd_idx_x = make_int2(ix, oc);
     const auto idx_x = device_2d_to_flat(nd_idx_x, istride);
@@ -428,7 +451,8 @@ template <typename T, bool channel_last = false>
 __global__ void kernel_nearest_interpolate_2d_backward(
     const int g_y_inner_size, const T *g_y, const int g_x_inner_size, T *g_x,
     int outer_size, const int2 ishape, const int2 istride, const int2 ostride,
-    const float sx, const float sy) {
+    const float sx, const float sy, const bool half_pixel,
+    const bool half_pixel_for_nn) {
 
   NBLA_CUDA_KERNEL_LOOP(index, g_y_inner_size) {
     const auto nd_index = device_flat_to_3d(index, ostride);
@@ -439,8 +463,10 @@ __global__ void kernel_nearest_interpolate_2d_backward(
     const auto ih = ishape.x;
     const auto iw = ishape.y;
 
-    const auto iy = min(static_cast<int>(sy * (oy + 0.5f)), ih - 1);
-    const auto ix = min(static_cast<int>(sx * (ox + 0.5f)), iw - 1);
+    const auto fy = get_src_index_for_nn(sy, oy, half_pixel, half_pixel_for_nn);
+    const auto fx = get_src_index_for_nn(sx, ox, half_pixel, half_pixel_for_nn);
+    const auto iy = min(static_cast<int>(fy), ih - 1);
+    const auto ix = min(static_cast<int>(fx), iw - 1);
 
     const auto nd_idx_yx = make_int3(iy, ix, oc);
     const auto idx_yx = device_3d_to_flat(nd_idx_yx, istride);
@@ -455,7 +481,8 @@ template <typename T, bool channel_last = false>
 __global__ void kernel_nearest_interpolate_3d_backward(
     const int g_y_inner_size, const T *g_y, const int g_x_inner_size, T *g_x,
     int outer_size, const int3 ishape, const int3 istride, const int3 ostride,
-    const float sx, const float sy, const float sz) {
+    const float sx, const float sy, const float sz, const bool half_pixel,
+    const bool half_pixel_for_nn) {
 
   NBLA_CUDA_KERNEL_LOOP(index, g_y_inner_size) {
     const auto nd_index = device_flat_to_4d(index, ostride);
@@ -468,9 +495,12 @@ __global__ void kernel_nearest_interpolate_3d_backward(
     const auto ih = ishape.y;
     const auto iw = ishape.z;
 
-    const auto iz = min(static_cast<int>(sz * (oz + 0.5f)), id - 1);
-    const auto iy = min(static_cast<int>(sy * (oy + 0.5f)), ih - 1);
-    const auto ix = min(static_cast<int>(sx * (ox + 0.5f)), iw - 1);
+    const auto fz = get_src_index_for_nn(sz, oz, half_pixel, half_pixel_for_nn);
+    const auto fy = get_src_index_for_nn(sy, oy, half_pixel, half_pixel_for_nn);
+    const auto fx = get_src_index_for_nn(sx, ox, half_pixel, half_pixel_for_nn);
+    const auto iz = min(static_cast<int>(fz), id - 1);
+    const auto iy = min(static_cast<int>(fy), ih - 1);
+    const auto ix = min(static_cast<int>(fx), iw - 1);
 
     const auto nd_idx_zyx = make_int4(iz, iy, ix, oc);
     const auto idx_zyx = device_4d_to_flat(nd_idx_zyx, istride);
@@ -511,17 +541,18 @@ void InterpolateCuda<T>::forward_impl(const Variables &inputs,
       auto kernel = this->channel_last_
                         ? kernel_linear_interpolate_1d<Tcu, true>
                         : kernel_linear_interpolate_1d<Tcu, false>;
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
-          kernel, dst_inner_size, dst, src_inner_size, src, outer_size, ishape,
-          istride, ostride, sx, this->align_corners_);
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, dst_inner_size, dst,
+                                     src_inner_size, src, outer_size, ishape,
+                                     istride, ostride, sx, this->half_pixel_);
     } else if (this->mode_ == "nearest") {
-      const float sx = iw / static_cast<float>(ow);
+      const float sx = compute_scale_for_nn(iw, ow, this->align_corners_,
+                                            this->half_pixel_for_nn_);
       auto kernel = this->channel_last_
                         ? kernel_nearest_interpolate_1d<Tcu, true>
                         : kernel_nearest_interpolate_1d<Tcu, false>;
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, dst_inner_size, dst,
-                                     src_inner_size, src, outer_size, ishape,
-                                     istride, ostride, sx);
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+          kernel, dst_inner_size, dst, src_inner_size, src, outer_size, ishape,
+          istride, ostride, sx, this->half_pixel_, this->half_pixel_for_nn_);
     }
   }
 
@@ -555,16 +586,19 @@ void InterpolateCuda<T>::forward_impl(const Variables &inputs,
                         : kernel_linear_interpolate_2d<Tcu, false>;
       NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
           kernel, dst_inner_size, dst, src_inner_size, src, outer_size, ishape,
-          istride, ostride, sx, sy, this->align_corners_);
+          istride, ostride, sx, sy, this->half_pixel_);
     } else if (this->mode_ == "nearest") {
-      const float sx = iw / static_cast<float>(ow);
-      const float sy = ih / static_cast<float>(oh);
+      const float sx = compute_scale_for_nn(iw, ow, this->align_corners_,
+                                            this->half_pixel_for_nn_);
+      const float sy = compute_scale_for_nn(ih, oh, this->align_corners_,
+                                            this->half_pixel_for_nn_);
       auto kernel = this->channel_last_
                         ? kernel_nearest_interpolate_2d<Tcu, true>
                         : kernel_nearest_interpolate_2d<Tcu, false>;
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, dst_inner_size, dst,
-                                     src_inner_size, src, outer_size, ishape,
-                                     istride, ostride, sx, sy);
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+          kernel, dst_inner_size, dst, src_inner_size, src, outer_size, ishape,
+          istride, ostride, sx, sy, this->half_pixel_,
+          this->half_pixel_for_nn_);
     }
   }
 
@@ -607,17 +641,21 @@ void InterpolateCuda<T>::forward_impl(const Variables &inputs,
                         : kernel_linear_interpolate_3d<Tcu, false>;
       NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
           kernel, dst_inner_size, dst, src_inner_size, src, outer_size, ishape,
-          istride, ostride, sx, sy, sz, this->align_corners_);
+          istride, ostride, sx, sy, sz, this->half_pixel_);
     } else if (this->mode_ == "nearest") {
-      const float sx = iw / static_cast<float>(ow);
-      const float sy = ih / static_cast<float>(oh);
-      const float sz = id / static_cast<float>(od);
+      const float sx = compute_scale_for_nn(iw, ow, this->align_corners_,
+                                            this->half_pixel_for_nn_);
+      const float sy = compute_scale_for_nn(ih, oh, this->align_corners_,
+                                            this->half_pixel_for_nn_);
+      const float sz = compute_scale_for_nn(id, od, this->align_corners_,
+                                            this->half_pixel_for_nn_);
       auto kernel = this->channel_last_
                         ? kernel_nearest_interpolate_3d<Tcu, true>
                         : kernel_nearest_interpolate_3d<Tcu, false>;
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, dst_inner_size, dst,
-                                     src_inner_size, src, outer_size, ishape,
-                                     istride, ostride, sx, sy, sz);
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+          kernel, dst_inner_size, dst, src_inner_size, src, outer_size, ishape,
+          istride, ostride, sx, sy, sz, this->half_pixel_,
+          this->half_pixel_for_nn_);
     }
   }
 }
@@ -658,17 +696,18 @@ void InterpolateCuda<T>::backward_impl(const Variables &inputs,
       auto kernel = this->channel_last_
                         ? kernel_linear_interpolate_1d_backward<Tcu, true>
                         : kernel_linear_interpolate_1d_backward<Tcu, false>;
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
-          kernel, g_y_inner_size, g_y, g_x_inner_size, g_x, outer_size, ishape,
-          istride, ostride, sx, this->align_corners_);
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, g_y_inner_size, g_y,
+                                     g_x_inner_size, g_x, outer_size, ishape,
+                                     istride, ostride, sx, this->half_pixel_);
     } else if (this->mode_ == "nearest") {
-      const float sx = iw / static_cast<float>(ow);
+      const float sx = compute_scale_for_nn(iw, ow, this->align_corners_,
+                                            this->half_pixel_for_nn_);
       auto kernel = this->channel_last_
                         ? kernel_nearest_interpolate_1d_backward<Tcu, true>
                         : kernel_nearest_interpolate_1d_backward<Tcu, false>;
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, g_y_inner_size, g_y,
-                                     g_x_inner_size, g_x, outer_size, ishape,
-                                     istride, ostride, sx);
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+          kernel, g_y_inner_size, g_y, g_x_inner_size, g_x, outer_size, ishape,
+          istride, ostride, sx, this->half_pixel_, this->half_pixel_for_nn_);
     }
   }
 
@@ -701,16 +740,19 @@ void InterpolateCuda<T>::backward_impl(const Variables &inputs,
                         : kernel_linear_interpolate_2d_backward<Tcu, false>;
       NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
           kernel, g_y_inner_size, g_y, g_x_inner_size, g_x, outer_size, ishape,
-          istride, ostride, sx, sy, this->align_corners_);
+          istride, ostride, sx, sy, this->half_pixel_);
     } else if (this->mode_ == "nearest") {
-      const float sx = iw / static_cast<float>(ow);
-      const float sy = ih / static_cast<float>(oh);
+      const float sx = compute_scale_for_nn(iw, ow, this->align_corners_,
+                                            this->half_pixel_for_nn_);
+      const float sy = compute_scale_for_nn(ih, oh, this->align_corners_,
+                                            this->half_pixel_for_nn_);
       auto kernel = this->channel_last_
                         ? kernel_nearest_interpolate_2d_backward<Tcu, true>
                         : kernel_nearest_interpolate_2d_backward<Tcu, false>;
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, g_y_inner_size, g_y,
-                                     g_x_inner_size, g_x, outer_size, ishape,
-                                     istride, ostride, sx, sy);
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+          kernel, g_y_inner_size, g_y, g_x_inner_size, g_x, outer_size, ishape,
+          istride, ostride, sx, sy, this->half_pixel_,
+          this->half_pixel_for_nn_);
     }
   }
 
@@ -753,17 +795,21 @@ void InterpolateCuda<T>::backward_impl(const Variables &inputs,
                         : kernel_linear_interpolate_3d_backward<Tcu, false>;
       NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
           kernel, g_y_inner_size, g_y, g_x_inner_size, g_x, outer_size, ishape,
-          istride, ostride, sx, sy, sz, this->align_corners_);
+          istride, ostride, sx, sy, sz, this->half_pixel_);
     } else if (this->mode_ == "nearest") {
-      const float sx = iw / static_cast<float>(ow);
-      const float sy = ih / static_cast<float>(oh);
-      const float sz = id / static_cast<float>(od);
+      const float sx = compute_scale_for_nn(iw, ow, this->align_corners_,
+                                            this->half_pixel_for_nn_);
+      const float sy = compute_scale_for_nn(ih, oh, this->align_corners_,
+                                            this->half_pixel_for_nn_);
+      const float sz = compute_scale_for_nn(id, od, this->align_corners_,
+                                            this->half_pixel_for_nn_);
       auto kernel = this->channel_last_
                         ? kernel_nearest_interpolate_3d_backward<Tcu, true>
                         : kernel_nearest_interpolate_3d_backward<Tcu, false>;
-      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, g_y_inner_size, g_y,
-                                     g_x_inner_size, g_x, outer_size, ishape,
-                                     istride, ostride, sx, sy, sz);
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+          kernel, g_y_inner_size, g_y, g_x_inner_size, g_x, outer_size, ishape,
+          istride, ostride, sx, sy, sz, this->half_pixel_,
+          this->half_pixel_for_nn_);
     }
   }
 }


### PR DESCRIPTION
For ONNX conversion and further conversion from ONNX to runtime libraries, the interpolation function now includes half_pixel and half_pixel_for_nn options and also are addressed for ONNX opset_10 supports. The half_pixel_for_nn options is for the backward-compat.