### PR TITLE
extend the timeout of all_reduce to avoid CI error

### DIFF
--- a/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
@@ -60,7 +60,7 @@ template <typename T>
 class NBLA_API MultiProcessDataParallelCommunicatorNccl
     : public MultiProcessDataParallelCommunicator<T> {
 protected:
-  int all_reduce_timeout_ = 30; // timeout=3s
+  int all_reduce_timeout_ = 100; // timeout=10s
   Watchdog watch_dog_;
   int device_id_;
 


### PR DESCRIPTION
We found CI error caused by exceed all_reduce's 3 seconds waiting, in order to

avoid CI error
We extend the timeout of all_reduce to 10 seconds.