### PR TITLE
SpatialTransformer

### DIFF
--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -531,6 +531,12 @@ MaxPoolingBackward:
 WarpByFlow:
   float: [float]
   half: [Half]
+AffineGrid:
+  float: [float]
+  half: [Half]
+WarpByGrid:
+  float: [float]
+  half: [Half]
 PatchCorrelation:
   float: [float]
   half: [Half]

--- a/build-tools/code_generator/function_types_cudnn.yaml
+++ b/build-tools/code_generator/function_types_cudnn.yaml
@@ -261,3 +261,9 @@ Add2:
 #   float: [float]
 # Sink:
 #   float: [float]
+AffineGrid:
+  float: [float]
+  half: [Half]
+WarpByGrid:
+  float: [float]
+  half: [Half]

--- a/include/nbla/cuda/cudnn/function/affine_grid.hpp
+++ b/include/nbla/cuda/cudnn/function/affine_grid.hpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_CUDNN_FUNCTION_AFFINE_GRID_HPP
+#define NBLA_CUDA_CUDNN_FUNCTION_AFFINE_GRID_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+
+#include <nbla/cuda/function/affine_grid.hpp>
+
+namespace nbla {
+
+namespace affine_grid {
+inline bool cudnn_condition(int size, bool align_corners) {
+  return (size == 2 && align_corners == true) ? true : false;
+}
+}
+
+template <typename T> class AffineGridCudaCudnn : public AffineGridCuda<T> {
+public:
+  typedef typename CudaType<T>::type Tcu;
+
+  explicit AffineGridCudaCudnn(const Context &ctx, const vector<int> &size,
+                               bool align_corners)
+      : AffineGridCuda<T>(ctx, size, align_corners),
+        device_(std::stoi(ctx.device_id)) {
+    if (affine_grid::cudnn_condition(this->size_.size(),
+                                     this->align_corners_)) {
+      NBLA_CUDNN_CHECK(cudnnCreateSpatialTransformerDescriptor(&theta_desc_));
+    }
+  }
+  virtual ~AffineGridCudaCudnn() {
+    if (affine_grid::cudnn_condition(this->size_.size(),
+                                     this->align_corners_)) {
+      NBLA_CUDNN_CHECK(cudnnDestroySpatialTransformerDescriptor(theta_desc_));
+    }
+  }
+  virtual string name() { return "AffineGridCudaCudnn"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+
+  cudnnSpatialTransformerDescriptor_t theta_desc_;
+
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/cudnn/function/warp_by_grid.hpp
+++ b/include/nbla/cuda/cudnn/function/warp_by_grid.hpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_CUDNN_FUNCTION_WARP_BY_GRID_HPP
+#define NBLA_CUDA_CUDNN_FUNCTION_WARP_BY_GRID_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+
+#include <nbla/cuda/function/warp_by_grid.hpp>
+
+namespace nbla {
+
+namespace warp_by_grid {
+inline bool cudnn_condition(const int size, const std::string mode,
+                            const PADDING_MODE padding_mode_t,
+                            const bool align_corners, const bool channel_last) {
+  return (size == 4 && mode == "linear" &&
+          padding_mode_t == PADDING_MODE::zero && align_corners == true &&
+          !channel_last)
+             ? true
+             : false;
+}
+}
+
+template <typename T> class WarpByGridCudaCudnn : public WarpByGridCuda<T> {
+public:
+  typedef typename CudaType<T>::type Tcu;
+
+  explicit WarpByGridCudaCudnn(const Context &ctx, const string &mode,
+                               const string &padding_mode, bool align_corners,
+                               bool channel_last)
+      : WarpByGridCuda<T>(ctx, mode, padding_mode, align_corners, channel_last),
+        device_(std::stoi(ctx.device_id)) {
+    NBLA_CUDNN_CHECK(
+        cudnnCreateSpatialTransformerDescriptor(&spatial_tf_desc_));
+    NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&x_desc_));
+    NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&y_desc_));
+  }
+
+  virtual ~WarpByGridCudaCudnn() {
+    NBLA_CUDNN_CHECK(
+        cudnnDestroySpatialTransformerDescriptor(spatial_tf_desc_));
+    NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(x_desc_));
+    NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(y_desc_));
+  }
+  virtual string name() { return "WarpByGridCudaCudnn"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+
+  cudnnSpatialTransformerDescriptor_t spatial_tf_desc_;
+  cudnnTensorDescriptor_t x_desc_;
+  cudnnTensorDescriptor_t y_desc_;
+
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/function/affine_grid.hpp
+++ b/include/nbla/cuda/function/affine_grid.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_AFFINE_GRID_HPP
+#define NBLA_CUDA_FUNCTION_AFFINE_GRID_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/affine_grid.hpp>
+
+namespace nbla {
+
+template <typename T> class AffineGridCuda : public AffineGrid<T> {
+public:
+  typedef typename CudaType<T>::type Tcu;
+
+  explicit AffineGridCuda(const Context &ctx, const vector<int> &size,
+                          bool align_corners)
+      : AffineGrid<T>(ctx, size, align_corners),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~AffineGridCuda() {}
+  virtual string name() { return "AffineGridCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/function/warp_by_grid.hpp
+++ b/include/nbla/cuda/function/warp_by_grid.hpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_WARP_BY_GRID_HPP
+#define NBLA_CUDA_FUNCTION_WARP_BY_GRID_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/warp_by_grid.hpp>
+
+namespace nbla {
+
+template <typename T> class WarpByGridCuda : public WarpByGrid<T> {
+public:
+  typedef typename CudaType<T>::type Tcu;
+
+  explicit WarpByGridCuda(const Context &ctx, const string &mode,
+                          const string &padding_mode, bool align_corners,
+                          bool channel_last)
+      : WarpByGrid<T>(ctx, mode, padding_mode, align_corners, channel_last),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~WarpByGridCuda() {}
+  virtual string name() { return "WarpByGridCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/src/nbla/cuda/cudnn/function/generic/affine_grid.cu
+++ b/src/nbla/cuda/cudnn/function/generic/affine_grid.cu
@@ -1,0 +1,109 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+#include <nbla/cuda/cudnn/function/affine_grid.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+__global__ void kernel_affine_grid_add(const int size, T *y, const T *x) {
+  NBLA_CUDA_KERNEL_LOOP(idx, size) { y[idx] += x[idx]; }
+}
+
+template <typename T>
+void AffineGridCudaCudnn<T>::setup_impl(const Variables &inputs,
+                                        const Variables &outputs) {
+  AffineGridCuda<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+
+  auto oshape = outputs[0]->shape();
+  if (!affine_grid::cudnn_condition(this->size_.size(), this->align_corners_)) {
+    return;
+  }
+  int B = oshape[0];
+  int H = oshape[1];
+  int W = oshape[2];
+  int V = oshape[3];
+  vector<int> dimA{
+      B, 1, H,
+      W}; // cudnn requires the redandant argument, C. This is for free.
+  NBLA_CUDNN_CHECK(cudnnSetSpatialTransformerNdDescriptor(
+      theta_desc_, CUDNN_SAMPLER_BILINEAR, cudnn_data_type<T>::type(), 4,
+      dimA.data()));
+}
+
+template <typename T>
+void AffineGridCudaCudnn<T>::forward_impl(const Variables &inputs,
+                                          const Variables &outputs) {
+  cuda_set_device(this->device_);
+
+  auto oshape = outputs[0]->shape();
+  if (!affine_grid::cudnn_condition(this->size_.size(), this->align_corners_)) {
+    AffineGridCuda<T>::forward_impl(inputs, outputs);
+    return;
+  }
+
+  cudnnHandle_t cudnn_handle =
+      SingletonManager::get<CudnnHandleManager>()->handle(this->device_);
+  const auto theta = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+  auto grid = outputs[0]->cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+  NBLA_CUDNN_CHECK(cudnnSpatialTfGridGeneratorForward(cudnn_handle, theta_desc_,
+                                                      theta, grid));
+}
+
+template <typename T>
+void AffineGridCudaCudnn<T>::backward_impl(const Variables &inputs,
+                                           const Variables &outputs,
+                                           const vector<bool> &propagate_down,
+                                           const vector<bool> &accum) {
+  if (!(propagate_down[0])) {
+    return;
+  }
+  cuda_set_device(this->device_);
+
+  auto oshape = outputs[0]->shape();
+  if (!affine_grid::cudnn_condition(this->size_.size(), this->align_corners_)) {
+    AffineGridCuda<T>::backward_impl(inputs, outputs, propagate_down, accum);
+    return;
+  }
+
+  cudnnHandle_t cudnn_handle =
+      SingletonManager::get<CudnnHandleManager>()->handle(this->device_);
+  const auto g_grid = outputs[0]->get_grad_pointer<Tcu>(this->ctx_);
+  if (propagate_down[0]) {
+    if (accum[0]) {
+      auto g_theta_tmp = make_shared<Variable>(inputs[0]->shape());
+      auto g_theta_tmp_ptr0 =
+          g_theta_tmp->cast_grad_and_get_pointer<Tcu>(this->ctx_, true);
+      auto size = inputs[0]->size();
+      auto g_theta_tmp_ptr1 = g_theta_tmp->get_grad_pointer<Tcu>(this->ctx_);
+      auto g_theta =
+          inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_, false);
+      NBLA_CUDNN_CHECK(cudnnSpatialTfGridGeneratorBackward(
+          cudnn_handle, theta_desc_, g_grid, g_theta_tmp_ptr0));
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_affine_grid_add, size, g_theta,
+                                     g_theta_tmp_ptr1);
+    } else {
+      auto g_theta =
+          inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_, true);
+      NBLA_CUDNN_CHECK(cudnnSpatialTfGridGeneratorBackward(
+          cudnn_handle, theta_desc_, g_grid, g_theta));
+    }
+  }
+}
+}

--- a/src/nbla/cuda/cudnn/function/generic/warp_by_grid.cu
+++ b/src/nbla/cuda/cudnn/function/generic/warp_by_grid.cu
@@ -1,0 +1,228 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+#include <nbla/cuda/cudnn/function/warp_by_grid.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+__global__ void kernel_warp_by_grid_add(const int size, T *y, const T *x) {
+  NBLA_CUDA_KERNEL_LOOP(idx, size) { y[idx] += x[idx]; }
+}
+
+template <typename T>
+void WarpByGridCudaCudnn<T>::setup_impl(const Variables &inputs,
+                                        const Variables &outputs) {
+  WarpByGridCuda<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+
+  auto oshape = outputs[0]->shape();
+  if (!warp_by_grid::cudnn_condition(
+          outputs[0]->shape().size(), this->mode_, this->padding_mode_t_,
+          this->align_corners_, this->channel_last_)) {
+    return;
+  }
+  int B = oshape[0];
+  int C = oshape[1];
+  int Ho = oshape[2];
+  int Wo = oshape[3];
+  vector<int> dimA{B, C, Ho, Wo};
+  NBLA_CUDNN_CHECK(cudnnSetSpatialTransformerNdDescriptor(
+      spatial_tf_desc_, CUDNN_SAMPLER_BILINEAR, cudnn_data_type<T>::type(), 4,
+      dimA.data()));
+  auto ishape = inputs[0]->shape();
+  int Hi = ishape[2];
+  int Wi = ishape[3];
+  vector<int> dimX{B, C, Hi, Wi};
+  cudnn_set_tensor_nd_descriptor_force_dim(x_desc_, cudnn_data_type<T>::type(),
+                                           dimX, dimX.size(),
+                                           this->channel_last_, false);
+  vector<int> dimY{B, C, Ho, Wo};
+  cudnn_set_tensor_nd_descriptor_force_dim(y_desc_, cudnn_data_type<T>::type(),
+                                           dimY, dimY.size(),
+                                           this->channel_last_, false);
+}
+
+template <typename T>
+void WarpByGridCudaCudnn<T>::forward_impl(const Variables &inputs,
+                                          const Variables &outputs) {
+  cuda_set_device(this->device_);
+
+  auto oshape = outputs[0]->shape();
+  if (!warp_by_grid::cudnn_condition(
+          outputs[0]->shape().size(), this->mode_, this->padding_mode_t_,
+          this->align_corners_, this->channel_last_)) {
+    WarpByGridCuda<T>::forward_impl(inputs, outputs);
+    return;
+  }
+
+  cudnnHandle_t cudnn_handle =
+      SingletonManager::get<CudnnHandleManager>()->handle(this->device_);
+  auto x = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+  auto grid = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+  auto y = outputs[0]->cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+  auto alpha = get_cudnn_scalar_arg<T>(1);
+  auto beta = get_cudnn_scalar_arg<T>(0);
+  NBLA_CUDNN_CHECK(cudnnSpatialTfSamplerForward(cudnn_handle, spatial_tf_desc_,
+                                                &alpha, x_desc_, x, grid, &beta,
+                                                y_desc_, y));
+}
+
+template <typename T>
+void WarpByGridCudaCudnn<T>::backward_impl(const Variables &inputs,
+                                           const Variables &outputs,
+                                           const vector<bool> &propagate_down,
+                                           const vector<bool> &accum) {
+  if (!(propagate_down[0] || propagate_down[1])) {
+    return;
+  }
+  cuda_set_device(this->device_);
+
+  auto oshape = outputs[0]->shape();
+
+#if defined(_WIN32) || defined(_WIN64)
+  WarpByGridCuda<T>::backward_impl(inputs, outputs, propagate_down, accum);
+  return;
+#endif
+  if (!warp_by_grid::cudnn_condition(
+          outputs[0]->shape().size(), this->mode_, this->padding_mode_t_,
+          this->align_corners_, this->channel_last_)) {
+    WarpByGridCuda<T>::backward_impl(inputs, outputs, propagate_down, accum);
+    return;
+  }
+
+  cudnnHandle_t cudnn_handle =
+      SingletonManager::get<CudnnHandleManager>()->handle(this->device_);
+  const auto x = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+  const auto grid = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+  const auto y = outputs[0]->get_data_pointer<Tcu>(this->ctx_);
+  const auto g_y = outputs[0]->get_grad_pointer<Tcu>(this->ctx_);
+  auto alpha = get_cudnn_scalar_arg<T>(1);
+  auto beta = get_cudnn_scalar_arg<T>(0);
+  auto g_alpha = get_cudnn_scalar_arg<T>(1);
+  auto g_beta = get_cudnn_scalar_arg<T>(0);
+  auto x_size = inputs[0]->size();
+  auto g_size = inputs[1]->size();
+
+  // beta 1 seems not working
+  if (propagate_down[0] && propagate_down[1]) {
+    if (!accum[0] && !accum[1]) {
+      auto g_x =
+          inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[0]);
+      auto g_grid =
+          inputs[1]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[1]);
+      NBLA_CUDNN_CHECK(cudnnSpatialTfSamplerBackward(
+          cudnn_handle, spatial_tf_desc_, &alpha, x_desc_, x, &beta, x_desc_,
+          g_x, &g_alpha, y_desc_, g_y, grid, &g_beta, g_grid));
+    } else if (!accum[0] && accum[1]) {
+      auto g_x =
+          inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[0]);
+      auto g_grid =
+          inputs[1]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[1]);
+      auto g_grid_tmp = make_shared<Variable>(inputs[1]->shape());
+      auto g_grid_tmp_ptr0 =
+          g_grid_tmp->cast_grad_and_get_pointer<Tcu>(this->ctx_, true);
+      auto g_grid_tmp_ptr1 = g_grid_tmp->get_grad_pointer<Tcu>(this->ctx_);
+      NBLA_CUDNN_CHECK(cudnnSpatialTfSamplerBackward(
+          cudnn_handle, spatial_tf_desc_, &alpha, x_desc_, x, &beta, x_desc_,
+          g_x, &g_alpha, y_desc_, g_y, grid, &g_beta, g_grid_tmp_ptr0));
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_warp_by_grid_add, g_size, g_grid,
+                                     g_grid_tmp_ptr1);
+    } else if (accum[0] && !accum[1]) {
+      auto g_x =
+          inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[0]);
+      auto g_grid =
+          inputs[1]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[1]);
+      auto g_x_tmp = make_shared<Variable>(inputs[0]->shape());
+      auto g_x_tmp_ptr0 =
+          g_x_tmp->cast_grad_and_get_pointer<Tcu>(this->ctx_, true);
+      auto g_x_tmp_ptr1 = g_x_tmp->get_grad_pointer<Tcu>(this->ctx_);
+      NBLA_CUDNN_CHECK(cudnnSpatialTfSamplerBackward(
+          cudnn_handle, spatial_tf_desc_, &alpha, x_desc_, x, &beta, x_desc_,
+          g_x_tmp_ptr0, &g_alpha, y_desc_, g_y, grid, &g_beta, g_grid));
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_warp_by_grid_add, x_size, g_x,
+                                     g_x_tmp_ptr1);
+    } else if (accum[0] && accum[1]) {
+      auto g_x =
+          inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[0]);
+      auto g_grid =
+          inputs[1]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[1]);
+      auto g_x_tmp = make_shared<Variable>(inputs[0]->shape());
+      auto g_x_tmp_ptr0 =
+          g_x_tmp->cast_grad_and_get_pointer<Tcu>(this->ctx_, true);
+      auto g_x_tmp_ptr1 = g_x_tmp->get_grad_pointer<Tcu>(this->ctx_);
+      auto g_grid_tmp = make_shared<Variable>(inputs[1]->shape());
+      auto g_grid_tmp_ptr0 =
+          g_grid_tmp->cast_grad_and_get_pointer<Tcu>(this->ctx_, true);
+      auto g_grid_tmp_ptr1 = g_grid_tmp->get_grad_pointer<Tcu>(this->ctx_);
+      NBLA_CUDNN_CHECK(cudnnSpatialTfSamplerBackward(
+          cudnn_handle, spatial_tf_desc_, &alpha, x_desc_, x, &beta, x_desc_,
+          g_x_tmp_ptr0, &g_alpha, y_desc_, g_y, grid, &g_beta,
+          g_grid_tmp_ptr0));
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_warp_by_grid_add, g_size, g_grid,
+                                     g_grid_tmp_ptr1);
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_warp_by_grid_add, x_size, g_x,
+                                     g_x_tmp_ptr1);
+    }
+  } else if (propagate_down[0] && !propagate_down[1]) {
+    auto g_x = inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[0]);
+    auto g_grid_tmp = make_shared<Variable>(inputs[1]->shape());
+    auto g_grid_tmp_ptr0 =
+        g_grid_tmp->cast_grad_and_get_pointer<Tcu>(this->ctx_, true);
+    if (!accum[0]) {
+      NBLA_CUDNN_CHECK(cudnnSpatialTfSamplerBackward(
+          cudnn_handle, spatial_tf_desc_, &alpha, x_desc_, x, &beta, x_desc_,
+          g_x, &g_alpha, y_desc_, g_y, grid, &g_beta, g_grid_tmp_ptr0));
+    } else {
+      auto g_x_tmp = make_shared<Variable>(inputs[0]->shape());
+      auto g_x_tmp_ptr0 =
+          g_x_tmp->cast_grad_and_get_pointer<Tcu>(this->ctx_, true);
+      auto g_x_tmp_ptr1 = g_x_tmp->get_grad_pointer<Tcu>(this->ctx_);
+      NBLA_CUDNN_CHECK(cudnnSpatialTfSamplerBackward(
+          cudnn_handle, spatial_tf_desc_, &alpha, x_desc_, x, &beta, x_desc_,
+          g_x_tmp_ptr0, &g_alpha, y_desc_, g_y, grid, &g_beta,
+          g_grid_tmp_ptr0));
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_warp_by_grid_add, x_size, g_x,
+                                     g_x_tmp_ptr1);
+    }
+
+  } else if (!propagate_down[0] && propagate_down[1]) {
+    auto g_x_tmp = make_shared<Variable>(inputs[0]->shape());
+    auto g_x_tmp_ptr0 =
+        g_x_tmp->cast_grad_and_get_pointer<Tcu>(this->ctx_, true);
+    auto g_grid =
+        inputs[1]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[1]);
+    if (!accum[1]) {
+      NBLA_CUDNN_CHECK(cudnnSpatialTfSamplerBackward(
+          cudnn_handle, spatial_tf_desc_, &alpha, x_desc_, x, &beta, x_desc_,
+          g_x_tmp_ptr0, &g_alpha, y_desc_, g_y, grid, &g_beta, g_grid));
+    } else {
+      auto g_grid_tmp = make_shared<Variable>(inputs[0]->shape());
+      auto g_grid_tmp_ptr0 =
+          g_grid_tmp->cast_grad_and_get_pointer<Tcu>(this->ctx_, true);
+      auto g_grid_tmp_ptr1 = g_grid_tmp->get_grad_pointer<Tcu>(this->ctx_);
+      NBLA_CUDNN_CHECK(cudnnSpatialTfSamplerBackward(
+          cudnn_handle, spatial_tf_desc_, &alpha, x_desc_, x, &beta, x_desc_,
+          g_x_tmp_ptr0, &g_alpha, y_desc_, g_y, grid, &g_beta,
+          g_grid_tmp_ptr0));
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_warp_by_grid_add, g_size, g_grid,
+                                     g_grid_tmp_ptr1);
+    }
+  }
+}
+}

--- a/src/nbla/cuda/function/generic/affine_grid.cu
+++ b/src/nbla/cuda/function/generic/affine_grid.cu
@@ -1,0 +1,221 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/affine_grid.hpp>
+#include <nbla/cuda/utils/nd_index.cuh>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T, bool align_corners>
+__global__ void kernel_generate_target_grid_2d(const Size_t isize, T *grid,
+                                               int3 shape, int2 stride, int B) {
+
+  NBLA_CUDA_KERNEL_LOOP(idx, isize) {
+    auto H = shape.x;
+    auto W = shape.y;
+    auto nd_index = device_flat_to_3d(idx, stride);
+    auto h = nd_index.x;
+    auto w = nd_index.y;
+    auto v = nd_index.z;
+
+    for (auto b = 0; b < B; b++) {
+      auto bidx = idx + b * isize;
+      // [-1, 1] <--> [0, S - 1] if align_corner
+      // [-1, 1] <--> [-0.5, S - 0.5] = [0 - 0.5, S - 1 + 0.5] if not
+      // align_corner
+      // Num. of v = 3, corresponding to (x, y, 1)
+      if (v == 0) {
+        auto x = T(2.0) * w / (W - 1) - T(1.0);
+        x = align_corners ? x : x * (T(W - 1) / T(W));
+        grid[bidx] = x;
+      } else if (v == 1) {
+        auto y = T(2.0) * h / (H - 1) - T(1.0);
+        y = align_corners ? y : y * (T(H - 1) / T(H));
+        grid[bidx] = y;
+      } else {
+        grid[bidx] = T(1);
+      }
+    }
+  }
+}
+
+template <typename T, bool align_corners>
+__global__ void kernel_generate_target_grid_3d(const Size_t isize, T *grid,
+                                               int4 shape, int3 stride, int B) {
+
+  NBLA_CUDA_KERNEL_LOOP(idx, isize) {
+    auto D = shape.x;
+    auto H = shape.y;
+    auto W = shape.z;
+    auto nd_index = device_flat_to_4d(idx, stride);
+    auto d = nd_index.x;
+    auto h = nd_index.y;
+    auto w = nd_index.z;
+    auto v = nd_index.w;
+
+    for (auto b = 0; b < B; b++) {
+      auto bidx = idx + b * isize;
+      // [-1, 1] <--> [0, S - 1] if align_corner
+      // [-1, 1] <--> [-0.5, S - 0.5] = [0 - 0.5, S - 1 + 0.5] if not
+      // align_corner
+      // Num. of v = 3, corresponding to (x, y, 1)
+      if (v == 0) {
+        auto x = T(2.0) * w / (W - 1) - T(1.0);
+        x = align_corners ? x : x * (T(W - 1) / T(W));
+        grid[bidx] = x;
+      } else if (v == 1) {
+        auto y = T(2.0) * h / (H - 1) - T(1.0);
+        y = align_corners ? y : y * (T(H - 1) / T(H));
+        grid[bidx] = y;
+      } else if (v == 2) {
+        auto z = T(2.0) * d / (D - 1) - T(1.0);
+        z = align_corners ? z : z * (T(D - 1) / T(D));
+        grid[bidx] = z;
+      } else {
+        grid[bidx] = T(1);
+      }
+    }
+  }
+}
+
+template <typename T>
+void AffineGridCuda<T>::setup_impl(const Variables &inputs,
+                                   const Variables &outputs) {
+  AffineGrid<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void AffineGridCuda<T>::forward_impl(const Variables &inputs,
+                                     const Variables &outputs) {
+  cuda_set_device(this->device_);
+
+  auto affine = inputs[0];
+  auto grid_s = outputs[0];
+
+  if (this->size_.size() == 2) {
+    // Target grid (with 1 for the translation)
+    auto B = affine->shape()[0];
+    auto H = this->size_[0];
+    auto W = this->size_[1];
+    Variable grid_t(Shape_t{B, H, W, 3});
+
+    auto isize = H * W * 3;
+    auto shape = make_int3(H, W, 3);
+    auto stride = make_int2(W * 3, 3);
+    auto grid_t_ptr = grid_t.cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+    auto generate_target_grid =
+        this->align_corners_ ? kernel_generate_target_grid_2d<Tcu, true>
+                             : kernel_generate_target_grid_2d<Tcu, false>;
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(generate_target_grid, isize, grid_t_ptr,
+                                   shape, stride, B);
+
+    // Transform: (B, H, W, 3) @ (B, 2, 3) --> (B, H, W, 2)
+    grid_t.reshape(Shape_t{B, H * W, 3}, false);
+    grid_s->reshape(Shape_t{B, H * W, 2}, false);
+    execute(this->batch_matmul_, Variables{&grid_t, affine}, Variables{grid_s});
+    grid_s->reshape(Shape_t{B, H, W, 2}, false);
+  } else if (this->size_.size() == 3) {
+    // Target grid (with 1 for the translation)
+    auto B = affine->shape()[0];
+    auto D = this->size_[0];
+    auto H = this->size_[1];
+    auto W = this->size_[2];
+    Variable grid_t(Shape_t{B, D, H, W, 4});
+
+    auto isize = D * H * W * 4;
+    auto shape = make_int4(D, H, W, 4);
+    auto stride = make_int3(H * W * 4, W * 4, 4);
+    auto grid_t_ptr = grid_t.cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+    auto generate_target_grid =
+        this->align_corners_ ? kernel_generate_target_grid_3d<Tcu, true>
+                             : kernel_generate_target_grid_3d<Tcu, false>;
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(generate_target_grid, isize, grid_t_ptr,
+                                   shape, stride, B);
+
+    /// Transform: (B, D, H, W, 4) @ (B, 3, 4) --> (B, D, H, W, 3)
+    grid_t.reshape(Shape_t{B, D * H * W, 4}, false);
+    grid_s->reshape(Shape_t{B, D * H * W, 3}, false);
+    execute(this->batch_matmul_, Variables{&grid_t, affine}, Variables{grid_s});
+    grid_s->reshape(Shape_t{B, D, H, W, 3}, false);
+  }
+}
+
+template <typename T>
+void AffineGridCuda<T>::backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum) {
+  if (!(propagate_down[0])) {
+    return;
+  }
+  // Gradient of outputs
+  auto affine = inputs[0];
+  auto B = affine->shape()[0];
+  auto grid_s = outputs[0];
+  if (this->size_.size() == 2) {
+    // Target grid with 1 for the translation
+    auto B = affine->shape()[0];
+    auto H = this->size_[0];
+    auto W = this->size_[1];
+    Variable grid_t(Shape_t{B, H, W, 3});
+
+    auto isize = H * W * 3;
+    auto shape = make_int3(H, W, 3);
+    auto stride = make_int2(W * 3, 3);
+    auto grid_t_ptr = grid_t.cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+    auto generate_target_grid =
+        this->align_corners_ ? kernel_generate_target_grid_2d<Tcu, true>
+                             : kernel_generate_target_grid_2d<Tcu, false>;
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(generate_target_grid, isize, grid_t_ptr,
+                                   shape, stride, B);
+
+    // Backward of the transformation: (B, H, W, 2) @ (B, 2, 3) --> (B, H, W, 2)
+    grid_t.reshape(Shape_t{B, H * W, 3}, false);
+    grid_s->reshape(Shape_t{B, H * W, 2}, false);
+    nbla::backward(this->batch_matmul_, Variables{&grid_t, affine},
+                   Variables{grid_s}, vector<bool>{false, propagate_down[0]},
+                   vector<bool>{false, accum[0]});
+    grid_s->reshape(Shape_t{B, H, W, 2}, false);
+  } else if (this->size_.size() == 3) {
+    auto B = affine->shape()[0];
+    auto D = this->size_[0];
+    auto H = this->size_[1];
+    auto W = this->size_[2];
+    Variable grid_t(Shape_t{B, D, H, W, 4});
+
+    auto isize = D * H * W * 4;
+    auto shape = make_int4(D, H, W, 4);
+    auto stride = make_int3(H * W * 4, W * 4, 4);
+    auto grid_t_ptr = grid_t.cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+    auto generate_target_grid =
+        this->align_corners_ ? kernel_generate_target_grid_3d<Tcu, true>
+                             : kernel_generate_target_grid_3d<Tcu, false>;
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(generate_target_grid, isize, grid_t_ptr,
+                                   shape, stride, B);
+
+    // Backward of the transformation: (B, D, H, W, 4) @ (B, 3, 4) --> (B, D, H,
+    // W, 3)
+    grid_t.reshape(Shape_t{B, D * H * W, 4}, false);
+    grid_s->reshape(Shape_t{B, D * H * W, 3}, false);
+    nbla::backward(this->batch_matmul_, Variables{&grid_t, affine},
+                   Variables{grid_s}, vector<bool>{false, propagate_down[0]},
+                   vector<bool>{false, accum[0]});
+    grid_s->reshape(Shape_t{B, D, H, W, 3}, false);
+  }
+}
+}

--- a/src/nbla/cuda/function/generic/warp_by_grid.cu
+++ b/src/nbla/cuda/function/generic/warp_by_grid.cu
@@ -1,0 +1,2071 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/warp_by_grid.hpp>
+#include <nbla/cuda/utils/atomic_add.cuh>
+#include <nbla/cuda/utils/nd_index.cuh>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T, bool align_corners = false>
+__forceinline__ __device__ T unnormalize_grid_with(T s, const int S) {
+  if (align_corners) {
+    // [-1, 1] <--> [0, S - 1]
+    return (s + T(1)) * (S - T(1)) / T(2);
+  } else {
+    // [-1, 1] <--> [-0.5, S - 0.5] = [0 - 0.5, S - 1 + 0.5]
+    return ((s + T(1)) * S - T(1)) / T(2);
+  }
+}
+
+template <typename T>
+__forceinline__ __device__ T get_src_findex_with_zero_pad(const T s,
+                                                          const int S) {
+  return s;
+}
+
+template <typename T>
+__forceinline__ __device__ T get_src_findex_with_repeat_pad(const T s,
+                                                            const int S) {
+  if (s < 0) {
+    return 0;
+  } else if (s > S - 1) {
+    return S - 1;
+  } else {
+    return s;
+  }
+}
+
+template <typename T>
+__forceinline__ __device__ T reflect(const T s, const int L, const int U) {
+  auto len = (U - L);
+  if (s < L) {
+    auto d = L - s;
+    auto nf = d / len;
+    auto n = static_cast<int>(nf);
+    auto r = d - n * len;
+    if (n % 2 == 0) {
+      return L + r;
+    } else {
+      return U - r;
+    }
+  } else if (s > U) {
+    auto d = s - U;
+    auto nf = d / len;
+    auto n = static_cast<int>(nf);
+    auto r = d - n * len;
+    if (n % 2 == 0) {
+      return U - r;
+    } else {
+      return L + r;
+    }
+  } else {
+    return s;
+  }
+}
+
+template <typename T, bool align_corners = false>
+__forceinline__ __device__ T get_src_findex_with_reflect_pad(T s, const int S) {
+  if (align_corners) {
+    return reflect(s, T(0), T(S - 1));
+  } else {
+    // address the borders {-0.5, S - 0.5} condition by two multiplication
+    auto sf = reflect(T(2) * s, T(-1), T(2) * T(S) - T(1));
+    sf = sf * T(0.5);
+    sf = get_src_findex_with_repeat_pad(sf, S);
+    return sf;
+  }
+}
+
+template <typename T>
+__forceinline__ __device__ T get_grad_coef_with_zero_pad(const T s,
+                                                         const int S) {
+  return T(1);
+}
+
+template <typename T>
+__forceinline__ __device__ T get_grad_coef_with_repeat_pad(const T s,
+                                                           const int S) {
+  if (s <= 0) {
+    return 0;
+  } else if (s >= S - 1) {
+    return 0;
+  } else {
+    return 1;
+  }
+}
+
+template <typename T>
+__forceinline__ __device__ T reflect_coef(const T s, const int L, const int U) {
+  auto len = (U - L);
+  if (s < L) {
+    auto d = L - s;
+    auto nf = d / len;
+    auto n = static_cast<int>(nf);
+    if (n % 2 == 0) {
+      return T(-1);
+    } else {
+      return T(1);
+    }
+  } else if (s > U) {
+    auto d = s - U;
+    auto nf = d / len;
+    auto n = static_cast<int>(nf);
+    if (n % 2 == 0) {
+      return T(-1);
+    } else {
+      return T(1);
+    }
+  } else {
+    return T(1);
+  }
+}
+
+template <typename T, bool align_corners = false>
+__forceinline__ __device__ T get_grad_coef_with_reflect_pad(T s, const int S) {
+  if (align_corners) {
+    return reflect_coef(s, T(0), T(S - 1));
+  } else {
+    // address the borders {-0.5, S - 0.5} condition by two multiplication
+    auto coef = reflect_coef(T(2) * s, T(-1), T(2) * T(S) - T(1));
+    auto sf = reflect(T(2) * s, T(-1), T(2) * T(S) - T(1));
+    sf = sf * T(0.5);
+    coef *= get_grad_coef_with_repeat_pad(sf, S);
+    return coef;
+  }
+}
+
+template <typename T, bool channel_last = false>
+__forceinline__ __device__ T get_pixel_value_2d(const T *input, int b, int c,
+                                                int h, int w, const int H,
+                                                const int W, const int2 istride,
+                                                const int iisize) {
+  if ((h >= 0 && h < H) && (w >= 0 && w < W)) {
+    auto ind_index = channel_last ? make_int3(h, w, c) : make_int3(c, h, w);
+    auto iidx = device_3d_to_flat(ind_index, istride);
+    auto b_iidx = iidx + b * iisize;
+    return input[b_iidx];
+  } else {
+    return T(0);
+  }
+}
+
+template <typename T, bool channel_last = false>
+__forceinline__ __device__ T get_pixel_value_3d(const T *input, int b, int c,
+                                                int d, int h, int w,
+                                                const int D, const int H,
+                                                const int W, const int3 istride,
+                                                const int iisize) {
+  if ((d >= 0 && d < D) && (h >= 0 && h < H) && (w >= 0 && w < W)) {
+    auto ind_index =
+        channel_last ? make_int4(d, h, w, c) : make_int4(c, d, h, w);
+    auto iidx = device_4d_to_flat(ind_index, istride);
+    auto b_iidx = iidx + b * iisize;
+    return input[b_iidx];
+  } else {
+    return T(0);
+  }
+}
+
+template <typename T, bool channel_last = false>
+__forceinline__ __device__ void
+backward_data_2d(T *igrad, const T ograd, const T p, const T q, int b, int c,
+                 int h, int w, const int H, const int W, const int2 istride,
+                 const int iisize) {
+  if ((h >= 0 && h < H) && (w >= 0 && w < W)) {
+    auto ind_index = channel_last ? make_int3(h, w, c) : make_int3(c, h, w);
+    auto iidx = device_3d_to_flat(ind_index, istride);
+    auto b_iidx = iidx + b * iisize;
+    atomic_add(igrad + b_iidx, ograd * p * q);
+  }
+}
+
+template <typename T, bool channel_last = false>
+__forceinline__ __device__ void
+backward_data_3d(T *igrad, const T ograd, const T p, const T q, const T r,
+                 int b, int c, int d, int h, int w, const int D, const int H,
+                 const int W, const int3 istride, const int iisize) {
+  if ((d >= 0 && d < D) && (h >= 0 && h < H) && (w >= 0 && w < W)) {
+    auto ind_index =
+        channel_last ? make_int4(d, h, w, c) : make_int4(c, d, h, w);
+    auto iidx = device_4d_to_flat(ind_index, istride);
+    auto b_iidx = iidx + b * iisize;
+    atomic_add(igrad + b_iidx, ograd * p * q * r);
+  }
+}
+
+/*
+  Forward implementations
+ */
+
+template <typename T, warp_by_grid::PADDING_MODE padding_mode =
+                          warp_by_grid::PADDING_MODE::zero,
+          bool align_corners = false, bool channel_last = false>
+__global__ void kernel_warp_linear_forward_2d(
+    const int oisize, const int iisize, const int gisize, T *output,
+    const T *input, const T *grid, const int3 ishape, const int2 istride,
+    const int2 gstride, const int2 ostride, const int B) {
+  auto Hi = channel_last ? ishape.x : ishape.y;
+  auto Wi = channel_last ? ishape.y : ishape.z;
+
+  auto unnormalize_grid = align_corners ? unnormalize_grid_with<T, true>
+                                        : unnormalize_grid_with<T, false>;
+  auto get_src_findex_with_pad = [&](const T s, const Size_t S) {
+    if (padding_mode == warp_by_grid::PADDING_MODE::zero) {
+      return get_src_findex_with_zero_pad(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::reflect) {
+      return align_corners ? get_src_findex_with_reflect_pad<T, true>(s, S)
+                           : get_src_findex_with_reflect_pad<T, false>(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::repeat) {
+      return get_src_findex_with_repeat_pad(s, S);
+    } else {
+      return T(-1);
+    }
+  };
+
+  NBLA_CUDA_KERNEL_LOOP(oidx, oisize) {
+    auto ond_index = device_flat_to_3d(oidx, ostride);
+    auto c = channel_last ? ond_index.z : ond_index.x;
+    auto h = channel_last ? ond_index.x : ond_index.y;
+    auto w = channel_last ? ond_index.y : ond_index.z;
+    auto gnd_index = make_int3(h, w, 0);
+    auto gidx = device_3d_to_flat(gnd_index, gstride);
+
+    for (auto b = 0; b < B; ++b) {
+      auto b_gidx = gidx + b * gisize;
+      auto xn = grid[b_gidx + 0];
+      auto yn = grid[b_gidx + 1];
+      auto xf0 = unnormalize_grid(xn, Wi);
+      auto yf0 = unnormalize_grid(yn, Hi);
+      auto xf = get_src_findex_with_pad(xf0, Wi);
+      auto yf = get_src_findex_with_pad(yf0, Hi);
+      auto xi0 = static_cast<int>(std::floor(xf));
+      auto yi0 = static_cast<int>(std::floor(yf));
+      auto xi1 = xi0 + 1;
+      auto yi1 = yi0 + 1;
+      auto px0 = xf - xi0;
+      auto py0 = yf - yi0;
+      auto px1 = T(1) - px0;
+      auto py1 = T(1) - py0;
+
+      auto v_y0x0 = get_pixel_value_2d<T, channel_last>(
+          input, b, c, yi0, xi0, Hi, Wi, istride, iisize);
+      auto v_y0x1 = get_pixel_value_2d<T, channel_last>(
+          input, b, c, yi0, xi1, Hi, Wi, istride, iisize);
+      auto v_y1x0 = get_pixel_value_2d<T, channel_last>(
+          input, b, c, yi1, xi0, Hi, Wi, istride, iisize);
+      auto v_y1x1 = get_pixel_value_2d<T, channel_last>(
+          input, b, c, yi1, xi1, Hi, Wi, istride, iisize);
+
+      auto b_oidx = oidx + b * oisize;
+      auto val = (v_y0x0 * py1 * px1) + (v_y0x1 * py1 * px0) +
+                 (v_y1x0 * py0 * px1) + (v_y1x1 * py0 * px0);
+      output[b_oidx] = val;
+    }
+  }
+}
+
+template <typename T, warp_by_grid::PADDING_MODE padding_mode =
+                          warp_by_grid::PADDING_MODE::zero,
+          bool align_corners = false, bool channel_last = false>
+__global__ void kernel_warp_linear_forward_3d(
+    const int oisize, const int iisize, const int gisize, T *output,
+    const T *input, const T *grid, const int4 ishape, const int3 istride,
+    const int3 gstride, const int3 ostride, const int B) {
+  auto Di = channel_last ? ishape.x : ishape.y;
+  auto Hi = channel_last ? ishape.y : ishape.z;
+  auto Wi = channel_last ? ishape.z : ishape.w;
+
+  auto unnormalize_grid = align_corners ? unnormalize_grid_with<T, true>
+                                        : unnormalize_grid_with<T, false>;
+  auto get_src_findex_with_pad = [&](const T s, const Size_t S) {
+    if (padding_mode == warp_by_grid::PADDING_MODE::zero) {
+      return get_src_findex_with_zero_pad(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::reflect) {
+      return align_corners ? get_src_findex_with_reflect_pad<T, true>(s, S)
+                           : get_src_findex_with_reflect_pad<T, false>(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::repeat) {
+      return get_src_findex_with_repeat_pad(s, S);
+    } else {
+      return T(-1);
+    }
+  };
+
+  NBLA_CUDA_KERNEL_LOOP(oidx, oisize) {
+    auto ond_index = device_flat_to_4d(oidx, ostride);
+    auto c = channel_last ? ond_index.w : ond_index.x;
+    auto d = channel_last ? ond_index.x : ond_index.y;
+    auto h = channel_last ? ond_index.y : ond_index.z;
+    auto w = channel_last ? ond_index.z : ond_index.w;
+    auto gnd_index = make_int4(d, h, w, 0);
+    auto gidx = device_4d_to_flat(gnd_index, gstride);
+
+    for (auto b = 0; b < B; ++b) {
+      auto b_gidx = gidx + b * gisize;
+      auto xn = grid[b_gidx + 0];
+      auto yn = grid[b_gidx + 1];
+      auto zn = grid[b_gidx + 2];
+      auto xf0 = unnormalize_grid(xn, Wi);
+      auto yf0 = unnormalize_grid(yn, Hi);
+      auto zf0 = unnormalize_grid(zn, Di);
+      auto xf = get_src_findex_with_pad(xf0, Wi);
+      auto yf = get_src_findex_with_pad(yf0, Hi);
+      auto zf = get_src_findex_with_pad(zf0, Di);
+      auto xi0 = static_cast<int>(std::floor(xf));
+      auto yi0 = static_cast<int>(std::floor(yf));
+      auto zi0 = static_cast<int>(std::floor(zf));
+      auto xi1 = xi0 + 1;
+      auto yi1 = yi0 + 1;
+      auto zi1 = zi0 + 1;
+      auto px0 = xf - xi0;
+      auto py0 = yf - yi0;
+      auto pz0 = zf - zi0;
+      auto px1 = T(1) - px0;
+      auto py1 = T(1) - py0;
+      auto pz1 = T(1) - pz0;
+
+      auto v_z0y0x0 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi0, yi0, xi0, Di, Hi, Wi, istride, iisize);
+      auto v_z0y0x1 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi0, yi0, xi1, Di, Hi, Wi, istride, iisize);
+      auto v_z0y1x0 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi0, yi1, xi0, Di, Hi, Wi, istride, iisize);
+      auto v_z0y1x1 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi0, yi1, xi1, Di, Hi, Wi, istride, iisize);
+      auto v_z1y0x0 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi1, yi0, xi0, Di, Hi, Wi, istride, iisize);
+      auto v_z1y0x1 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi1, yi0, xi1, Di, Hi, Wi, istride, iisize);
+      auto v_z1y1x0 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi1, yi1, xi0, Di, Hi, Wi, istride, iisize);
+      auto v_z1y1x1 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi1, yi1, xi1, Di, Hi, Wi, istride, iisize);
+      auto val = v_z0y0x0 * pz1 * py1 * px1 + v_z0y0x1 * pz1 * py1 * px0 +
+                 v_z0y1x0 * pz1 * py0 * px1 + v_z0y1x1 * pz1 * py0 * px0 +
+                 v_z1y0x0 * pz0 * py1 * px1 + v_z1y0x1 * pz0 * py1 * px0 +
+                 v_z1y1x0 * pz0 * py0 * px1 + v_z1y1x1 * pz0 * py0 * px0;
+
+      auto b_oidx = oidx + b * oisize;
+      output[b_oidx] = val;
+    }
+  }
+}
+
+template <typename T, warp_by_grid::PADDING_MODE padding_mode =
+                          warp_by_grid::PADDING_MODE::zero,
+          bool align_corners = false, bool channel_last = false>
+__global__ void kernel_warp_nearest_forward_2d(
+    const int oisize, const int iisize, const int gisize, T *output,
+    const T *input, const T *grid, const int3 ishape, const int2 istride,
+    const int2 gstride, const int2 ostride, const int B) {
+  auto Hi = channel_last ? ishape.x : ishape.y;
+  auto Wi = channel_last ? ishape.y : ishape.z;
+
+  auto unnormalize_grid = align_corners ? unnormalize_grid_with<T, true>
+                                        : unnormalize_grid_with<T, false>;
+  auto get_src_findex_with_pad = [&](const T s, const Size_t S) {
+    if (padding_mode == warp_by_grid::PADDING_MODE::zero) {
+      return get_src_findex_with_zero_pad(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::reflect) {
+      return align_corners ? get_src_findex_with_reflect_pad<T, true>(s, S)
+                           : get_src_findex_with_reflect_pad<T, false>(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::repeat) {
+      return get_src_findex_with_repeat_pad(s, S);
+    } else {
+      return T(-1);
+    }
+  };
+
+  NBLA_CUDA_KERNEL_LOOP(oidx, oisize) {
+    auto ond_index = device_flat_to_3d(oidx, ostride);
+    auto c = channel_last ? ond_index.z : ond_index.x;
+    auto h = channel_last ? ond_index.x : ond_index.y;
+    auto w = channel_last ? ond_index.y : ond_index.z;
+    auto gnd_index = make_int3(h, w, 0);
+    auto gidx = device_3d_to_flat(gnd_index, gstride);
+
+    for (auto b = 0; b < B; ++b) {
+      auto b_gidx = gidx + b * gisize;
+      auto xn = grid[b_gidx + 0];
+      auto yn = grid[b_gidx + 1];
+      auto xf0 = unnormalize_grid(xn, Wi);
+      auto yf0 = unnormalize_grid(yn, Hi);
+      auto xf = get_src_findex_with_pad(xf0, Wi);
+      auto yf = get_src_findex_with_pad(yf0, Hi);
+      auto xi = static_cast<int>(std::floor(xf + T(0.5)));
+      auto yi = static_cast<int>(std::floor(yf + T(0.5)));
+
+      auto b_oidx = oidx + b * oisize;
+      auto val = get_pixel_value_2d<T, channel_last>(input, b, c, yi, xi, Hi,
+                                                     Wi, istride, iisize);
+      output[b_oidx] = val;
+    }
+  }
+}
+
+template <typename T, warp_by_grid::PADDING_MODE padding_mode =
+                          warp_by_grid::PADDING_MODE::zero,
+          bool align_corners = false, bool channel_last = false>
+__global__ void kernel_warp_nearest_forward_3d(
+    const int oisize, const int iisize, const int gisize, T *output,
+    const T *input, const T *grid, const int4 ishape, const int3 istride,
+    const int3 gstride, const int3 ostride, const int B) {
+  auto Di = channel_last ? ishape.x : ishape.y;
+  auto Hi = channel_last ? ishape.y : ishape.z;
+  auto Wi = channel_last ? ishape.z : ishape.w;
+
+  auto unnormalize_grid = align_corners ? unnormalize_grid_with<T, true>
+                                        : unnormalize_grid_with<T, false>;
+  auto get_src_findex_with_pad = [&](const T s, const Size_t S) {
+    if (padding_mode == warp_by_grid::PADDING_MODE::zero) {
+      return get_src_findex_with_zero_pad(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::reflect) {
+      return align_corners ? get_src_findex_with_reflect_pad<T, true>(s, S)
+                           : get_src_findex_with_reflect_pad<T, false>(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::repeat) {
+      return get_src_findex_with_repeat_pad(s, S);
+    } else {
+      return T(-1);
+    }
+  };
+
+  NBLA_CUDA_KERNEL_LOOP(oidx, oisize) {
+    auto ond_index = device_flat_to_4d(oidx, ostride);
+    auto c = channel_last ? ond_index.w : ond_index.x;
+    auto d = channel_last ? ond_index.x : ond_index.y;
+    auto h = channel_last ? ond_index.y : ond_index.z;
+    auto w = channel_last ? ond_index.z : ond_index.w;
+    auto gnd_index = make_int4(d, h, w, 0);
+    auto gidx = device_4d_to_flat(gnd_index, gstride);
+
+    for (auto b = 0; b < B; ++b) {
+      auto b_gidx = gidx + b * gisize;
+      auto xn = grid[b_gidx + 0];
+      auto yn = grid[b_gidx + 1];
+      auto zn = grid[b_gidx + 2];
+      auto xf0 = unnormalize_grid(xn, Wi);
+      auto yf0 = unnormalize_grid(yn, Hi);
+      auto zf0 = unnormalize_grid(zn, Di);
+      auto xf = get_src_findex_with_pad(xf0, Wi);
+      auto yf = get_src_findex_with_pad(yf0, Hi);
+      auto zf = get_src_findex_with_pad(zf0, Di);
+      auto xi = static_cast<int>(std::floor(xf + T(0.5)));
+      auto yi = static_cast<int>(std::floor(yf + T(0.5)));
+      auto zi = static_cast<int>(std::floor(zf + T(0.5)));
+
+      auto b_oidx = oidx + b * oisize;
+      auto val = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi, yi, xi, Di, Hi, Wi, istride, iisize);
+      output[b_oidx] = val;
+    }
+  }
+}
+
+/*
+  Backward implementations wrt data.
+ */
+
+template <typename T, warp_by_grid::PADDING_MODE padding_mode =
+                          warp_by_grid::PADDING_MODE::zero,
+          bool align_corners = false, bool channel_last = false>
+__global__ void kernel_warp_linear_backward_data_2d(
+    const int oisize, const int iisize, const int gisize, T *igrad,
+    const T *ograd, const T *grid, const int3 ishape, const int2 istride,
+    const int2 gstride, const int2 ostride, const int B) {
+  auto Hi = channel_last ? ishape.x : ishape.y;
+  auto Wi = channel_last ? ishape.y : ishape.z;
+
+  auto unnormalize_grid = align_corners ? unnormalize_grid_with<T, true>
+                                        : unnormalize_grid_with<T, false>;
+  auto get_src_findex_with_pad = [&](const T s, const Size_t S) {
+    if (padding_mode == warp_by_grid::PADDING_MODE::zero) {
+      return get_src_findex_with_zero_pad(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::reflect) {
+      return align_corners ? get_src_findex_with_reflect_pad<T, true>(s, S)
+                           : get_src_findex_with_reflect_pad<T, false>(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::repeat) {
+      return get_src_findex_with_repeat_pad(s, S);
+    } else {
+      return T(-1);
+    }
+  };
+
+  NBLA_CUDA_KERNEL_LOOP(oidx, oisize) {
+    auto ond_index = device_flat_to_3d(oidx, ostride);
+    auto c = channel_last ? ond_index.z : ond_index.x;
+    auto h = channel_last ? ond_index.x : ond_index.y;
+    auto w = channel_last ? ond_index.y : ond_index.z;
+    auto gnd_index = make_int3(h, w, 0);
+    auto gidx = device_3d_to_flat(gnd_index, gstride);
+
+    for (auto b = 0; b < B; ++b) {
+      auto b_gidx = gidx + b * gisize;
+      auto xn = grid[b_gidx + 0];
+      auto yn = grid[b_gidx + 1];
+      auto xf0 = unnormalize_grid(xn, Wi);
+      auto yf0 = unnormalize_grid(yn, Hi);
+      auto xf = get_src_findex_with_pad(xf0, Wi);
+      auto yf = get_src_findex_with_pad(yf0, Hi);
+      auto xi0 = static_cast<int>(std::floor(xf));
+      auto yi0 = static_cast<int>(std::floor(yf));
+      auto xi1 = xi0 + 1;
+      auto yi1 = yi0 + 1;
+      auto px0 = xf - xi0;
+      auto py0 = yf - yi0;
+      auto px1 = T(1) - px0;
+      auto py1 = T(1) - py0;
+
+      auto b_oidx = oidx + b * oisize;
+      auto grad = ograd[b_oidx];
+      backward_data_2d<T, channel_last>(igrad, grad, py1, px1, b, c, yi0, xi0,
+                                        Hi, Wi, istride, iisize);
+      backward_data_2d<T, channel_last>(igrad, grad, py1, px0, b, c, yi0, xi1,
+                                        Hi, Wi, istride, iisize);
+      backward_data_2d<T, channel_last>(igrad, grad, py0, px1, b, c, yi1, xi0,
+                                        Hi, Wi, istride, iisize);
+      backward_data_2d<T, channel_last>(igrad, grad, py0, px0, b, c, yi1, xi1,
+                                        Hi, Wi, istride, iisize);
+    }
+  }
+}
+
+template <typename T, warp_by_grid::PADDING_MODE padding_mode =
+                          warp_by_grid::PADDING_MODE::zero,
+          bool align_corners = false, bool channel_last = false>
+__global__ void kernel_warp_nearest_backward_data_2d(
+    const int oisize, const int iisize, const int gisize, T *igrad,
+    const T *ograd, const T *grid, const int3 ishape, const int2 istride,
+    const int2 gstride, const int2 ostride, const int B) {
+  auto Hi = channel_last ? ishape.x : ishape.y;
+  auto Wi = channel_last ? ishape.y : ishape.z;
+
+  auto unnormalize_grid = align_corners ? unnormalize_grid_with<T, true>
+                                        : unnormalize_grid_with<T, false>;
+  auto get_src_findex_with_pad = [&](const T s, const Size_t S) {
+    if (padding_mode == warp_by_grid::PADDING_MODE::zero) {
+      return get_src_findex_with_zero_pad(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::reflect) {
+      return align_corners ? get_src_findex_with_reflect_pad<T, true>(s, S)
+                           : get_src_findex_with_reflect_pad<T, false>(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::repeat) {
+      return get_src_findex_with_repeat_pad(s, S);
+    } else {
+      return T(-1);
+    }
+  };
+
+  NBLA_CUDA_KERNEL_LOOP(oidx, oisize) {
+    auto ond_index = device_flat_to_3d(oidx, ostride);
+    auto c = channel_last ? ond_index.z : ond_index.x;
+    auto h = channel_last ? ond_index.x : ond_index.y;
+    auto w = channel_last ? ond_index.y : ond_index.z;
+    auto gnd_index = make_int3(h, w, 0);
+    auto gidx = device_3d_to_flat(gnd_index, gstride);
+
+    for (auto b = 0; b < B; ++b) {
+      auto b_gidx = gidx + b * gisize;
+      auto xn = grid[b_gidx + 0];
+      auto yn = grid[b_gidx + 1];
+      auto xf0 = unnormalize_grid(xn, Wi);
+      auto yf0 = unnormalize_grid(yn, Hi);
+      auto xf = get_src_findex_with_pad(xf0, Wi);
+      auto yf = get_src_findex_with_pad(yf0, Hi);
+      auto xi = static_cast<int>(std::floor(xf + T(0.5)));
+      auto yi = static_cast<int>(std::floor(yf + T(0.5)));
+
+      auto b_oidx = oidx + b * oisize;
+      auto grad = ograd[b_oidx];
+      backward_data_2d<T, channel_last>(igrad, grad, T(1.0), T(1.0), b, c, yi,
+                                        xi, Hi, Wi, istride, iisize);
+    }
+  }
+}
+
+template <typename T, warp_by_grid::PADDING_MODE padding_mode =
+                          warp_by_grid::PADDING_MODE::zero,
+          bool align_corners = false, bool channel_last = false>
+__global__ void kernel_warp_linear_backward_data_3d(
+    const int oisize, const int iisize, const int gisize, T *igrad,
+    const T *ograd, const T *grid, const int4 ishape, const int3 istride,
+    const int3 gstride, const int3 ostride, const int B) {
+  auto Di = channel_last ? ishape.x : ishape.y;
+  auto Hi = channel_last ? ishape.y : ishape.z;
+  auto Wi = channel_last ? ishape.z : ishape.w;
+
+  auto unnormalize_grid = align_corners ? unnormalize_grid_with<T, true>
+                                        : unnormalize_grid_with<T, false>;
+  auto get_src_findex_with_pad = [&](const T s, const Size_t S) {
+    if (padding_mode == warp_by_grid::PADDING_MODE::zero) {
+      return get_src_findex_with_zero_pad(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::reflect) {
+      return align_corners ? get_src_findex_with_reflect_pad<T, true>(s, S)
+                           : get_src_findex_with_reflect_pad<T, false>(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::repeat) {
+      return get_src_findex_with_repeat_pad(s, S);
+    } else {
+      return T(-1);
+    }
+  };
+
+  NBLA_CUDA_KERNEL_LOOP(oidx, oisize) {
+    auto ond_index = device_flat_to_4d(oidx, ostride);
+    auto c = channel_last ? ond_index.w : ond_index.x;
+    auto d = channel_last ? ond_index.x : ond_index.y;
+    auto h = channel_last ? ond_index.y : ond_index.z;
+    auto w = channel_last ? ond_index.z : ond_index.w;
+    auto gnd_index = make_int4(d, h, w, 0);
+    auto gidx = device_4d_to_flat(gnd_index, gstride);
+
+    for (auto b = 0; b < B; ++b) {
+      auto b_gidx = gidx + b * gisize;
+      auto xn = grid[b_gidx + 0];
+      auto yn = grid[b_gidx + 1];
+      auto zn = grid[b_gidx + 2];
+      auto xf0 = unnormalize_grid(xn, Wi);
+      auto yf0 = unnormalize_grid(yn, Hi);
+      auto zf0 = unnormalize_grid(zn, Di);
+      auto xf = get_src_findex_with_pad(xf0, Wi);
+      auto yf = get_src_findex_with_pad(yf0, Hi);
+      auto zf = get_src_findex_with_pad(zf0, Di);
+      auto xi0 = static_cast<int>(std::floor(xf));
+      auto yi0 = static_cast<int>(std::floor(yf));
+      auto zi0 = static_cast<int>(std::floor(zf));
+      auto xi1 = xi0 + 1;
+      auto yi1 = yi0 + 1;
+      auto zi1 = zi0 + 1;
+      auto px0 = xf - xi0;
+      auto py0 = yf - yi0;
+      auto pz0 = zf - zi0;
+      auto px1 = T(1) - px0;
+      auto py1 = T(1) - py0;
+      auto pz1 = T(1) - pz0;
+
+      auto b_oidx = oidx + b * oisize;
+      auto grad = ograd[b_oidx];
+      if (channel_last) {
+        backward_data_3d<T, true>(igrad, grad, pz1, py1, px1, b, c, zi0, yi0,
+                                  xi0, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, true>(igrad, grad, pz1, py1, px0, b, c, zi0, yi0,
+                                  xi1, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, true>(igrad, grad, pz1, py0, px1, b, c, zi0, yi1,
+                                  xi0, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, true>(igrad, grad, pz1, py0, px0, b, c, zi0, yi1,
+                                  xi1, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, true>(igrad, grad, pz0, py1, px1, b, c, zi1, yi0,
+                                  xi0, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, true>(igrad, grad, pz0, py1, px0, b, c, zi1, yi0,
+                                  xi1, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, true>(igrad, grad, pz0, py0, px1, b, c, zi1, yi1,
+                                  xi0, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, true>(igrad, grad, pz0, py0, px0, b, c, zi1, yi1,
+                                  xi1, Di, Hi, Wi, istride, iisize);
+      } else {
+        backward_data_3d<T, false>(igrad, grad, pz1, py1, px1, b, c, zi0, yi0,
+                                   xi0, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, false>(igrad, grad, pz1, py1, px0, b, c, zi0, yi0,
+                                   xi1, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, false>(igrad, grad, pz1, py0, px1, b, c, zi0, yi1,
+                                   xi0, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, false>(igrad, grad, pz1, py0, px0, b, c, zi0, yi1,
+                                   xi1, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, false>(igrad, grad, pz0, py1, px1, b, c, zi1, yi0,
+                                   xi0, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, false>(igrad, grad, pz0, py1, px0, b, c, zi1, yi0,
+                                   xi1, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, false>(igrad, grad, pz0, py0, px1, b, c, zi1, yi1,
+                                   xi0, Di, Hi, Wi, istride, iisize);
+        backward_data_3d<T, false>(igrad, grad, pz0, py0, px0, b, c, zi1, yi1,
+                                   xi1, Di, Hi, Wi, istride, iisize);
+      }
+    }
+  }
+}
+
+template <typename T, warp_by_grid::PADDING_MODE padding_mode =
+                          warp_by_grid::PADDING_MODE::zero,
+          bool align_corners = false, bool channel_last = false>
+__global__ void kernel_warp_nearest_backward_data_3d(
+    const int oisize, const int iisize, const int gisize, T *igrad,
+    const T *ograd, const T *grid, const int4 ishape, const int3 istride,
+    const int3 gstride, const int3 ostride, const int B) {
+  auto Di = channel_last ? ishape.x : ishape.y;
+  auto Hi = channel_last ? ishape.y : ishape.z;
+  auto Wi = channel_last ? ishape.z : ishape.w;
+
+  auto unnormalize_grid = align_corners ? unnormalize_grid_with<T, true>
+                                        : unnormalize_grid_with<T, false>;
+  auto get_src_findex_with_pad = [&](const T s, const Size_t S) {
+    if (padding_mode == warp_by_grid::PADDING_MODE::zero) {
+      return get_src_findex_with_zero_pad(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::reflect) {
+      return align_corners ? get_src_findex_with_reflect_pad<T, true>(s, S)
+                           : get_src_findex_with_reflect_pad<T, false>(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::repeat) {
+      return get_src_findex_with_repeat_pad(s, S);
+    } else {
+      return T(-1);
+    }
+  };
+
+  NBLA_CUDA_KERNEL_LOOP(oidx, oisize) {
+    auto ond_index = device_flat_to_4d(oidx, ostride);
+    auto c = channel_last ? ond_index.w : ond_index.x;
+    auto d = channel_last ? ond_index.x : ond_index.y;
+    auto h = channel_last ? ond_index.y : ond_index.z;
+    auto w = channel_last ? ond_index.z : ond_index.w;
+    auto gnd_index = make_int4(d, h, w, 0);
+    auto gidx = device_4d_to_flat(gnd_index, gstride);
+
+    for (auto b = 0; b < B; ++b) {
+      auto b_gidx = gidx + b * gisize;
+      auto xn = grid[b_gidx + 0];
+      auto yn = grid[b_gidx + 1];
+      auto zn = grid[b_gidx + 2];
+      auto xf0 = unnormalize_grid(xn, Wi);
+      auto yf0 = unnormalize_grid(yn, Hi);
+      auto zf0 = unnormalize_grid(zn, Di);
+      auto xf = get_src_findex_with_pad(xf0, Wi);
+      auto yf = get_src_findex_with_pad(yf0, Hi);
+      auto zf = get_src_findex_with_pad(zf0, Di);
+      auto xi = static_cast<int>(std::floor(xf + T(0.5)));
+      auto yi = static_cast<int>(std::floor(yf + T(0.5)));
+      auto zi = static_cast<int>(std::floor(zf + T(0.5)));
+
+      auto b_oidx = oidx + b * oisize;
+      auto grad = ograd[b_oidx];
+      backward_data_3d<T, channel_last>(igrad, grad, T(1.0), T(1.0), T(1.0), b,
+                                        c, zi, yi, xi, Di, Hi, Wi, istride,
+                                        iisize);
+    }
+  }
+}
+
+/*
+  Backward implementations wrt grid.
+ */
+
+template <typename T, warp_by_grid::PADDING_MODE padding_mode =
+                          warp_by_grid::PADDING_MODE::zero,
+          bool align_corners = false, bool channel_last = false>
+__global__ void kernel_warp_linear_backward_grid_2d(
+    const int oisize, const int iisize, const int gisize, T *ggrad,
+    const T *ograd, const T *input, const T *grid, const int3 ishape,
+    const int2 istride, const int2 gstride, const int2 ostride, const int B) {
+  auto Hi = channel_last ? ishape.x : ishape.y;
+  auto Wi = channel_last ? ishape.y : ishape.z;
+
+  auto unnormalize_grid = align_corners ? unnormalize_grid_with<T, true>
+                                        : unnormalize_grid_with<T, false>;
+  auto get_src_findex_with_pad = [&](const T s, const Size_t S) {
+    if (padding_mode == warp_by_grid::PADDING_MODE::zero) {
+      return get_src_findex_with_zero_pad(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::reflect) {
+      return align_corners ? get_src_findex_with_reflect_pad<T, true>(s, S)
+                           : get_src_findex_with_reflect_pad<T, false>(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::repeat) {
+      return get_src_findex_with_repeat_pad(s, S);
+    } else {
+      return T(-1);
+    }
+  };
+  auto get_grad_coef_with_pad = [&](const T s, const Size_t S) {
+    T coef;
+    if (padding_mode == warp_by_grid::PADDING_MODE::zero) {
+      coef = get_grad_coef_with_zero_pad(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::reflect) {
+      coef = align_corners ? get_grad_coef_with_reflect_pad<T, true>(s, S)
+                           : get_grad_coef_with_reflect_pad<T, false>(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::repeat) {
+      coef = get_grad_coef_with_repeat_pad(s, S);
+    } else {
+      return T(0);
+    }
+    return align_corners ? coef * T(S - 1) / T(2) : coef * T(S) / T(2);
+  };
+
+  NBLA_CUDA_KERNEL_LOOP(oidx, oisize) {
+    auto ond_index = device_flat_to_3d(oidx, ostride);
+    auto c = channel_last ? ond_index.z : ond_index.x;
+    auto h = channel_last ? ond_index.x : ond_index.y;
+    auto w = channel_last ? ond_index.y : ond_index.z;
+    auto gnd_index = make_int3(h, w, 0);
+    auto gidx = device_3d_to_flat(gnd_index, gstride);
+
+    for (auto b = 0; b < B; ++b) {
+      auto b_gidx = gidx + b * gisize;
+      auto xn = grid[b_gidx + 0];
+      auto yn = grid[b_gidx + 1];
+      auto xf0 = unnormalize_grid(xn, Wi);
+      auto yf0 = unnormalize_grid(yn, Hi);
+      auto xf = get_src_findex_with_pad(xf0, Wi);
+      auto yf = get_src_findex_with_pad(yf0, Hi);
+      auto xi0 = static_cast<int>(std::floor(xf));
+      auto yi0 = static_cast<int>(std::floor(yf));
+      auto xi1 = xi0 + 1;
+      auto yi1 = yi0 + 1;
+      auto px0 = xf - xi0;
+      auto py0 = yf - yi0;
+      auto px1 = T(1) - px0;
+      auto py1 = T(1) - py0;
+
+      auto v_y0x0 = get_pixel_value_2d<T, channel_last>(
+          input, b, c, yi0, xi0, Hi, Wi, istride, iisize);
+      auto v_y0x1 = get_pixel_value_2d<T, channel_last>(
+          input, b, c, yi0, xi1, Hi, Wi, istride, iisize);
+      auto v_y1x0 = get_pixel_value_2d<T, channel_last>(
+          input, b, c, yi1, xi0, Hi, Wi, istride, iisize);
+      auto v_y1x1 = get_pixel_value_2d<T, channel_last>(
+          input, b, c, yi1, xi1, Hi, Wi, istride, iisize);
+      auto b_oidx = oidx + b * oisize;
+      auto grad = ograd[b_oidx];
+
+      // d_grid = d_output * local_grad{output/pad(x)} * local_grad{pad(x)/x} *
+      // unnormalized_coef
+      auto grad_x = grad * ((v_y0x1 - v_y0x0) * py1 + (v_y1x1 - v_y1x0) * py0);
+      auto grad_y = grad * ((v_y1x0 - v_y0x0) * px1 + (v_y1x1 - v_y0x1) * px0);
+      auto coef_x = get_grad_coef_with_pad(xf0, Wi);
+      auto coef_y = get_grad_coef_with_pad(yf0, Hi);
+      atomic_add(ggrad + b_gidx + 0, grad_x * coef_x);
+      atomic_add(ggrad + b_gidx + 1, grad_y * coef_y);
+    }
+  }
+}
+
+template <typename T, warp_by_grid::PADDING_MODE padding_mode =
+                          warp_by_grid::PADDING_MODE::zero,
+          bool align_corners = false, bool channel_last = false>
+__global__ void kernel_warp_linear_backward_grid_3d(
+    const int oisize, const int iisize, const int gisize, T *ggrad,
+    const T *ograd, const T *input, const T *grid, const int4 ishape,
+    const int3 istride, const int3 gstride, const int3 ostride, const int B) {
+  auto Di = channel_last ? ishape.x : ishape.y;
+  auto Hi = channel_last ? ishape.y : ishape.z;
+  auto Wi = channel_last ? ishape.z : ishape.w;
+
+  auto unnormalize_grid = align_corners ? unnormalize_grid_with<T, true>
+                                        : unnormalize_grid_with<T, false>;
+  auto get_src_findex_with_pad = [&](const T s, const Size_t S) {
+    if (padding_mode == warp_by_grid::PADDING_MODE::zero) {
+      return get_src_findex_with_zero_pad(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::reflect) {
+      return align_corners ? get_src_findex_with_reflect_pad<T, true>(s, S)
+                           : get_src_findex_with_reflect_pad<T, false>(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::repeat) {
+      return get_src_findex_with_repeat_pad(s, S);
+    } else {
+      return T(-1);
+    }
+  };
+  auto get_grad_coef_with_pad = [&](const T s, const Size_t S) {
+    T coef;
+    if (padding_mode == warp_by_grid::PADDING_MODE::zero) {
+      coef = get_grad_coef_with_zero_pad(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::reflect) {
+      coef = align_corners ? get_grad_coef_with_reflect_pad<T, true>(s, S)
+                           : get_grad_coef_with_reflect_pad<T, false>(s, S);
+    } else if (padding_mode == warp_by_grid::PADDING_MODE::repeat) {
+      coef = get_grad_coef_with_repeat_pad(s, S);
+    } else {
+      return T(0);
+    }
+    return align_corners ? coef * T(S - 1) / T(2) : coef * T(S) / T(2);
+  };
+
+  NBLA_CUDA_KERNEL_LOOP(oidx, oisize) {
+    auto ond_index = device_flat_to_4d(oidx, ostride);
+    auto c = channel_last ? ond_index.w : ond_index.x;
+    auto d = channel_last ? ond_index.x : ond_index.y;
+    auto h = channel_last ? ond_index.y : ond_index.z;
+    auto w = channel_last ? ond_index.z : ond_index.w;
+    auto gnd_index = make_int4(d, h, w, 0);
+    auto gidx = device_4d_to_flat(gnd_index, gstride);
+
+    for (auto b = 0; b < B; ++b) {
+      auto b_gidx = gidx + b * gisize;
+      auto xn = grid[b_gidx + 0];
+      auto yn = grid[b_gidx + 1];
+      auto zn = grid[b_gidx + 2];
+      auto xf0 = unnormalize_grid(xn, Wi);
+      auto yf0 = unnormalize_grid(yn, Hi);
+      auto zf0 = unnormalize_grid(zn, Di);
+      auto xf = get_src_findex_with_pad(xf0, Wi);
+      auto yf = get_src_findex_with_pad(yf0, Hi);
+      auto zf = get_src_findex_with_pad(zf0, Di);
+      auto xi0 = static_cast<int>(std::floor(xf));
+      auto yi0 = static_cast<int>(std::floor(yf));
+      auto zi0 = static_cast<int>(std::floor(zf));
+      auto xi1 = xi0 + 1;
+      auto yi1 = yi0 + 1;
+      auto zi1 = zi0 + 1;
+      auto px0 = xf - xi0;
+      auto py0 = yf - yi0;
+      auto pz0 = zf - zi0;
+      auto px1 = T(1) - px0;
+      auto py1 = T(1) - py0;
+      auto pz1 = T(1) - pz0;
+
+      auto v_z0y0x0 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi0, yi0, xi0, Di, Hi, Wi, istride, iisize);
+      auto v_z0y0x1 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi0, yi0, xi1, Di, Hi, Wi, istride, iisize);
+      auto v_z0y1x0 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi0, yi1, xi0, Di, Hi, Wi, istride, iisize);
+      auto v_z0y1x1 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi0, yi1, xi1, Di, Hi, Wi, istride, iisize);
+      auto v_z1y0x0 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi1, yi0, xi0, Di, Hi, Wi, istride, iisize);
+      auto v_z1y0x1 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi1, yi0, xi1, Di, Hi, Wi, istride, iisize);
+      auto v_z1y1x0 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi1, yi1, xi0, Di, Hi, Wi, istride, iisize);
+      auto v_z1y1x1 = get_pixel_value_3d<T, channel_last>(
+          input, b, c, zi1, yi1, xi1, Di, Hi, Wi, istride, iisize);
+      auto b_oidx = oidx + b * oisize;
+      auto grad = ograd[b_oidx];
+
+      // d_grid = d_output * local_grad{output/pad(x)} * local_grad{pad(x)/x} *
+      // unnormalized_coef
+      auto grad_x = grad * ((v_z0y0x1 - v_z0y0x0) * pz1 * py1 +
+                            (v_z0y1x1 - v_z0y1x0) * pz1 * py0 +
+                            (v_z1y0x1 - v_z1y0x0) * pz0 * py1 +
+                            (v_z1y1x1 - v_z1y1x0) * pz0 * py0);
+      auto grad_y = grad * ((v_z0y1x0 - v_z0y0x0) * pz1 * px1 +
+                            (v_z0y1x1 - v_z0y0x1) * pz1 * px0 +
+                            (v_z1y1x0 - v_z1y0x0) * pz0 * px1 +
+                            (v_z1y1x1 - v_z1y0x1) * pz0 * px0);
+      auto grad_z = grad * ((v_z1y0x0 - v_z0y0x0) * py1 * px1 +
+                            (v_z1y0x1 - v_z0y0x1) * py1 * px0 +
+                            (v_z1y1x0 - v_z0y1x0) * py0 * px1 +
+                            (v_z1y1x1 - v_z0y1x1) * py0 * px0);
+      auto coef_x = get_grad_coef_with_pad(xf0, Wi);
+      auto coef_y = get_grad_coef_with_pad(yf0, Hi);
+      auto coef_z = get_grad_coef_with_pad(zf0, Di);
+      atomic_add(ggrad + b_gidx + 0, grad_x * coef_x);
+      atomic_add(ggrad + b_gidx + 1, grad_y * coef_y);
+      atomic_add(ggrad + b_gidx + 2, grad_z * coef_z);
+    }
+  }
+}
+
+template <typename T>
+void WarpByGridCuda<T>::setup_impl(const Variables &inputs,
+                                   const Variables &outputs) {
+  WarpByGrid<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void WarpByGridCuda<T>::forward_impl(const Variables &inputs,
+                                     const Variables &outputs) {
+  cuda_set_device(this->device_);
+  auto ndims = inputs[1]->shape().size();
+  auto channel_last = this->channel_last_;
+  auto align_corners = this->align_corners_;
+  auto padding_mode_t = this->padding_mode_t_;
+  using PADDING_MODE = warp_by_grid::PADDING_MODE;
+  auto zero = PADDING_MODE::zero;
+  auto repeat = PADDING_MODE::repeat;
+  auto reflect = PADDING_MODE::reflect;
+
+  if (ndims == 4) {
+    auto B = inputs[0]->shape()[0];
+    auto Ci = channel_last ? inputs[0]->shape()[3] : inputs[0]->shape()[1];
+    auto Hi = channel_last ? inputs[0]->shape()[1] : inputs[0]->shape()[2];
+    auto Wi = channel_last ? inputs[0]->shape()[2] : inputs[0]->shape()[3];
+    auto Ho = channel_last ? outputs[0]->shape()[1] : outputs[0]->shape()[2];
+    auto Wo = channel_last ? outputs[0]->shape()[2] : outputs[0]->shape()[3];
+
+    auto ishape = channel_last ? make_int3(Hi, Wi, Ci) : make_int3(Ci, Hi, Wi);
+
+    auto istride =
+        channel_last ? make_int2(Wi * Ci, Ci) : make_int2(Hi * Wi, Wi);
+    auto gstride = make_int2(Wo * 2, 2);
+    auto ostride =
+        channel_last ? make_int2(Wo * Ci, Ci) : make_int2(Ho * Wo, Wo);
+
+    auto output = outputs[0]->cast_data_and_get_pointer<Tcu>(this->ctx_);
+    auto input = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+    auto grid = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+
+    auto oisize = Ci * Ho * Wo;
+    auto iisize = Ci * Hi * Wi;
+    auto gisize = Ho * Wo * 2;
+
+    if (this->mode_ == "linear") {
+      if (channel_last) {
+        if (padding_mode_t == zero && align_corners) {
+          auto kernel = kernel_warp_linear_forward_2d<Tcu, PADDING_MODE::zero,
+                                                      true, true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && align_corners) {
+          auto kernel = kernel_warp_linear_forward_2d<Tcu, PADDING_MODE::repeat,
+                                                      true, true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && align_corners) {
+          auto kernel =
+              kernel_warp_linear_forward_2d<Tcu, PADDING_MODE::reflect, true,
+                                            true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == zero && !align_corners) {
+          auto kernel = kernel_warp_linear_forward_2d<Tcu, PADDING_MODE::zero,
+                                                      false, true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && !align_corners) {
+          auto kernel = kernel_warp_linear_forward_2d<Tcu, PADDING_MODE::repeat,
+                                                      false, true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && !align_corners) {
+          auto kernel =
+              kernel_warp_linear_forward_2d<Tcu, PADDING_MODE::reflect, false,
+                                            true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        }
+      } else {
+        if (padding_mode_t == zero && align_corners) {
+          auto kernel = kernel_warp_linear_forward_2d<Tcu, PADDING_MODE::zero,
+                                                      true, false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && align_corners) {
+          auto kernel = kernel_warp_linear_forward_2d<Tcu, PADDING_MODE::repeat,
+                                                      true, false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && align_corners) {
+          auto kernel =
+              kernel_warp_linear_forward_2d<Tcu, PADDING_MODE::reflect, true,
+                                            false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == zero && !align_corners) {
+          auto kernel = kernel_warp_linear_forward_2d<Tcu, PADDING_MODE::zero,
+                                                      false, false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && !align_corners) {
+          auto kernel = kernel_warp_linear_forward_2d<Tcu, PADDING_MODE::repeat,
+                                                      false, false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && !align_corners) {
+          auto kernel =
+              kernel_warp_linear_forward_2d<Tcu, PADDING_MODE::reflect, false,
+                                            false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        }
+      }
+    } else if (this->mode_ == "nearest") {
+      if (channel_last) {
+        if (padding_mode_t == zero && align_corners) {
+          auto kernel = kernel_warp_nearest_forward_2d<Tcu, PADDING_MODE::zero,
+                                                       true, true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_2d<Tcu, PADDING_MODE::repeat, true,
+                                             true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_2d<Tcu, PADDING_MODE::reflect, true,
+                                             true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == zero && !align_corners) {
+          auto kernel = kernel_warp_nearest_forward_2d<Tcu, PADDING_MODE::zero,
+                                                       false, true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && !align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_2d<Tcu, PADDING_MODE::repeat, false,
+                                             true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && !align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_2d<Tcu, PADDING_MODE::reflect, false,
+                                             true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        }
+      } else {
+        if (padding_mode_t == zero && align_corners) {
+          auto kernel = kernel_warp_nearest_forward_2d<Tcu, PADDING_MODE::zero,
+                                                       true, false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_2d<Tcu, PADDING_MODE::repeat, true,
+                                             false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_2d<Tcu, PADDING_MODE::reflect, true,
+                                             false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == zero && !align_corners) {
+          auto kernel = kernel_warp_nearest_forward_2d<Tcu, PADDING_MODE::zero,
+                                                       false, false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && !align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_2d<Tcu, PADDING_MODE::repeat, false,
+                                             false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && !align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_2d<Tcu, PADDING_MODE::reflect, false,
+                                             false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        }
+      }
+    }
+  } else if (ndims == 5) {
+    auto B = inputs[0]->shape()[0];
+    auto Ci = channel_last ? inputs[0]->shape()[4] : inputs[0]->shape()[1];
+    auto Di = channel_last ? inputs[0]->shape()[1] : inputs[0]->shape()[2];
+    auto Hi = channel_last ? inputs[0]->shape()[2] : inputs[0]->shape()[3];
+    auto Wi = channel_last ? inputs[0]->shape()[3] : inputs[0]->shape()[4];
+    auto Do = channel_last ? outputs[0]->shape()[1] : outputs[0]->shape()[2];
+    auto Ho = channel_last ? outputs[0]->shape()[2] : outputs[0]->shape()[3];
+    auto Wo = channel_last ? outputs[0]->shape()[3] : outputs[0]->shape()[4];
+
+    auto ishape =
+        channel_last ? make_int4(Di, Hi, Wi, Ci) : make_int4(Ci, Di, Hi, Wi);
+
+    auto istride = channel_last ? make_int3(Hi * Wi * Ci, Wi * Ci, Ci)
+                                : make_int3(Di * Hi * Wi, Hi * Wi, Wi);
+    auto gstride = make_int3(Ho * Wo * 3, Wo * 3, 3);
+    auto ostride = channel_last ? make_int3(Ho * Wo * Ci, Wo * Ci, Ci)
+                                : make_int3(Do * Ho * Wo, Ho * Wo, Wo);
+
+    auto output = outputs[0]->cast_data_and_get_pointer<Tcu>(this->ctx_);
+    auto input = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+    auto grid = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+
+    auto oisize = Ci * Do * Ho * Wo;
+    auto iisize = Ci * Di * Hi * Wi;
+    auto gisize = Do * Ho * Wo * 3;
+
+    if (this->mode_ == "linear") {
+      if (channel_last) {
+        if (padding_mode_t == zero && align_corners) {
+          auto kernel = kernel_warp_linear_forward_3d<Tcu, PADDING_MODE::zero,
+                                                      true, true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && align_corners) {
+          auto kernel = kernel_warp_linear_forward_3d<Tcu, PADDING_MODE::repeat,
+                                                      true, true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && align_corners) {
+          auto kernel =
+              kernel_warp_linear_forward_3d<Tcu, PADDING_MODE::reflect, true,
+                                            true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == zero && !align_corners) {
+          auto kernel = kernel_warp_linear_forward_3d<Tcu, PADDING_MODE::zero,
+                                                      false, true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && !align_corners) {
+          auto kernel = kernel_warp_linear_forward_3d<Tcu, PADDING_MODE::repeat,
+                                                      false, true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && !align_corners) {
+          auto kernel =
+              kernel_warp_linear_forward_3d<Tcu, PADDING_MODE::reflect, false,
+                                            true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        }
+      } else {
+        if (padding_mode_t == zero && align_corners) {
+          auto kernel = kernel_warp_linear_forward_3d<Tcu, PADDING_MODE::zero,
+                                                      true, false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && align_corners) {
+          auto kernel = kernel_warp_linear_forward_3d<Tcu, PADDING_MODE::repeat,
+                                                      true, false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && align_corners) {
+          auto kernel =
+              kernel_warp_linear_forward_3d<Tcu, PADDING_MODE::reflect, true,
+                                            false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == zero && !align_corners) {
+          auto kernel = kernel_warp_linear_forward_3d<Tcu, PADDING_MODE::zero,
+                                                      false, false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && !align_corners) {
+          auto kernel = kernel_warp_linear_forward_3d<Tcu, PADDING_MODE::repeat,
+                                                      false, false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && !align_corners) {
+          auto kernel =
+              kernel_warp_linear_forward_3d<Tcu, PADDING_MODE::reflect, false,
+                                            false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        }
+      }
+    } else if (this->mode_ == "nearest") {
+      if (channel_last) {
+        if (padding_mode_t == zero && align_corners) {
+          auto kernel = kernel_warp_nearest_forward_3d<Tcu, PADDING_MODE::zero,
+                                                       true, true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_3d<Tcu, PADDING_MODE::repeat, true,
+                                             true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_3d<Tcu, PADDING_MODE::reflect, true,
+                                             true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == zero && !align_corners) {
+          auto kernel = kernel_warp_nearest_forward_3d<Tcu, PADDING_MODE::zero,
+                                                       false, true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && !align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_3d<Tcu, PADDING_MODE::repeat, false,
+                                             true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && !align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_3d<Tcu, PADDING_MODE::reflect, false,
+                                             true>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        }
+      } else {
+        if (padding_mode_t == zero && align_corners) {
+          auto kernel = kernel_warp_nearest_forward_3d<Tcu, PADDING_MODE::zero,
+                                                       true, false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_3d<Tcu, PADDING_MODE::repeat, true,
+                                             false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_3d<Tcu, PADDING_MODE::reflect, true,
+                                             false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == zero && !align_corners) {
+          auto kernel = kernel_warp_nearest_forward_3d<Tcu, PADDING_MODE::zero,
+                                                       false, false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == repeat && !align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_3d<Tcu, PADDING_MODE::repeat, false,
+                                             false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        } else if (padding_mode_t == reflect && !align_corners) {
+          auto kernel =
+              kernel_warp_nearest_forward_3d<Tcu, PADDING_MODE::reflect, false,
+                                             false>;
+          NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize, output,
+                                         input, grid, ishape, istride, gstride,
+                                         ostride, B);
+        }
+      }
+    }
+  }
+}
+
+template <typename T>
+void WarpByGridCuda<T>::backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum) {
+  if (!(propagate_down[0] || propagate_down[1])) {
+    return;
+  }
+  cuda_set_device(this->device_);
+  auto ndims = inputs[1]->shape().size();
+  auto channel_last = this->channel_last_;
+  auto align_corners = this->align_corners_;
+  auto padding_mode_t = this->padding_mode_t_;
+  using PADDING_MODE = warp_by_grid::PADDING_MODE;
+  auto zero = PADDING_MODE::zero;
+  auto repeat = PADDING_MODE::repeat;
+  auto reflect = PADDING_MODE::reflect;
+
+  // w.r.t. data
+  if (propagate_down[0]) {
+    if (ndims == 4) {
+      auto B = inputs[0]->shape()[0];
+      auto Ci = channel_last ? inputs[0]->shape()[3] : inputs[0]->shape()[1];
+      auto Hi = channel_last ? inputs[0]->shape()[1] : inputs[0]->shape()[2];
+      auto Wi = channel_last ? inputs[0]->shape()[2] : inputs[0]->shape()[3];
+      auto Ho = channel_last ? outputs[0]->shape()[1] : outputs[0]->shape()[2];
+      auto Wo = channel_last ? outputs[0]->shape()[2] : outputs[0]->shape()[3];
+
+      auto ishape =
+          channel_last ? make_int3(Hi, Wi, Ci) : make_int3(Ci, Hi, Wi);
+
+      auto istride =
+          channel_last ? make_int2(Wi * Ci, Ci) : make_int2(Hi * Wi, Wi);
+      auto gstride = make_int2(Wo * 2, 2);
+      auto ostride =
+          channel_last ? make_int2(Wo * Ci, Ci) : make_int2(Ho * Wo, Wo);
+
+      auto output = outputs[0]->get_data_pointer<Tcu>(this->ctx_);
+      auto input = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+      auto grid = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+      auto ograd = outputs[0]->get_grad_pointer<Tcu>(this->ctx_);
+      auto igrad = inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_);
+      auto ggrad = inputs[1]->cast_grad_and_get_pointer<Tcu>(this->ctx_);
+
+      auto oisize = Ci * Ho * Wo;
+      auto iisize = Ci * Hi * Wi;
+      auto gisize = Ho * Wo * 2;
+
+      if (this->mode_ == "linear") {
+        if (channel_last) {
+          if (padding_mode_t == zero && align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_2d<Tcu, PADDING_MODE::zero,
+                                                    true, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_2d<Tcu, PADDING_MODE::repeat,
+                                                    true, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_2d<Tcu, PADDING_MODE::reflect,
+                                                    true, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == zero && !align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_2d<Tcu, PADDING_MODE::zero,
+                                                    false, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && !align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_2d<Tcu, PADDING_MODE::repeat,
+                                                    false, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && !align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_2d<Tcu, PADDING_MODE::reflect,
+                                                    false, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          }
+        } else {
+          if (padding_mode_t == zero && align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_2d<Tcu, PADDING_MODE::zero,
+                                                    true, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_2d<Tcu, PADDING_MODE::repeat,
+                                                    true, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_2d<Tcu, PADDING_MODE::reflect,
+                                                    true, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == zero && !align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_2d<Tcu, PADDING_MODE::zero,
+                                                    false, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && !align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_2d<Tcu, PADDING_MODE::repeat,
+                                                    false, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && !align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_2d<Tcu, PADDING_MODE::reflect,
+                                                    false, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          }
+        }
+      } else if (this->mode_ == "nearest") {
+        if (channel_last) {
+          if (padding_mode_t == zero && align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_2d<Tcu, PADDING_MODE::zero,
+                                                     true, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_2d<Tcu, PADDING_MODE::repeat,
+                                                     true, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_2d<Tcu, PADDING_MODE::reflect,
+                                                     true, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == zero && !align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_2d<Tcu, PADDING_MODE::zero,
+                                                     false, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && !align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_2d<Tcu, PADDING_MODE::repeat,
+                                                     false, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && !align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_2d<Tcu, PADDING_MODE::reflect,
+                                                     false, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          }
+        } else {
+          if (padding_mode_t == zero && align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_2d<Tcu, PADDING_MODE::zero,
+                                                     true, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_2d<Tcu, PADDING_MODE::repeat,
+                                                     true, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_2d<Tcu, PADDING_MODE::reflect,
+                                                     true, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == zero && !align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_2d<Tcu, PADDING_MODE::zero,
+                                                     false, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && !align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_2d<Tcu, PADDING_MODE::repeat,
+                                                     false, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && !align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_2d<Tcu, PADDING_MODE::reflect,
+                                                     false, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          }
+        }
+      }
+    } else if (ndims == 5) {
+      auto B = inputs[0]->shape()[0];
+      auto Ci = channel_last ? inputs[0]->shape()[4] : inputs[0]->shape()[1];
+      auto Di = channel_last ? inputs[0]->shape()[1] : inputs[0]->shape()[2];
+      auto Hi = channel_last ? inputs[0]->shape()[2] : inputs[0]->shape()[3];
+      auto Wi = channel_last ? inputs[0]->shape()[3] : inputs[0]->shape()[4];
+      auto Do = channel_last ? outputs[0]->shape()[1] : outputs[0]->shape()[2];
+      auto Ho = channel_last ? outputs[0]->shape()[2] : outputs[0]->shape()[3];
+      auto Wo = channel_last ? outputs[0]->shape()[3] : outputs[0]->shape()[4];
+
+      auto ishape =
+          channel_last ? make_int4(Di, Hi, Wi, Ci) : make_int4(Ci, Di, Hi, Wi);
+
+      auto istride = channel_last ? make_int3(Hi * Wi * Ci, Wi * Ci, Ci)
+                                  : make_int3(Di * Hi * Wi, Hi * Wi, Wi);
+      auto gstride = make_int3(Ho * Wo * 3, Wo * 3, 3);
+      auto ostride = channel_last ? make_int3(Ho * Wo * Ci, Wo * Ci, Ci)
+                                  : make_int3(Do * Ho * Wo, Ho * Wo, Wo);
+
+      auto output = outputs[0]->get_data_pointer<Tcu>(this->ctx_);
+      auto input = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+      auto grid = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+      auto ograd = outputs[0]->get_grad_pointer<Tcu>(this->ctx_);
+      auto igrad = inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_);
+      auto ggrad = inputs[1]->cast_grad_and_get_pointer<Tcu>(this->ctx_);
+
+      auto oisize = Ci * Do * Ho * Wo;
+      auto iisize = Ci * Di * Hi * Wi;
+      auto gisize = Do * Ho * Wo * 3;
+
+      if (this->mode_ == "linear") {
+        if (channel_last) {
+          if (padding_mode_t == zero && align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_3d<Tcu, PADDING_MODE::zero,
+                                                    true, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_3d<Tcu, PADDING_MODE::repeat,
+                                                    true, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_3d<Tcu, PADDING_MODE::reflect,
+                                                    true, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == zero && !align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_3d<Tcu, PADDING_MODE::zero,
+                                                    false, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && !align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_3d<Tcu, PADDING_MODE::repeat,
+                                                    false, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && !align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_3d<Tcu, PADDING_MODE::reflect,
+                                                    false, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          }
+        } else {
+          if (padding_mode_t == zero && align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_3d<Tcu, PADDING_MODE::zero,
+                                                    true, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_3d<Tcu, PADDING_MODE::repeat,
+                                                    true, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_3d<Tcu, PADDING_MODE::reflect,
+                                                    true, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == zero && !align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_3d<Tcu, PADDING_MODE::zero,
+                                                    false, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && !align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_3d<Tcu, PADDING_MODE::repeat,
+                                                    false, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && !align_corners) {
+            auto kernel =
+                kernel_warp_linear_backward_data_3d<Tcu, PADDING_MODE::reflect,
+                                                    false, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          }
+        }
+      } else if (this->mode_ == "nearest") {
+        if (channel_last) {
+          if (padding_mode_t == zero && align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_3d<Tcu, PADDING_MODE::zero,
+                                                     true, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_3d<Tcu, PADDING_MODE::repeat,
+                                                     true, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_3d<Tcu, PADDING_MODE::reflect,
+                                                     true, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == zero && !align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_3d<Tcu, PADDING_MODE::zero,
+                                                     false, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && !align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_3d<Tcu, PADDING_MODE::repeat,
+                                                     false, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && !align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_3d<Tcu, PADDING_MODE::reflect,
+                                                     false, true>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          }
+        } else {
+          if (padding_mode_t == zero && align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_3d<Tcu, PADDING_MODE::zero,
+                                                     true, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_3d<Tcu, PADDING_MODE::repeat,
+                                                     true, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_3d<Tcu, PADDING_MODE::reflect,
+                                                     true, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == zero && !align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_3d<Tcu, PADDING_MODE::zero,
+                                                     false, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == repeat && !align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_3d<Tcu, PADDING_MODE::repeat,
+                                                     false, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          } else if (padding_mode_t == reflect && !align_corners) {
+            auto kernel =
+                kernel_warp_nearest_backward_data_3d<Tcu, PADDING_MODE::reflect,
+                                                     false, false>;
+            NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                           igrad, ograd, grid, ishape, istride,
+                                           gstride, ostride, B);
+          }
+        }
+      }
+    }
+
+    // w.r.t. grid
+    if (propagate_down[1]) {
+      if (ndims == 4) {
+        auto B = inputs[0]->shape()[0];
+        auto Ci = channel_last ? inputs[0]->shape()[3] : inputs[0]->shape()[1];
+        auto Hi = channel_last ? inputs[0]->shape()[1] : inputs[0]->shape()[2];
+        auto Wi = channel_last ? inputs[0]->shape()[2] : inputs[0]->shape()[3];
+        auto Ho =
+            channel_last ? outputs[0]->shape()[1] : outputs[0]->shape()[2];
+        auto Wo =
+            channel_last ? outputs[0]->shape()[2] : outputs[0]->shape()[3];
+
+        auto ishape =
+            channel_last ? make_int3(Hi, Wi, Ci) : make_int3(Ci, Hi, Wi);
+
+        auto istride =
+            channel_last ? make_int2(Wi * Ci, Ci) : make_int2(Hi * Wi, Wi);
+        auto gstride = make_int2(Wo * 2, 2);
+        auto ostride =
+            channel_last ? make_int2(Wo * Ci, Ci) : make_int2(Ho * Wo, Wo);
+
+        auto output = outputs[0]->get_data_pointer<Tcu>(this->ctx_);
+        auto input = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+        auto grid = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+        auto ograd = outputs[0]->get_grad_pointer<Tcu>(this->ctx_);
+        auto igrad = inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_);
+        auto ggrad = inputs[1]->cast_grad_and_get_pointer<Tcu>(this->ctx_);
+
+        auto oisize = Ci * Ho * Wo;
+        auto iisize = Ci * Hi * Wi;
+        auto gisize = Ho * Wo * 2;
+
+        if (this->mode_ == "linear") {
+          if (channel_last) {
+            if (padding_mode_t == zero && align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_2d<Tcu, PADDING_MODE::zero,
+                                                      true, true>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == repeat && align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_2d<Tcu, PADDING_MODE::repeat,
+                                                      true, true>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == reflect && align_corners) {
+              auto kernel = kernel_warp_linear_backward_grid_2d<
+                  Tcu, PADDING_MODE::reflect, true, true>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == zero && !align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_2d<Tcu, PADDING_MODE::zero,
+                                                      false, true>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == repeat && !align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_2d<Tcu, PADDING_MODE::repeat,
+                                                      false, true>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == reflect && !align_corners) {
+              auto kernel = kernel_warp_linear_backward_grid_2d<
+                  Tcu, PADDING_MODE::reflect, false, true>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            }
+          } else {
+            if (padding_mode_t == zero && align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_2d<Tcu, PADDING_MODE::zero,
+                                                      true, false>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == repeat && align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_2d<Tcu, PADDING_MODE::repeat,
+                                                      true, false>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == reflect && align_corners) {
+              auto kernel = kernel_warp_linear_backward_grid_2d<
+                  Tcu, PADDING_MODE::reflect, true, false>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == zero && !align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_2d<Tcu, PADDING_MODE::zero,
+                                                      false, false>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == repeat && !align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_2d<Tcu, PADDING_MODE::repeat,
+                                                      false, false>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == reflect && !align_corners) {
+              auto kernel = kernel_warp_linear_backward_grid_2d<
+                  Tcu, PADDING_MODE::reflect, false, false>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            }
+          }
+        } else if (this->mode_ == "nearest") {
+          NBLA_ERROR(
+              error_code::not_implemented,
+              "Backward wrt the grid is not supported in the nearest mode. "
+              "Use the `linear` mode.");
+        }
+      } else if (ndims == 5) {
+        auto B = inputs[0]->shape()[0];
+        auto Ci = channel_last ? inputs[0]->shape()[4] : inputs[0]->shape()[1];
+        auto Di = channel_last ? inputs[0]->shape()[1] : inputs[0]->shape()[2];
+        auto Hi = channel_last ? inputs[0]->shape()[2] : inputs[0]->shape()[3];
+        auto Wi = channel_last ? inputs[0]->shape()[3] : inputs[0]->shape()[4];
+        auto Do =
+            channel_last ? outputs[0]->shape()[1] : outputs[0]->shape()[2];
+        auto Ho =
+            channel_last ? outputs[0]->shape()[2] : outputs[0]->shape()[3];
+        auto Wo =
+            channel_last ? outputs[0]->shape()[3] : outputs[0]->shape()[4];
+
+        auto ishape = channel_last ? make_int4(Di, Hi, Wi, Ci)
+                                   : make_int4(Ci, Di, Hi, Wi);
+
+        auto istride = channel_last ? make_int3(Hi * Wi * Ci, Wi * Ci, Ci)
+                                    : make_int3(Di * Hi * Wi, Hi * Wi, Wi);
+        auto gstride = make_int3(Ho * Wo * 3, Wo * 3, 3);
+        auto ostride = channel_last ? make_int3(Ho * Wo * Ci, Wo * Ci, Ci)
+                                    : make_int3(Do * Ho * Wo, Ho * Wo, Wo);
+
+        auto output = outputs[0]->get_data_pointer<Tcu>(this->ctx_);
+        auto input = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+        auto grid = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+        auto ograd = outputs[0]->get_grad_pointer<Tcu>(this->ctx_);
+        auto igrad = inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_);
+        auto ggrad = inputs[1]->cast_grad_and_get_pointer<Tcu>(this->ctx_);
+
+        auto oisize = Ci * Do * Ho * Wo;
+        auto iisize = Ci * Di * Hi * Wi;
+        auto gisize = Do * Ho * Wo * 3;
+
+        if (this->mode_ == "linear") {
+          if (channel_last) {
+            if (padding_mode_t == zero && align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_3d<Tcu, PADDING_MODE::zero,
+                                                      true, true>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == repeat && align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_3d<Tcu, PADDING_MODE::repeat,
+                                                      true, true>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == reflect && align_corners) {
+              auto kernel = kernel_warp_linear_backward_grid_3d<
+                  Tcu, PADDING_MODE::reflect, true, true>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == zero && !align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_3d<Tcu, PADDING_MODE::zero,
+                                                      false, true>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == repeat && !align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_3d<Tcu, PADDING_MODE::repeat,
+                                                      false, true>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == reflect && !align_corners) {
+              auto kernel = kernel_warp_linear_backward_grid_3d<
+                  Tcu, PADDING_MODE::reflect, false, true>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            }
+          } else {
+            if (padding_mode_t == zero && align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_3d<Tcu, PADDING_MODE::zero,
+                                                      true, false>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == repeat && align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_3d<Tcu, PADDING_MODE::repeat,
+                                                      true, false>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == reflect && align_corners) {
+              auto kernel = kernel_warp_linear_backward_grid_3d<
+                  Tcu, PADDING_MODE::reflect, true, false>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == zero && !align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_3d<Tcu, PADDING_MODE::zero,
+                                                      false, false>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == repeat && !align_corners) {
+              auto kernel =
+                  kernel_warp_linear_backward_grid_3d<Tcu, PADDING_MODE::repeat,
+                                                      false, false>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            } else if (padding_mode_t == reflect && !align_corners) {
+              auto kernel = kernel_warp_linear_backward_grid_3d<
+                  Tcu, PADDING_MODE::reflect, false, false>;
+              NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, oisize, iisize, gisize,
+                                             ggrad, ograd, input, grid, ishape,
+                                             istride, gstride, ostride, B);
+            }
+          }
+        } else if (this->mode_ == "nearest") {
+          NBLA_ERROR(
+              error_code::not_implemented,
+              "Backward wrt the grid is not supported in the nearest mode. "
+              "Use the `linear` mode.");
+        }
+      }
+    }
+  }
+}
+}


### PR DESCRIPTION
Spatial Transformer is composed of two functions:

-  AffineGrid (2d/3d) generates the normalized grid by the affine transformation.
-  WarpByGrid (2d/3d, linear/nearest, channel_first/last, zero/repeat/reflect pad) warps the input image by the grid generated by AffineGrid.