### PR TITLE
Optimize normalization functions implementation

### DIFF
--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -94,13 +94,28 @@ Sinc:
 BatchNormalization:
   float: [float]
   half: [Half]
+GroupNormalization:
+  float: [float]
+  half: [Half]
+InstanceNormalization:
+  float: [float]
+  half: [Half]
+LayerNormalization:
+  float: [float]
+  half: [Half]
 NormNormalization:
   float: [float]
   half: [Half]
 SyncBatchNormalization:
   float: [float]
   half: [Half]
+TensorNormalization:
+  float: [float]
+  half: [Half]
 WeightNormalization:
+  float: [float]
+  half: [Half]
+WeightStandardization:
   float: [float]
   half: [Half]
 MeanSubtraction:

--- a/build-tools/code_generator/function_types_cudnn.yaml
+++ b/build-tools/code_generator/function_types_cudnn.yaml
@@ -67,6 +67,21 @@ BatchNormalization:
 FusedBatchNormalization:
   float: [float]
   half: [Half]
+GroupNormalization:
+  float: [float]
+  half: [Half]
+InstanceNormalization:
+  float: [float]
+  half: [Half]
+LayerNormalization:
+  float: [float]
+  half: [Half]
+TensorNormalization:
+  float: [float]
+  half: [Half]
+WeightStandardization:
+  float: [float]
+  half: [Half]
 # MeanSubtraction:
 #   float: [float]
 Sum:

--- a/include/nbla/cuda/cudnn/function/batch_normalization.hpp
+++ b/include/nbla/cuda/cudnn/function/batch_normalization.hpp
@@ -51,8 +51,10 @@ public:
   typedef typename CudaType<T>::type Tw;
 
   BatchNormalizationCudaCudnn(const Context &ctx, const vector<int> axes,
-                              float decay_rate, float eps, bool batch_stat)
-      : BatchNormalizationCuda<T>(ctx, axes, decay_rate, eps, batch_stat),
+                              float decay_rate, float eps, bool batch_stat,
+                              bool no_scale, bool no_bias)
+      : BatchNormalizationCuda<T>(ctx, axes, decay_rate, eps, batch_stat,
+                                  no_scale, no_bias),
         device_(std::stoi(ctx.device_id)) {
 #if CUDNN_VERSION < 5000
     std::cout << "Falling back to BatchNormalizationCuda since BN does not "

--- a/include/nbla/cuda/cudnn/function/group_normalization.hpp
+++ b/include/nbla/cuda/cudnn/function/group_normalization.hpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_CUDNN_FUNCTION_GROUP_NORMALIZATION_HPP
+#define NBLA_CUDA_CUDNN_FUNCTION_GROUP_NORMALIZATION_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+
+#include <nbla/function/group_normalization.hpp>
+
+namespace nbla {
+
+template <typename T>
+class GroupNormalizationCudaCudnn : public GroupNormalization<T> {
+public:
+  explicit GroupNormalizationCudaCudnn(const Context &ctx, int num_groups,
+                                       int channel_axis,
+                                       const vector<int> &batch_axis, float eps,
+                                       bool no_scale, bool no_bias)
+      : GroupNormalization<T>(ctx, num_groups, channel_axis, batch_axis, eps,
+                              no_scale, no_bias),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~GroupNormalizationCudaCudnn() {}
+  virtual string name() { return "GroupNormalizationCudaCudnn"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/cudnn/function/instance_normalization.hpp
+++ b/include/nbla/cuda/cudnn/function/instance_normalization.hpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_CUDNN_FUNCTION_INSTANCE_NORMALIZATION_HPP
+#define NBLA_CUDA_CUDNN_FUNCTION_INSTANCE_NORMALIZATION_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+
+#include <nbla/function/instance_normalization.hpp>
+
+namespace nbla {
+
+template <typename T>
+class InstanceNormalizationCudaCudnn : public InstanceNormalization<T> {
+public:
+  explicit InstanceNormalizationCudaCudnn(const Context &ctx, int channel_axis,
+                                          const vector<int> &batch_axis,
+                                          float eps, bool no_scale,
+                                          bool no_bias)
+      : InstanceNormalization<T>(ctx, channel_axis, batch_axis, eps, no_scale,
+                                 no_bias),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~InstanceNormalizationCudaCudnn() {}
+  virtual string name() { return "InstanceNormalizationCudaCudnn"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/cudnn/function/layer_normalization.hpp
+++ b/include/nbla/cuda/cudnn/function/layer_normalization.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_CUDNN_FUNCTION_LAYER_NORMALIZATION_HPP
+#define NBLA_CUDA_CUDNN_FUNCTION_LAYER_NORMALIZATION_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+
+#include <nbla/function/layer_normalization.hpp>
+
+namespace nbla {
+
+template <typename T>
+class LayerNormalizationCudaCudnn : public LayerNormalization<T> {
+public:
+  explicit LayerNormalizationCudaCudnn(const Context &ctx,
+                                       const vector<int> &batch_axis, float eps,
+                                       bool no_scale, bool no_bias)
+      : LayerNormalization<T>(ctx, batch_axis, eps, no_scale, no_bias),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~LayerNormalizationCudaCudnn() {}
+  virtual string name() { return "LayerNormalizationCudaCudnn"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/cudnn/function/sync_batch_normalization.hpp
+++ b/include/nbla/cuda/cudnn/function/sync_batch_normalization.hpp
@@ -53,7 +53,8 @@ public:
       : SyncBatchNormalizationCuda<T>(ctx, comm, group, axes, decay_rate, eps,
                                       batch_stat),
         device_(std::stoi(ctx.device_id)),
-        batch_norm_cudnn_(ctx, axes, decay_rate, eps, batch_stat) {
+        batch_norm_cudnn_(ctx, axes, decay_rate, eps, batch_stat,
+                          false /* no_scale */, false /* no_bias */) {
 #if CUDNN_VERSION < 5000
     std::cout << "Falling back to BatchNormalizationCuda since BN does not "
                  "exist in CUDNN_VERSION < 5000."

--- a/include/nbla/cuda/cudnn/function/tensor_normalization.hpp
+++ b/include/nbla/cuda/cudnn/function/tensor_normalization.hpp
@@ -1,0 +1,49 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_CUDNN_FUNCTION_TENSOR_NORMALIZATION_HPP
+#define NBLA_CUDA_CUDNN_FUNCTION_TENSOR_NORMALIZATION_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+
+#include <nbla/function/tensor_normalization.hpp>
+
+namespace nbla {
+
+template <typename T>
+class TensorNormalizationCudaCudnn : public TensorNormalization<T> {
+public:
+  explicit TensorNormalizationCudaCudnn(const Context &ctx,
+                                        const vector<int> &axes, float eps,
+                                        bool no_scale, bool no_bias)
+      : TensorNormalization<T>(ctx, axes, eps, no_scale, no_bias),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~TensorNormalizationCudaCudnn() {}
+  virtual string name() { return "TensorNormalizationCudaCudnn"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/cudnn/function/weight_standardization.hpp
+++ b/include/nbla/cuda/cudnn/function/weight_standardization.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_CUDNN_FUNCTION_WEIGHT_STANDARDIZATION_HPP
+#define NBLA_CUDA_CUDNN_FUNCTION_WEIGHT_STANDARDIZATION_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+
+#include <nbla/function/weight_standardization.hpp>
+
+namespace nbla {
+
+template <typename T>
+class WeightStandardizationCudaCudnn : public WeightStandardization<T> {
+public:
+  explicit WeightStandardizationCudaCudnn(const Context &ctx, int channel_axis,
+                                          float eps)
+      : WeightStandardization<T>(ctx, channel_axis, eps),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~WeightStandardizationCudaCudnn() {}
+  virtual string name() { return "WeightStandardizationCudaCudnn"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/function/batch_normalization.hpp
+++ b/include/nbla/cuda/function/batch_normalization.hpp
@@ -53,8 +53,10 @@ public:
   typedef typename CudaType<T>::type Tc;
 
   BatchNormalizationCuda(const Context &ctx, const vector<int> axes,
-                         float decay_rate, float eps, bool batch_stat)
-      : BatchNormalization<T>(ctx, axes, decay_rate, eps, batch_stat),
+                         float decay_rate, float eps, bool batch_stat,
+                         bool no_scale, bool no_bias)
+      : BatchNormalization<T>(ctx, axes, decay_rate, eps, batch_stat, no_scale,
+                              no_bias),
         device_(std::stoi(ctx.device_id)) {}
   virtual ~BatchNormalizationCuda() {}
   virtual string name() { return "BatchNormalizationCuda"; }

--- a/include/nbla/cuda/function/group_normalization.hpp
+++ b/include/nbla/cuda/function/group_normalization.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_GROUP_NORMALIZATION_HPP
+#define NBLA_CUDA_FUNCTION_GROUP_NORMALIZATION_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/group_normalization.hpp>
+
+namespace nbla {
+
+template <typename T>
+class GroupNormalizationCuda : public GroupNormalization<T> {
+public:
+  explicit GroupNormalizationCuda(const Context &ctx, int num_groups,
+                                  int channel_axis,
+                                  const vector<int> &batch_axis, float eps,
+                                  bool no_scale, bool no_bias)
+      : GroupNormalization<T>(ctx, num_groups, channel_axis, batch_axis, eps,
+                              no_scale, no_bias),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~GroupNormalizationCuda() {}
+  virtual string name() { return "GroupNormalizationCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/function/instance_normalization.hpp
+++ b/include/nbla/cuda/function/instance_normalization.hpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_INSTANCE_NORMALIZATION_HPP
+#define NBLA_CUDA_FUNCTION_INSTANCE_NORMALIZATION_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/instance_normalization.hpp>
+
+namespace nbla {
+
+template <typename T>
+class InstanceNormalizationCuda : public InstanceNormalization<T> {
+public:
+  explicit InstanceNormalizationCuda(const Context &ctx, int channel_axis,
+                                     const vector<int> &batch_axis, float eps,
+                                     bool no_scale, bool no_bias)
+      : InstanceNormalization<T>(ctx, channel_axis, batch_axis, eps, no_scale,
+                                 no_bias),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~InstanceNormalizationCuda() {}
+  virtual string name() { return "InstanceNormalizationCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/function/layer_normalization.hpp
+++ b/include/nbla/cuda/function/layer_normalization.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_LAYER_NORMALIZATION_HPP
+#define NBLA_CUDA_FUNCTION_LAYER_NORMALIZATION_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/layer_normalization.hpp>
+
+namespace nbla {
+
+template <typename T>
+class LayerNormalizationCuda : public LayerNormalization<T> {
+public:
+  explicit LayerNormalizationCuda(const Context &ctx,
+                                  const vector<int> &batch_axis, float eps,
+                                  bool no_scale, bool no_bias)
+      : LayerNormalization<T>(ctx, batch_axis, eps, no_scale, no_bias),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~LayerNormalizationCuda() {}
+  virtual string name() { return "LayerNormalizationCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/function/sync_batch_normalization.hpp
+++ b/include/nbla/cuda/function/sync_batch_normalization.hpp
@@ -63,7 +63,8 @@ public:
       : SyncBatchNormalization<T>(ctx, comm, group, axes, decay_rate, eps,
                                   batch_stat),
         device_(std::stoi(ctx.device_id)),
-        batch_norm_(ctx, axes, decay_rate, eps, batch_stat) {}
+        batch_norm_(ctx, axes, decay_rate, eps, batch_stat,
+                    false /* no_scale */, false /* no_scale */) {}
   virtual ~SyncBatchNormalizationCuda() {}
   virtual string name() override { return "SyncBatchNormalizationCuda"; }
   virtual vector<string> allowed_array_classes() override {

--- a/include/nbla/cuda/function/tensor_normalization.hpp
+++ b/include/nbla/cuda/function/tensor_normalization.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_TENSOR_NORMALIZATION_HPP
+#define NBLA_CUDA_FUNCTION_TENSOR_NORMALIZATION_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/tensor_normalization.hpp>
+
+namespace nbla {
+
+template <typename T>
+class TensorNormalizationCuda : public TensorNormalization<T> {
+public:
+  explicit TensorNormalizationCuda(const Context &ctx, const vector<int> &axes,
+                                   float eps, bool no_scale, bool no_bias)
+      : TensorNormalization<T>(ctx, axes, eps, no_scale, no_bias),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~TensorNormalizationCuda() {}
+  virtual string name() { return "TensorNormalizationCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/function/weight_standardization.hpp
+++ b/include/nbla/cuda/function/weight_standardization.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_WEIGHT_STANDARDIZATION_HPP
+#define NBLA_CUDA_FUNCTION_WEIGHT_STANDARDIZATION_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/weight_standardization.hpp>
+
+namespace nbla {
+
+template <typename T>
+class WeightStandardizationCuda : public WeightStandardization<T> {
+public:
+  explicit WeightStandardizationCuda(const Context &ctx, int channel_axis,
+                                     float eps)
+      : WeightStandardization<T>(ctx, channel_axis, eps),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~WeightStandardizationCuda() {}
+  virtual string name() { return "WeightStandardizationCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/src/nbla/cuda/cudnn/function/generic/group_normalization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/group_normalization.cu
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+#include <nbla/cuda/cudnn/function/group_normalization.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void GroupNormalizationCudaCudnn<T>::setup_impl(const Variables &inputs,
+                                                const Variables &outputs) {
+  GroupNormalization<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void GroupNormalizationCudaCudnn<T>::forward_impl(const Variables &inputs,
+                                                  const Variables &outputs) {
+  cuda_set_device(this->device_);
+  GroupNormalization<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void GroupNormalizationCudaCudnn<T>::backward_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  if (!(propagate_down[0] || (inputs.size() > 1 && propagate_down[1]) ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+  cuda_set_device(this->device_);
+  GroupNormalization<T>::backward_impl(inputs, outputs, propagate_down, accum);
+}
+}

--- a/src/nbla/cuda/cudnn/function/generic/instance_normalization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/instance_normalization.cu
@@ -1,0 +1,49 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+#include <nbla/cuda/cudnn/function/instance_normalization.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void InstanceNormalizationCudaCudnn<T>::setup_impl(const Variables &inputs,
+                                                   const Variables &outputs) {
+  InstanceNormalization<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void InstanceNormalizationCudaCudnn<T>::forward_impl(const Variables &inputs,
+                                                     const Variables &outputs) {
+  cuda_set_device(this->device_);
+  InstanceNormalization<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void InstanceNormalizationCudaCudnn<T>::backward_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  if (!(propagate_down[0] || (inputs.size() > 1 && propagate_down[1]) ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+  cuda_set_device(this->device_);
+  InstanceNormalization<T>::backward_impl(inputs, outputs, propagate_down,
+                                          accum);
+}
+}

--- a/src/nbla/cuda/cudnn/function/generic/layer_normalization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/layer_normalization.cu
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+#include <nbla/cuda/cudnn/function/layer_normalization.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void LayerNormalizationCudaCudnn<T>::setup_impl(const Variables &inputs,
+                                                const Variables &outputs) {
+  LayerNormalization<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void LayerNormalizationCudaCudnn<T>::forward_impl(const Variables &inputs,
+                                                  const Variables &outputs) {
+  cuda_set_device(this->device_);
+  LayerNormalization<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void LayerNormalizationCudaCudnn<T>::backward_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  if (!(propagate_down[0] || (inputs.size() > 1 && propagate_down[1]) ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+  cuda_set_device(this->device_);
+  LayerNormalization<T>::backward_impl(inputs, outputs, propagate_down, accum);
+}
+}

--- a/src/nbla/cuda/cudnn/function/generic/tensor_normalization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/tensor_normalization.cu
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+#include <nbla/cuda/cudnn/function/tensor_normalization.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void TensorNormalizationCudaCudnn<T>::setup_impl(const Variables &inputs,
+                                                 const Variables &outputs) {
+  TensorNormalization<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void TensorNormalizationCudaCudnn<T>::forward_impl(const Variables &inputs,
+                                                   const Variables &outputs) {
+  cuda_set_device(this->device_);
+  TensorNormalization<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void TensorNormalizationCudaCudnn<T>::backward_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  if (!(propagate_down[0] || (inputs.size() > 1 && propagate_down[1]) ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+  cuda_set_device(this->device_);
+  TensorNormalization<T>::backward_impl(inputs, outputs, propagate_down, accum);
+}
+}

--- a/src/nbla/cuda/cudnn/function/generic/weight_standardization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/weight_standardization.cu
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+#include <nbla/cuda/cudnn/function/weight_standardization.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void WeightStandardizationCudaCudnn<T>::setup_impl(const Variables &inputs,
+                                                   const Variables &outputs) {
+  WeightStandardization<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void WeightStandardizationCudaCudnn<T>::forward_impl(const Variables &inputs,
+                                                     const Variables &outputs) {
+  cuda_set_device(this->device_);
+  WeightStandardization<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void WeightStandardizationCudaCudnn<T>::backward_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  if (!(propagate_down[0])) {
+    return;
+  }
+  cuda_set_device(this->device_);
+  WeightStandardization<T>::backward_impl(inputs, outputs, propagate_down,
+                                          accum);
+}
+}

--- a/src/nbla/cuda/function/generic/group_normalization.cu
+++ b/src/nbla/cuda/function/generic/group_normalization.cu
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/group_normalization.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void GroupNormalizationCuda<T>::setup_impl(const Variables &inputs,
+                                           const Variables &outputs) {
+  GroupNormalization<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void GroupNormalizationCuda<T>::forward_impl(const Variables &inputs,
+                                             const Variables &outputs) {
+  cuda_set_device(this->device_);
+  GroupNormalization<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void GroupNormalizationCuda<T>::backward_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  if (!(propagate_down[0] || (inputs.size() > 1 && propagate_down[1]) ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+  cuda_set_device(this->device_);
+  GroupNormalization<T>::backward_impl(inputs, outputs, propagate_down, accum);
+}
+}

--- a/src/nbla/cuda/function/generic/instance_normalization.cu
+++ b/src/nbla/cuda/function/generic/instance_normalization.cu
@@ -1,0 +1,48 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/instance_normalization.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void InstanceNormalizationCuda<T>::setup_impl(const Variables &inputs,
+                                              const Variables &outputs) {
+  InstanceNormalization<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void InstanceNormalizationCuda<T>::forward_impl(const Variables &inputs,
+                                                const Variables &outputs) {
+  cuda_set_device(this->device_);
+  InstanceNormalization<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void InstanceNormalizationCuda<T>::backward_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  if (!(propagate_down[0] || (inputs.size() > 1 && propagate_down[1]) ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+  cuda_set_device(this->device_);
+  InstanceNormalization<T>::backward_impl(inputs, outputs, propagate_down,
+                                          accum);
+}
+}

--- a/src/nbla/cuda/function/generic/kernel/batch_normalization.cu
+++ b/src/nbla/cuda/function/generic/kernel/batch_normalization.cu
@@ -126,7 +126,7 @@ void backward_batch_data_parallel_reduction(
     backward_batch_data_kernel_mean_variance_preprocess<<<
         blocks, NBLA_CUDA_NUM_THREADS>>>(
         /* Input */
-        N, dy_trans + i * N, x_trans + i * N, g + i, m + i,
+        N, dy_trans + i * N, x_trans + i * N, g ? g + i : nullptr, m + i,
         /* Output */
         tmp_mean_buffer_per_block, tmp_variance_buffer_per_block,
         tmp_t_buffer_per_block);
@@ -167,7 +167,7 @@ void backward_batch_gamma_beta_parallel_reduction(
         /* Input */
         gamma_reduction_space, beta_reduction_space, blocks,
         /* Output */
-        dg + i, db + i);
+        dg ? dg + i : nullptr, db ? db + i : nullptr);
   }
 }
 }

--- a/src/nbla/cuda/function/generic/layer_normalization.cu
+++ b/src/nbla/cuda/function/generic/layer_normalization.cu
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/layer_normalization.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void LayerNormalizationCuda<T>::setup_impl(const Variables &inputs,
+                                           const Variables &outputs) {
+  LayerNormalization<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void LayerNormalizationCuda<T>::forward_impl(const Variables &inputs,
+                                             const Variables &outputs) {
+  cuda_set_device(this->device_);
+  LayerNormalization<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void LayerNormalizationCuda<T>::backward_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  if (!(propagate_down[0] || (inputs.size() > 1 && propagate_down[1]) ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+  cuda_set_device(this->device_);
+  LayerNormalization<T>::backward_impl(inputs, outputs, propagate_down, accum);
+}
+}

--- a/src/nbla/cuda/function/generic/tensor_normalization.cu
+++ b/src/nbla/cuda/function/generic/tensor_normalization.cu
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/tensor_normalization.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void TensorNormalizationCuda<T>::setup_impl(const Variables &inputs,
+                                            const Variables &outputs) {
+  TensorNormalization<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void TensorNormalizationCuda<T>::forward_impl(const Variables &inputs,
+                                              const Variables &outputs) {
+  cuda_set_device(this->device_);
+  TensorNormalization<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void TensorNormalizationCuda<T>::backward_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  if (!(propagate_down[0] || (inputs.size() > 1 && propagate_down[1]) ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+  cuda_set_device(this->device_);
+  TensorNormalization<T>::backward_impl(inputs, outputs, propagate_down, accum);
+}
+}

--- a/src/nbla/cuda/function/generic/weight_standardization.cu
+++ b/src/nbla/cuda/function/generic/weight_standardization.cu
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/weight_standardization.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void WeightStandardizationCuda<T>::setup_impl(const Variables &inputs,
+                                              const Variables &outputs) {
+  WeightStandardization<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void WeightStandardizationCuda<T>::forward_impl(const Variables &inputs,
+                                                const Variables &outputs) {
+  cuda_set_device(this->device_);
+  WeightStandardization<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void WeightStandardizationCuda<T>::backward_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  if (!(propagate_down[0])) {
+    return;
+  }
+  cuda_set_device(this->device_);
+  WeightStandardization<T>::backward_impl(inputs, outputs, propagate_down,
+                                          accum);
+}
+}


### PR DESCRIPTION
We ported the python-based implementation of the following normalization functions to the cpp-side and optimized these in memory and computation tradeoff.

- LayerNormalization
- InstanceNormalization
- GroupNormalization
- WeightStanderdization