### PR TITLE
Inplace for unary/binary arithmetic functions

### DIFF
--- a/include/nbla/cuda/function/add_scalar.hpp
+++ b/include/nbla/cuda/function/add_scalar.hpp
@@ -22,6 +22,6 @@ namespace nbla {
 
 /** @copydoc AddScalar
 */
-NBLA_DECLARE_TRANSFORM_UNARY_CUDA_1(AddScalar, double);
+NBLA_DECLARE_TRANSFORM_UNARY_CUDA_1_INPLACE(AddScalar, double);
 }
 #endif

--- a/include/nbla/cuda/function/bc_add2.hpp
+++ b/include/nbla/cuda/function/bc_add2.hpp
@@ -22,6 +22,6 @@ namespace nbla {
 
 /** @copydoc BcAdd2
 */
-NBLA_DECLARE_TRANSFORM_BINARY_CUDA(BcAdd2);
+NBLA_DECLARE_TRANSFORM_BINARY_CUDA_INPLACE(BcAdd2);
 }
 #endif

--- a/include/nbla/cuda/function/div2.hpp
+++ b/include/nbla/cuda/function/div2.hpp
@@ -22,6 +22,6 @@ namespace nbla {
 
 /** @copydoc Div2
 */
-NBLA_DECLARE_TRANSFORM_BINARY_CUDA(Div2);
+NBLA_DECLARE_TRANSFORM_BINARY_CUDA_INPLACE(Div2);
 }
 #endif

--- a/include/nbla/cuda/function/mul2.hpp
+++ b/include/nbla/cuda/function/mul2.hpp
@@ -22,6 +22,6 @@ namespace nbla {
 
 /** @copydoc Mul2
 */
-NBLA_DECLARE_TRANSFORM_BINARY_CUDA(Mul2);
+NBLA_DECLARE_TRANSFORM_BINARY_CUDA_INPLACE(Mul2);
 }
 #endif

--- a/include/nbla/cuda/function/mul_scalar.hpp
+++ b/include/nbla/cuda/function/mul_scalar.hpp
@@ -22,6 +22,6 @@ namespace nbla {
 
 /** @copydoc MulScalar
 */
-NBLA_DECLARE_TRANSFORM_UNARY_CUDA_1(MulScalar, double);
+NBLA_DECLARE_TRANSFORM_UNARY_CUDA_1_INPLACE(MulScalar, double);
 }
 #endif

--- a/include/nbla/cuda/function/pow2.hpp
+++ b/include/nbla/cuda/function/pow2.hpp
@@ -22,6 +22,6 @@ namespace nbla {
 
 /** @copydoc Pow2
 */
-NBLA_DECLARE_TRANSFORM_BINARY_CUDA(Pow2);
+NBLA_DECLARE_TRANSFORM_BINARY_CUDA_INPLACE(Pow2);
 }
 #endif

--- a/include/nbla/cuda/function/pow_scalar.hpp
+++ b/include/nbla/cuda/function/pow_scalar.hpp
@@ -22,6 +22,6 @@ namespace nbla {
 
 /** @copydoc PowScalar
 */
-NBLA_DECLARE_TRANSFORM_UNARY_CUDA_1(PowScalar, double);
+NBLA_DECLARE_TRANSFORM_UNARY_CUDA_1_INPLACE(PowScalar, double);
 }
 #endif

--- a/include/nbla/cuda/function/sub2.hpp
+++ b/include/nbla/cuda/function/sub2.hpp
@@ -22,6 +22,6 @@ namespace nbla {
 
 /** @copydoc Sub2
 */
-NBLA_DECLARE_TRANSFORM_BINARY_CUDA(Sub2);
+NBLA_DECLARE_TRANSFORM_BINARY_CUDA_INPLACE(Sub2);
 }
 #endif

--- a/include/nbla/cuda/function/utils/base_transform_binary.hpp
+++ b/include/nbla/cuda/function/utils/base_transform_binary.hpp
@@ -32,8 +32,8 @@ protected:
   int device_;
 
 public:
-  TransformBinaryCuda(const Context &ctx, Args... args)
-      : BaseTransformBinary<Args...>(ctx, args...),
+  TransformBinaryCuda(const Context &ctx, bool inplace, Args... args)
+      : BaseTransformBinary<Args...>(ctx, inplace, args...),
         device_(std::stoi(ctx.device_id)) {}
   virtual ~TransformBinaryCuda() {}
   virtual vector<dtypes> in_types() {
@@ -64,9 +64,21 @@ protected:                                                                     \
 #define NBLA_DECLARE_TRANSFORM_BINARY_CUDA(NAME)                               \
   template <typename T> class NAME##Cuda : public TransformBinaryCuda<T> {     \
     NBLA_DECLARE_TRANSFORM_BINARY_CUDA_CLASS_COMMON(NAME)                      \
-    explicit NAME##Cuda(const Context &ctx) : TransformBinaryCuda<T>(ctx) {}   \
+    explicit NAME##Cuda(const Context &ctx)                                    \
+        : TransformBinaryCuda<T>(ctx, false) {}                                \
     virtual shared_ptr<Function> copy() const {                                \
       return create_##NAME(this->ctx_);                                        \
+    }                                                                          \
+    NBLA_DECLARE_TRANSFORM_BINARY_CUDA_FORWARD_BACKWARD();                     \
+  }
+
+#define NBLA_DECLARE_TRANSFORM_BINARY_CUDA_INPLACE(NAME)                       \
+  template <typename T> class NAME##Cuda : public TransformBinaryCuda<T> {     \
+    NBLA_DECLARE_TRANSFORM_BINARY_CUDA_CLASS_COMMON(NAME)                      \
+    explicit NAME##Cuda(const Context &ctx, bool inplace)                      \
+        : TransformBinaryCuda<T>(ctx, inplace) {}                              \
+    virtual shared_ptr<Function> copy() const {                                \
+      return create_##NAME(this->ctx_, this->inplace_);                        \
     }                                                                          \
     NBLA_DECLARE_TRANSFORM_BINARY_CUDA_FORWARD_BACKWARD();                     \
   }
@@ -82,7 +94,7 @@ protected:                                                                     \
   NBLA_DECLARE_TRANSFORM_BINARY_CUDA_CLASS_BEGIN_N(NAME, A0) {                 \
     NBLA_DECLARE_TRANSFORM_BINARY_CUDA_CLASS_COMMON(NAME)                      \
     explicit NAME##Cuda(const Context &ctx, const A0 &a0)                      \
-        : TransformBinaryCuda<T, A0>(ctx, a0) {}                               \
+        : TransformBinaryCuda<T, A0>(ctx, false, a0) {}                        \
     virtual shared_ptr<Function> copy() const {                                \
       return create_##NAME(this->ctx_, std::get<0>(this->args_));              \
     }                                                                          \

--- a/src/nbla/cuda/cudnn/function/generic/add2.cu
+++ b/src/nbla/cuda/cudnn/function/generic/add2.cu
@@ -32,8 +32,8 @@ void Add2CudaCudnn<T>::setup_impl(const Variables &inputs,
                                   const Variables &outputs) {
   if (inputs[0]->shape() != inputs[1]->shape()) {
     // Trying to fallback to broadcastable Add2.
-    this->fall_back_func_ =
-        std::shared_ptr<Function>(new BcAdd2Cuda<T>(this->ctx_));
+    this->fall_back_func_ = std::shared_ptr<Function>(
+        new BcAdd2Cuda<T>(this->ctx_, this->inplace_));
     this->fall_back_func_->setup(inputs, outputs);
     return;
   }

--- a/src/nbla/cuda/function/generic/div2.cu
+++ b/src/nbla/cuda/function/generic/div2.cu
@@ -22,5 +22,5 @@
 namespace nbla {
 
 NBLA_DEFINE_TRANSFORM_BINARY_CUDA(Div2, x0 / x1, dy / x1,
-                                  dy *(-x0 / (x1 * x1)));
+                                  dy *(-(inplace ? y *x1 : x0) / (x1 * x1)));
 }

--- a/src/nbla/cuda/function/generic/mul2.cu
+++ b/src/nbla/cuda/function/generic/mul2.cu
@@ -19,5 +19,6 @@
 
 namespace nbla {
 
-NBLA_DEFINE_TRANSFORM_BINARY_CUDA(Mul2, x0 *x1, dy *x1, dy *x0);
+NBLA_DEFINE_TRANSFORM_BINARY_CUDA(Mul2, x0 *x1, dy *x1,
+                                  inplace ? dy *y / x1 : dy *x0);
 }

--- a/src/nbla/cuda/function/generic/pow2.cu
+++ b/src/nbla/cuda/function/generic/pow2.cu
@@ -21,7 +21,9 @@
 
 namespace nbla {
 
-NBLA_DEFINE_TRANSFORM_BINARY_CUDA(Pow2, std::pow(x0, x1),
-                                  dy *x1 *std::pow(x0, x1 - (T)1),
-                                  dy *std::log(x0) * std::pow(x0, x1));
+NBLA_DEFINE_TRANSFORM_BINARY_CUDA(
+    Pow2, std::pow(x0, x1),
+    dy *x1 *std::pow(inplace ? std::pow(y, 1 / x1) : x0, x1 - (T)1),
+    dy *std::log(inplace ? std::pow(y, 1 / x1) : x0) *
+        std::pow(inplace ? std::pow(y, 1 / x1) : x0, x1));
 }

--- a/src/nbla/cuda/function/generic/pow_scalar.cu
+++ b/src/nbla/cuda/function/generic/pow_scalar.cu
@@ -20,7 +20,8 @@
 namespace nbla {
 
 NBLA_DEFINE_TRANSFORM_UNARY_CUDA_1(
-    PowScalar, std::pow(x, (T)a0),
+    PowScalar,
+    a0 == 0.5f ? std::sqrt(x) : a0 == -0.5f ? rsqrt(x) : std::pow(x, (T)a0),
     dy *(T)a0 *std::pow((inplace ? std::pow(y, (T)1 / (T)a0) : x),
                         (T)a0 - (T)1),
     double, false);

--- a/src/nbla/cuda/function/generic/pow_scalar.cu
+++ b/src/nbla/cuda/function/generic/pow_scalar.cu
@@ -19,7 +19,9 @@
 
 namespace nbla {
 
-NBLA_DEFINE_TRANSFORM_UNARY_CUDA_1(PowScalar, std::pow(x, (T)a0),
-                                   dy *(T)a0 *std::pow(x, (T)a0 - (T)1), double,
-                                   false);
+NBLA_DEFINE_TRANSFORM_UNARY_CUDA_1(
+    PowScalar, std::pow(x, (T)a0),
+    dy *(T)a0 *std::pow((inplace ? std::pow(y, (T)1 / (T)a0) : x),
+                        (T)a0 - (T)1),
+    double, false);
 }

--- a/src/nbla/cuda/solver/generic/clip_grad.cuh
+++ b/src/nbla/cuda/solver/generic/clip_grad.cuh
@@ -41,7 +41,7 @@ void clip_grad_by_norm_cuda(const Context &ctx,
   Variable sum(Shape_t{});
 
   // calculate g^2
-  auto f_pow_scalar = create_PowScalar(ctx, 2.0);
+  auto f_pow_scalar = create_PowScalar(ctx, 2.0, false);
   f_pow_scalar->setup(Variables{&g}, Variables{&g_pow});
   f_pow_scalar->forward(Variables{&g}, Variables{&g_pow});
 


### PR DESCRIPTION
We added the inplace option to the unary/binary arithmetic functions in sense of a memory optimization.

- Sub2/Mul2/Div2/Pow2
- {Sub2/Mul2/Div2/Pow2}Scalar

and do the inplace-way in the arithmetic operators (\_\_iadd\_\_, \_\_isub\_\_, \_\_i{true}div\_\_, \_\_ipow\_\_) in Variable class in python.
