### PR TITLE
fix: solve the nccl error while running more than 2 gpus

### DIFF
--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -200,3 +200,10 @@ ENV PATH /opt/miniconda3/envs/nnabla-build/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/miniconda3/envs/nnabla-build/lib:$LD_LIBRARY_PATH
 ENV CC /usr/local/bin/gcc
 ENV CXX /usr/local/bin/g++
+
+####################################################
+# Solve nccl error that No space left on device
+# while creating shared memory segment.
+####################################################
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf

--- a/docker/development/Dockerfile.build-mpi-ppc64le
+++ b/docker/development/Dockerfile.build-mpi-ppc64le
@@ -191,3 +191,10 @@ ENV PATH /opt/miniconda3/envs/nnabla-build/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/miniconda3/envs/nnabla-build/lib:$LD_LIBRARY_PATH
 ENV CC /usr/local/bin/gcc
 ENV CXX /usr/local/bin/g++
+
+####################################################
+# Solve nccl error that No space left on device
+# while creating shared memory segment.
+####################################################
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf

--- a/docker/py36/cuda100/mpi2.1.1/Dockerfile
+++ b/docker/py36/cuda100/mpi2.1.1/Dockerfile
@@ -45,6 +45,11 @@ ENV PATH /opt/miniconda3/bin:$PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda100-nccl2-mpi2.1.1==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py36/cuda100/mpi3.1.6/Dockerfile
+++ b/docker/py36/cuda100/mpi3.1.6/Dockerfile
@@ -72,6 +72,11 @@ ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda100-nccl2-mpi3.1.6==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py36/cuda102/mpi2.1.1/Dockerfile
+++ b/docker/py36/cuda102/mpi2.1.1/Dockerfile
@@ -45,6 +45,11 @@ ENV PATH /opt/miniconda3/bin:$PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda102-nccl2-mpi2.1.1==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py36/cuda102/mpi3.1.6/Dockerfile
+++ b/docker/py36/cuda102/mpi3.1.6/Dockerfile
@@ -72,6 +72,11 @@ ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda102-nccl2-mpi3.1.6==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py36/cuda110/mpi2.1.1/Dockerfile
+++ b/docker/py36/cuda110/mpi2.1.1/Dockerfile
@@ -45,6 +45,11 @@ ENV PATH /opt/miniconda3/bin:$PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda110-nccl2-mpi2.1.1==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py36/cuda110/mpi3.1.6/Dockerfile
+++ b/docker/py36/cuda110/mpi3.1.6/Dockerfile
@@ -72,6 +72,11 @@ ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda110-nccl2-mpi3.1.6==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py37/cuda100/mpi2.1.1/Dockerfile
+++ b/docker/py37/cuda100/mpi2.1.1/Dockerfile
@@ -45,6 +45,11 @@ ENV PATH /opt/miniconda3/bin:$PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda100-nccl2-mpi2.1.1==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py37/cuda100/mpi3.1.6/Dockerfile
+++ b/docker/py37/cuda100/mpi3.1.6/Dockerfile
@@ -72,6 +72,11 @@ ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda100-nccl2-mpi3.1.6==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py37/cuda102/mpi2.1.1/Dockerfile
+++ b/docker/py37/cuda102/mpi2.1.1/Dockerfile
@@ -45,6 +45,11 @@ ENV PATH /opt/miniconda3/bin:$PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda102-nccl2-mpi2.1.1==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py37/cuda102/mpi3.1.6/Dockerfile
+++ b/docker/py37/cuda102/mpi3.1.6/Dockerfile
@@ -72,6 +72,11 @@ ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda102-nccl2-mpi3.1.6==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py37/cuda110/mpi2.1.1/Dockerfile
+++ b/docker/py37/cuda110/mpi2.1.1/Dockerfile
@@ -45,6 +45,11 @@ ENV PATH /opt/miniconda3/bin:$PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda110-nccl2-mpi2.1.1==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py37/cuda110/mpi3.1.6/Dockerfile
+++ b/docker/py37/cuda110/mpi3.1.6/Dockerfile
@@ -72,6 +72,11 @@ ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda110-nccl2-mpi3.1.6==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py38/cuda100/mpi2.1.1/Dockerfile
+++ b/docker/py38/cuda100/mpi2.1.1/Dockerfile
@@ -45,6 +45,11 @@ ENV PATH /opt/miniconda3/bin:$PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda100-nccl2-mpi2.1.1==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py38/cuda100/mpi3.1.6/Dockerfile
+++ b/docker/py38/cuda100/mpi3.1.6/Dockerfile
@@ -72,6 +72,11 @@ ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda100-nccl2-mpi3.1.6==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py38/cuda102/mpi2.1.1/Dockerfile
+++ b/docker/py38/cuda102/mpi2.1.1/Dockerfile
@@ -45,6 +45,11 @@ ENV PATH /opt/miniconda3/bin:$PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda102-nccl2-mpi2.1.1==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py38/cuda102/mpi3.1.6/Dockerfile
+++ b/docker/py38/cuda102/mpi3.1.6/Dockerfile
@@ -72,6 +72,11 @@ ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda102-nccl2-mpi3.1.6==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py38/cuda110/mpi2.1.1/Dockerfile
+++ b/docker/py38/cuda110/mpi2.1.1/Dockerfile
@@ -45,6 +45,11 @@ ENV PATH /opt/miniconda3/bin:$PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda110-nccl2-mpi2.1.1==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/py38/cuda110/mpi3.1.6/Dockerfile
+++ b/docker/py38/cuda110/mpi3.1.6/Dockerfile
@@ -72,6 +72,11 @@ ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 ARG NNABLA_VER
 RUN pip install nnabla-ext-cuda110-nccl2-mpi3.1.6==${NNABLA_VER}
 
+# Solve nccl error that No space left on device 
+# while creating shared memory segment.
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
 # Prepare default user
 RUN useradd -m nnabla
 RUN chown -R nnabla:nnabla /home/nnabla

--- a/docker/runtime/Dockerfile.runtime-mpi
+++ b/docker/runtime/Dockerfile.runtime-mpi
@@ -102,3 +102,10 @@ ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 COPY --from=miniconda /opt/miniconda3 /opt/miniconda3
 ENV PATH /opt/miniconda3/bin:$PATH
 ENV LD_LIBRARY_PATH /usr/lib64:/opt/miniconda3/lib:$LD_LIBRARY_PATH
+
+####################################################
+# Solve nccl error that No space left on device
+# while creating shared memory segment.
+####################################################
+RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
+RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf


### PR DESCRIPTION
Solve the nccl error `ncclCommInitRank failed.` While running more than 2 GPUs. 
That detail is No space left on device while creating shared memory segment.
