### PR TITLE
add code to implement asymmetric watch dog

### DIFF
--- a/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
+++ b/include/nbla/cuda/communicator/multi_process_data_parallel_communicator.hpp
@@ -60,7 +60,8 @@ template <typename T>
 class NBLA_API MultiProcessDataParallelCommunicatorNccl
     : public MultiProcessDataParallelCommunicator<T> {
 protected:
-  int all_reduce_timeout_ = 500; // timeout=50s
+  int all_reduce_timeout_ = 500;             // timeout=50s
+  static const int TIMES_FOR_OTHER_NODE = 5; // times for other node
   Watchdog watch_dog_;
   int device_id_;
 


### PR DESCRIPTION
When rank0 node performed a long time operation, watch dog unintented to raise an exception, which is not expected by user.
We realized that watch dog should be asymmetric, from rank0 to others, we have a strict constraint, from others to rank0, we should have a relative loose constraint, which allowed rank0 do some asymmetric operations.
This PR stands for this purpose.