### PR TITLE
CuDNN does not support fused batchnorm on compute_arch 5.3

### DIFF
--- a/src/nbla/cuda/cudnn/function/generic/fused_batch_normalization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/fused_batch_normalization.cu
@@ -66,6 +66,16 @@ void FusedBatchNormalizationCudaCudnn<T>::setup_impl(const Variables &inputs,
     can_use_bn_ex = false;
   }
 #endif // _WIN32
+  if (can_use_bn_ex) {
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, this->device_);
+    if ((prop.major == 5) && (prop.minor == 3)) {
+      NBLA_LOG_WARN("FusedBatchNormalization is not supported by CuDNN on "
+                    "compute archtitecture 5.3 - "
+                    "fallback to composite implementation.")
+      can_use_bn_ex = false;
+    }
+  }
   if (!can_use_bn_ex || outputs.size() == 3) {
     this->fall_back_func_ = make_shared<FusedBatchNormalization<T>>(
         this->ctx_, this->axes_, this->decay_rate_, this->eps_,


### PR DESCRIPTION
**Fix FusedBatchNormalizationCudaCudnn for compute architecture 3.5**

The CuDNN library does not support fused batchnorm on compute architecture 5.3 that is used in NVIDA Jetson Nano. This PR adds querying the compute architecture of the active device and replace the fused batchnorm by a composite function chain.

**Details:**

The function `cudnnGetBatchNormalizationForwardTrainingExWorkspaceSize` fails with error `ARCH_MISMATCH`.

CUDA environment on Jetson Nano:
```
CUDA Version: 10.0
Runtime: /usr/local/cuda/lib64/libcudart.so
CUBLAS: /usr/local/cuda/lib64/libcublas.so
CURAND: /usr/local/cuda/lib64/libcurand.so
CUFFT: /usr/local/cuda/lib64/libcufft.so
cuDNN-libs: /usr/lib/aarch64-linux-gnu/libcudnn.so
cuDNN-includes: /usr/include
cuDNN version: 7.6.3
CUDA libs: /usr/local/cuda/lib64/libcudart.so;/usr/local/cuda/lib64/libcublas.so;/usr/local/cuda/lib64/libcurand.so;/usr/local/cuda/lib64/libcufft.so;/usr/lib/aarch64-linux-gnu/libcudnn.so
CUDA includes: /usr/local/cuda/include;/usr/include
```