### PR TITLE
extend watch dog time so not too sensitive

### DIFF
--- a/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
@@ -60,7 +60,7 @@ template <typename T>
 class NBLA_API MultiProcessDataParallelCommunicatorNccl
     : public MultiProcessDataParallelCommunicator<T> {
 protected:
-  int all_reduce_timeout_ = 100; // timeout=10s
+  int all_reduce_timeout_ = 500; // timeout=50s
   Watchdog watch_dog_;
   int device_id_;
 

--- a/include/nbla/cuda/communicator/watch_dog.hpp
+++ b/include/nbla/cuda/communicator/watch_dog.hpp
@@ -19,7 +19,7 @@ namespace nbla {
 
 class Watchdog {
 private:
-  static const int TIMEOUT_TICKS = 100;    // default timeout is 10s
+  static const int TIMEOUT_TICKS = 600;    // default timeout is 60s
   static const int TICK = 100;             // 100 ms each tick
   static const int STOP_WATCH_DOG = -1000; // arbitrary negative value
   static const int EXIT_WATCH_DOG = 1;     // exit flag


### PR DESCRIPTION
- Extend watchdog time to avoid too sensitive

For some reason, different nodes starting to work seems from very different start time point, so that init() will take more than 10 seconds, which trigger watchdog unexpectedly. Extending watchdog time is helpful to ensure no response case by a related long time.  
