### PR TITLE
add watch dog for those might cause dead-waiting functions

### DIFF
--- a/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
@@ -22,6 +22,7 @@
 #include <nbla/context.hpp>
 #include <nbla/cuda/array/cuda_array.hpp>
 #include <nbla/cuda/communicator/nccl_utils.hpp>
+#include <nbla/cuda/communicator/watch_dog.hpp>
 #include <nbla/variable.hpp>
 
 #include <memory>
@@ -59,6 +60,8 @@ template <typename T>
 class NBLA_API MultiProcessDataParallelCommunicatorNccl
     : public MultiProcessDataParallelCommunicator<T> {
 protected:
+  int all_reduce_timeout_ = 30; // timeout=3s
+  Watchdog watch_dog_;
   int device_id_;
 
   static bool mpi_initialized_;
@@ -145,6 +148,9 @@ public:
                           const string &group = "world");
   virtual CommunicatorBackwardCallbackPtr
   all_reduce_callback(const vector<NdArrayPtr> &ndarray_list, size_t pack_size,
+                      bool division = false, const string &group = "world");
+  virtual CommunicatorBackwardCallbackPtr
+  all_reduce_callback(NdArrayPtr ndarray, size_t pack_size,
                       bool division = false, const string &group = "world");
   virtual void reduce_scatter(const vector<NdArrayPtr> &ndarray_list,
                               NdArrayPtr ndarray, bool division = false,

--- a/include/nbla/cuda/communicator/watch_dog.hpp
+++ b/include/nbla/cuda/communicator/watch_dog.hpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2020 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+namespace nbla {
+
+class Watchdog {
+private:
+  static const int TIMEOUT_TICKS = 100;    // default timeout is 10s
+  static const int TICK = 100;             // 100 ms each tick
+  static const int STOP_WATCH_DOG = -1000; // arbitrary negative value
+  static const int EXIT_WATCH_DOG = 1;     // exit flag
+  static const int START_WATCH_DOG = 1;    // a positive value to start
+  int state_;
+  int exit_flag_;
+  int timeout_ticks_;
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  int bootup_flag_;
+  std::mutex bootup_;
+  std::condition_variable bcv_;
+  bool in_lock_;
+  std::thread thread_;
+  void watch_dog_loop();
+
+public:
+  Watchdog(int timeout_ticks = TIMEOUT_TICKS);
+  ~Watchdog();
+  friend class WatchdogLock;
+  class WatchdogLock {
+  public:
+    WatchdogLock(Watchdog &wd, int timeout_ticks = -1);
+    ~WatchdogLock();
+
+  private:
+    Watchdog &wd_;
+    int previous_timeout_;
+  };
+};
+}

--- a/src/nbla/cuda/CMakeLists.txt
+++ b/src/nbla/cuda/CMakeLists.txt
@@ -100,6 +100,7 @@ set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};${ARCH_FLAGS}")
 
 file(GLOB CPP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
   ./*.cpp
+  communicator/*.cpp
   memory/*.cpp
   array/*.cpp
   cudnn/*.cpp

--- a/src/nbla/cuda/communicator/watch_dog.cpp
+++ b/src/nbla/cuda/communicator/watch_dog.cpp
@@ -1,0 +1,85 @@
+// Copyright (c) 2020 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <nbla/cuda/communicator/watch_dog.hpp>
+#include <nbla/exception.hpp>
+#include <stdio.h>
+
+namespace nbla {
+void Watchdog::watch_dog_loop() {
+  std::unique_lock<std::mutex> lck(mutex_);
+  {
+    std::unique_lock<std::mutex> blck(bootup_);
+    bootup_flag_ = 1;
+    bcv_.notify_one();
+  }
+  while (!exit_flag_) {
+    if (state_ == START_WATCH_DOG) {
+      std::cv_status r =
+          cv_.wait_for(lck, std::chrono::milliseconds(TICK * timeout_ticks_));
+      if (r == std::cv_status::timeout) {
+        NBLA_ERROR(error_code::runtime,
+                   "System stop response within %8.2f seconds!",
+                   (TICK * timeout_ticks_) / 1000.0);
+      }
+    } else {
+      cv_.wait(lck);
+    }
+  }
+}
+
+Watchdog::Watchdog(int timeout_ticks)
+    : state_(0), exit_flag_(0), timeout_ticks_(timeout_ticks), mutex_(), cv_(),
+      bootup_flag_(0), bootup_(), bcv_(), in_lock_(false),
+      thread_(&Watchdog::watch_dog_loop, this) {
+  std::unique_lock<std::mutex> lck(bootup_);
+  while (!bootup_flag_)
+    bcv_.wait(lck);
+}
+
+Watchdog::~Watchdog() {
+  {
+    std::unique_lock<std::mutex> lck(mutex_);
+    exit_flag_ = 1;
+    state_ = STOP_WATCH_DOG;
+    cv_.notify_one();
+  }
+  thread_.join();
+}
+
+Watchdog::WatchdogLock::WatchdogLock(Watchdog &wd, int timeout_ticks)
+    : wd_(wd), previous_timeout_(-1) {
+  if (wd_.in_lock_) {
+    NBLA_ERROR(error_code::value, "Watchdog lock nested is not allowed.");
+  }
+  wd_.in_lock_ = true;
+  std::unique_lock<std::mutex> lck(wd_.mutex_);
+  if (timeout_ticks > 0) {
+    previous_timeout_ = wd_.timeout_ticks_;
+    wd_.timeout_ticks_ = timeout_ticks;
+  }
+  wd_.state_ = START_WATCH_DOG;
+  wd_.cv_.notify_all();
+}
+
+Watchdog::WatchdogLock::~WatchdogLock() {
+  std::unique_lock<std::mutex> lck(wd_.mutex_);
+  wd_.state_ = STOP_WATCH_DOG;
+  if (previous_timeout_ != -1)
+    wd_.timeout_ticks_ = previous_timeout_;
+  wd_.cv_.notify_all();
+  wd_.in_lock_ = false;
+}
+}

--- a/src/nbla/cuda/test/test_watch_dog.cpp
+++ b/src/nbla/cuda/test/test_watch_dog.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2020 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gtest/gtest.h"
+#include <chrono>
+#include <nbla/cuda/communicator/watch_dog.hpp>
+#include <nbla/exception.hpp>
+#include <thread>
+
+#include <stdio.h>
+
+namespace nbla {
+
+TEST(WatchDogTest, SimpleConstructWatchdog) { Watchdog watch_dog; }
+
+TEST(WatchDogTest, TestFinishedInTime) {
+  Watchdog watch_dog;
+  {
+    Watchdog::WatchdogLock lck(watch_dog);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+}
+
+TEST(WatchDogTest, TestMultiTimeCheck) {
+  Watchdog watch_dog(2);
+  for (int i = 0; i < 8; ++i) {
+    Watchdog::WatchdogLock lck(watch_dog);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+}
+
+TEST(WatchDogTest, NotAllowNested) {
+  try {
+    Watchdog watch_dog(5);
+    {
+      Watchdog::WatchdogLock lck(watch_dog);
+      Watchdog::WatchdogLock lck1(watch_dog);
+      FAIL() << "Not raise an exception";
+    }
+  } catch (const Exception &expected) {
+    printf("catched exception!\n");
+  }
+}
+
+TEST(WatchDogTest, TestLocalTimeoutSetting) {
+  Watchdog watch_dog(3);
+  {
+    Watchdog::WatchdogLock lck(watch_dog, 2);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  {
+    Watchdog::WatchdogLock lck(watch_dog, 3);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+  {
+    Watchdog::WatchdogLock lck(watch_dog, 4);
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  }
+}
+
+#if 0
+// These 2 cases are skipped.
+// This one is due to too long testing time.
+TEST(WatchDogTest, LongTimeoutTest) {
+  Watchdog watch_dog;
+  Watchdog::WatchdogLock lck(watch_dog, 150);
+  std::this_thread::sleep_for(std::chrono::milliseconds(14900));
+}
+
+// This one is that it can cause test stopped with error.
+// Since the exception from watchdog thread cannot be catched
+// in caller thread.
+TEST(WatchDogTest, TestFinishedOutTime) {
+  try {
+     Watchdog watch_dog(5);
+     {
+       Watchdog::WatchdogLock lck(watch_dog);
+       std::this_thread::sleep_for(std::chrono::milliseconds(700));
+       FAIL() << "Not raise an exception";
+     }
+  }
+  catch(const Exception& expected) {
+      printf("catched exception!\n");
+  }
+}
+#endif
+}


### PR DESCRIPTION
- Add a watchdog class, which created a guard thread, waiting for a specified time.
- RAII-similar idiom is used for starting and stopping watch dog clock, by WatchdogLock class
- Throw an exception when specified timeout is out and watch dog lock is still unlock.
- In any scope, if placing a WatchdogLock, we can protect this scope from dead-waiting