### PR TITLE
Split convolution workspace size

### DIFF
--- a/include/nbla/cuda/cudnn/cudnn.hpp
+++ b/include/nbla/cuda/cudnn/cudnn.hpp
@@ -320,19 +320,32 @@ struct NBLA_CUDA_API CudnnConvResource {
   cudnnConvolutionBwdFilterAlgo_t
       bwd_filter_algo; ///< Best Backward filter algorithm found.
   cudnnConvolutionBwdDataAlgo_t
-      bwd_data_algo;                ///< Best backward data algorithm found.
-  size_t fwd_workspace_size;        ///< Forward workspace size.
-  size_t bwd_filter_workspace_size; ///< Backward filter workspace size.
-  size_t bwd_data_workspace_size;   ///< Backward data workspace size.
+      bwd_data_algo; ///< Best backward data algorithm found.
 
   CudnnConvResource(const CudnnConvDesc &desc);
   ~CudnnConvResource();
 
   /** Get maximum workspace size.
    */
-  size_t workspace_size() const;
+  size_t max_workspace_size() const;
+
+  /** Get forward workspace size.
+   */
+  size_t fwd_workspace_size() const;
+
+  /** Get backward-filter workspace size.
+   */
+  size_t bwd_filter_workspace_size() const;
+
+  /** Get backward-data workspace size.
+   */
+  size_t bwd_data_workspace_size() const;
 
 private:
+  size_t fwd_workspace_size_;        ///< Forward workspace size.
+  size_t bwd_filter_workspace_size_; ///< Backward filter workspace size.
+  size_t bwd_data_workspace_size_;   ///< Backward data workspace size.
+
   void find_forward_algorithm(int workspace_limit, bool deterministic,
                               bool heuristic);
   void find_backward_data_algorithm(int workspace_limit, bool deterministic,

--- a/src/nbla/cuda/cudnn/function/generic/convolution.cu
+++ b/src/nbla/cuda/cudnn/function/generic/convolution.cu
@@ -110,7 +110,7 @@ void ConvolutionCudaCudnn<T>::forward_impl(const Variables &inputs,
   if (inputs.size() == 3) {
     b = inputs[2]->get_data_pointer<Tw>(this->ctx_);
   }
-  auto workspace_size = rsc_->workspace_size();
+  auto workspace_size = rsc_->fwd_workspace_size();
   NdArray workspace_arr;
 
   void *workspace{nullptr};
@@ -123,8 +123,8 @@ void ConvolutionCudaCudnn<T>::forward_impl(const Variables &inputs,
 #if CUDNN_VERSION >= 7000
   NBLA_CUDNN_CHECK(cudnnConvolutionForward(
       cudnn_handle_, &alpha, rsc_->x_desc, x, rsc_->w_desc, w,
-      rsc_->conv_desc.desc, rsc_->fwd_algo, workspace, rsc_->fwd_workspace_size,
-      &beta, rsc_->y_desc, y));
+      rsc_->conv_desc.desc, rsc_->fwd_algo, workspace,
+      rsc_->fwd_workspace_size(), &beta, rsc_->y_desc, y));
   if (inputs.size() == 3) {
     NBLA_CUDNN_CHECK(cudnnAddTensor(cudnn_handle_, &alpha, rsc_->b_desc, b,
                                     &alpha, rsc_->y_desc, y));
@@ -134,7 +134,7 @@ void ConvolutionCudaCudnn<T>::forward_impl(const Variables &inputs,
     NBLA_CUDNN_CHECK(cudnnConvolutionForward(
         cudnn_handle_, &alpha, rsc_->x_desc, x + x_offset_ * g, rsc_->w_desc,
         w + w_offset_ * g, rsc_->conv_desc.desc, rsc_->fwd_algo, workspace,
-        rsc_->fwd_workspace_size, &beta, rsc_->y_desc, y + y_offset_ * g));
+        rsc_->fwd_workspace_size(), &beta, rsc_->y_desc, y + y_offset_ * g));
     if (inputs.size() == 3) {
       // TODO: Bias addition should be outside of the loop. In that case,
       // b_desc and y_desc must be whole image descriptor.
@@ -172,7 +172,8 @@ void ConvolutionCudaCudnn<T>::backward_impl(const Variables &inputs,
     db = inputs[2]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[2]);
   }
   auto alpha = get_cudnn_scalar_arg<T>(1);
-  auto workspace_size = rsc_->workspace_size();
+  auto workspace_size = std::max(rsc_->bwd_data_workspace_size(),
+                                 rsc_->bwd_filter_workspace_size());
   NdArray workspace_arr, workspace_arr_dgrad;
   void *workspace{nullptr}, *workspace_dgrad{nullptr};
   if (workspace_size) {
@@ -191,7 +192,7 @@ void ConvolutionCudaCudnn<T>::backward_impl(const Variables &inputs,
     NBLA_CUDNN_CHECK(cudnnConvolutionBackwardData(
         dgrad_handle_, &alpha, rsc_->w_desc, w, rsc_->y_desc, dy,
         rsc_->conv_dgrad_desc.desc, rsc_->bwd_data_algo, workspace_dgrad,
-        rsc_->bwd_data_workspace_size, &beta, rsc_->x_desc, dx));
+        rsc_->bwd_data_workspace_size(), &beta, rsc_->x_desc, dx));
   }
   if (propagate_down[1]) {
     /** Note:
@@ -204,7 +205,7 @@ void ConvolutionCudaCudnn<T>::backward_impl(const Variables &inputs,
     NBLA_CUDNN_CHECK(cudnnConvolutionBackwardFilter(
         cudnn_handle_, &alpha, rsc_->x_desc, x, rsc_->y_desc, dy,
         rsc_->conv_wgrad_desc.desc, rsc_->bwd_filter_algo, workspace,
-        rsc_->bwd_filter_workspace_size, &beta, rsc_->w_desc, dw));
+        rsc_->bwd_filter_workspace_size(), &beta, rsc_->w_desc, dw));
   }
   if (inputs.size() == 3 && propagate_down[2]) {
     auto beta = get_cudnn_scalar_arg<T>(accum[2] ? 1 : 0);
@@ -219,7 +220,7 @@ void ConvolutionCudaCudnn<T>::backward_impl(const Variables &inputs,
       NBLA_CUDNN_CHECK(cudnnConvolutionBackwardData(
           cudnn_handle_, &alpha, rsc_->w_desc, w + w_offset_ * g, rsc_->y_desc,
           dy + y_offset_ * g, rsc_->conv_dgrad_desc.desc, rsc_->bwd_data_algo,
-          workspace, rsc_->bwd_data_workspace_size, &beta, rsc_->x_desc,
+          workspace, rsc_->bwd_data_workspace_size(), &beta, rsc_->x_desc,
           dx + x_offset_ * g));
     }
     if (propagate_down[1]) {
@@ -227,7 +228,7 @@ void ConvolutionCudaCudnn<T>::backward_impl(const Variables &inputs,
       NBLA_CUDNN_CHECK(cudnnConvolutionBackwardFilter(
           cudnn_handle_, &alpha, rsc_->x_desc, x + x_offset_ * g, rsc_->y_desc,
           dy + y_offset_ * g, rsc_->conv_wgrad_desc.desc, rsc_->bwd_filter_algo,
-          workspace, rsc_->bwd_filter_workspace_size, &beta, rsc_->w_desc,
+          workspace, rsc_->bwd_filter_workspace_size(), &beta, rsc_->w_desc,
           dw + w_offset_ * g));
     }
     if (inputs.size() == 3 && propagate_down[2]) {

--- a/src/nbla/cuda/cudnn/function/generic/convolution.cu
+++ b/src/nbla/cuda/cudnn/function/generic/convolution.cu
@@ -110,7 +110,7 @@ void ConvolutionCudaCudnn<T>::forward_impl(const Variables &inputs,
   if (inputs.size() == 3) {
     b = inputs[2]->get_data_pointer<Tw>(this->ctx_);
   }
-  auto workspace_size = rsc_->fwd_workspace_size();
+  const auto workspace_size = rsc_->fwd_workspace_size();
   NdArray workspace_arr;
 
   void *workspace{nullptr};
@@ -123,8 +123,8 @@ void ConvolutionCudaCudnn<T>::forward_impl(const Variables &inputs,
 #if CUDNN_VERSION >= 7000
   NBLA_CUDNN_CHECK(cudnnConvolutionForward(
       cudnn_handle_, &alpha, rsc_->x_desc, x, rsc_->w_desc, w,
-      rsc_->conv_desc.desc, rsc_->fwd_algo, workspace,
-      rsc_->fwd_workspace_size(), &beta, rsc_->y_desc, y));
+      rsc_->conv_desc.desc, rsc_->fwd_algo, workspace, workspace_size, &beta,
+      rsc_->y_desc, y));
   if (inputs.size() == 3) {
     NBLA_CUDNN_CHECK(cudnnAddTensor(cudnn_handle_, &alpha, rsc_->b_desc, b,
                                     &alpha, rsc_->y_desc, y));
@@ -134,7 +134,7 @@ void ConvolutionCudaCudnn<T>::forward_impl(const Variables &inputs,
     NBLA_CUDNN_CHECK(cudnnConvolutionForward(
         cudnn_handle_, &alpha, rsc_->x_desc, x + x_offset_ * g, rsc_->w_desc,
         w + w_offset_ * g, rsc_->conv_desc.desc, rsc_->fwd_algo, workspace,
-        rsc_->fwd_workspace_size(), &beta, rsc_->y_desc, y + y_offset_ * g));
+        workspace_size, &beta, rsc_->y_desc, y + y_offset_ * g));
     if (inputs.size() == 3) {
       // TODO: Bias addition should be outside of the loop. In that case,
       // b_desc and y_desc must be whole image descriptor.
@@ -172,15 +172,21 @@ void ConvolutionCudaCudnn<T>::backward_impl(const Variables &inputs,
     db = inputs[2]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[2]);
   }
   auto alpha = get_cudnn_scalar_arg<T>(1);
-  auto workspace_size = std::max(rsc_->bwd_data_workspace_size(),
-                                 rsc_->bwd_filter_workspace_size());
+  // Workspaces must be allocated respectively because
+  // cudnnConvolutionBackwardFilter and cudnnConvolutionBackwardData
+  // run concurrently in different stream.
+  const auto workspace_size = rsc_->bwd_filter_workspace_size();
+  const auto workspace_size_dgrad = rsc_->bwd_data_workspace_size();
   NdArray workspace_arr, workspace_arr_dgrad;
   void *workspace{nullptr}, *workspace_dgrad{nullptr};
   if (workspace_size) {
     workspace_arr.reshape({static_cast<Size_t>(workspace_size)}, true);
     workspace =
         workspace_arr.cast(dtypes::BYTE, this->ctx_, true)->pointer<void>();
-    workspace_arr_dgrad.reshape({static_cast<Size_t>(workspace_size)}, true);
+  }
+  if (workspace_size_dgrad) {
+    workspace_arr_dgrad.reshape({static_cast<Size_t>(workspace_size_dgrad)},
+                                true);
     workspace_dgrad = workspace_arr_dgrad.cast(dtypes::BYTE, this->ctx_, true)
                           ->pointer<void>();
   }
@@ -192,7 +198,7 @@ void ConvolutionCudaCudnn<T>::backward_impl(const Variables &inputs,
     NBLA_CUDNN_CHECK(cudnnConvolutionBackwardData(
         dgrad_handle_, &alpha, rsc_->w_desc, w, rsc_->y_desc, dy,
         rsc_->conv_dgrad_desc.desc, rsc_->bwd_data_algo, workspace_dgrad,
-        rsc_->bwd_data_workspace_size(), &beta, rsc_->x_desc, dx));
+        workspace_size_dgrad, &beta, rsc_->x_desc, dx));
   }
   if (propagate_down[1]) {
     /** Note:
@@ -205,7 +211,7 @@ void ConvolutionCudaCudnn<T>::backward_impl(const Variables &inputs,
     NBLA_CUDNN_CHECK(cudnnConvolutionBackwardFilter(
         cudnn_handle_, &alpha, rsc_->x_desc, x, rsc_->y_desc, dy,
         rsc_->conv_wgrad_desc.desc, rsc_->bwd_filter_algo, workspace,
-        rsc_->bwd_filter_workspace_size(), &beta, rsc_->w_desc, dw));
+        workspace_size, &beta, rsc_->w_desc, dw));
   }
   if (inputs.size() == 3 && propagate_down[2]) {
     auto beta = get_cudnn_scalar_arg<T>(accum[2] ? 1 : 0);
@@ -220,7 +226,7 @@ void ConvolutionCudaCudnn<T>::backward_impl(const Variables &inputs,
       NBLA_CUDNN_CHECK(cudnnConvolutionBackwardData(
           cudnn_handle_, &alpha, rsc_->w_desc, w + w_offset_ * g, rsc_->y_desc,
           dy + y_offset_ * g, rsc_->conv_dgrad_desc.desc, rsc_->bwd_data_algo,
-          workspace, rsc_->bwd_data_workspace_size(), &beta, rsc_->x_desc,
+          workspace, workspace_size_dgrad, &beta, rsc_->x_desc,
           dx + x_offset_ * g));
     }
     if (propagate_down[1]) {
@@ -228,8 +234,7 @@ void ConvolutionCudaCudnn<T>::backward_impl(const Variables &inputs,
       NBLA_CUDNN_CHECK(cudnnConvolutionBackwardFilter(
           cudnn_handle_, &alpha, rsc_->x_desc, x + x_offset_ * g, rsc_->y_desc,
           dy + y_offset_ * g, rsc_->conv_wgrad_desc.desc, rsc_->bwd_filter_algo,
-          workspace, rsc_->bwd_filter_workspace_size(), &beta, rsc_->w_desc,
-          dw + w_offset_ * g));
+          workspace, workspace_size, &beta, rsc_->w_desc, dw + w_offset_ * g));
     }
     if (inputs.size() == 3 && propagate_down[2]) {
       auto beta = get_cudnn_scalar_arg<T>(accum[2] ? 1 : 0);

--- a/src/nbla/cuda/cudnn/function/generic/deconvolution.cu
+++ b/src/nbla/cuda/cudnn/function/generic/deconvolution.cu
@@ -90,7 +90,7 @@ void DeconvolutionCudaCudnn<T>::forward_impl(const Variables &inputs,
   if (inputs.size() == 3) {
     b = inputs[2]->get_data_pointer<Tw>(this->ctx_);
   }
-  auto workspace_size = rsc_->workspace_size();
+  auto workspace_size = rsc_->bwd_data_workspace_size();
   NdArray workspace_arr;
   void *workspace{nullptr};
   if (workspace_size) {
@@ -102,7 +102,7 @@ void DeconvolutionCudaCudnn<T>::forward_impl(const Variables &inputs,
   NBLA_CUDNN_CHECK(cudnnConvolutionBackwardData(
       cudnn_handle_, &alpha, rsc_->w_desc, w, rsc_->y_desc, y,
       rsc_->conv_dgrad_desc.desc, rsc_->bwd_data_algo, workspace,
-      rsc_->bwd_data_workspace_size, &beta, rsc_->x_desc, x));
+      rsc_->bwd_data_workspace_size(), &beta, rsc_->x_desc, x));
   if (inputs.size() == 3) {
     NBLA_CUDNN_CHECK(cudnnAddTensor(cudnn_handle_, &alpha, rsc_->b_desc_deconv,
                                     b, &alpha, rsc_->x_desc, x));
@@ -112,7 +112,7 @@ void DeconvolutionCudaCudnn<T>::forward_impl(const Variables &inputs,
     NBLA_CUDNN_CHECK(cudnnConvolutionBackwardData(
         cudnn_handle_, &alpha, rsc_->w_desc, w + w_offset_ * g, rsc_->y_desc,
         y + y_offset_ * g, rsc_->conv_dgrad_desc.desc, rsc_->bwd_data_algo,
-        workspace, rsc_->bwd_data_workspace_size, &beta, rsc_->x_desc,
+        workspace, rsc_->bwd_data_workspace_size(), &beta, rsc_->x_desc,
         x + x_offset_ * g));
     if (inputs.size() == 3) {
       // TODO: Bias addition should be outside of the loop. In that case,
@@ -152,7 +152,8 @@ void DeconvolutionCudaCudnn<T>::backward_impl(
   }
   auto alpha = get_cudnn_scalar_arg<T>(1);
 
-  auto workspace_size = rsc_->workspace_size();
+  auto workspace_size =
+      std::max(rsc_->fwd_workspace_size(), rsc_->bwd_filter_workspace_size());
   NdArray workspace_arr;
   void *workspace{nullptr};
   if (workspace_size) {
@@ -167,14 +168,14 @@ void DeconvolutionCudaCudnn<T>::backward_impl(
     NBLA_CUDNN_CHECK(cudnnConvolutionForward(
         cudnn_handle_, &alpha, rsc_->x_desc, dx, rsc_->w_desc, w,
         rsc_->conv_desc.desc, rsc_->fwd_algo, workspace,
-        rsc_->fwd_workspace_size, &beta, rsc_->y_desc, dy));
+        rsc_->fwd_workspace_size(), &beta, rsc_->y_desc, dy));
   }
   if (propagate_down[1]) {
     auto beta = get_cudnn_scalar_arg<T>(accum[1] ? 1 : 0);
     NBLA_CUDNN_CHECK(cudnnConvolutionBackwardFilter(
         cudnn_handle_, &alpha, rsc_->x_desc, dx, rsc_->y_desc, y,
         rsc_->conv_wgrad_desc.desc, rsc_->bwd_filter_algo, workspace,
-        rsc_->bwd_filter_workspace_size, &beta, rsc_->w_desc, dw));
+        rsc_->bwd_filter_workspace_size(), &beta, rsc_->w_desc, dw));
   }
   if (inputs.size() == 3 && propagate_down[2]) {
     auto beta = get_cudnn_scalar_arg<T>(accum[2] ? 1 : 0);
@@ -190,7 +191,7 @@ void DeconvolutionCudaCudnn<T>::backward_impl(
       NBLA_CUDNN_CHECK(cudnnConvolutionForward(
           cudnn_handle_, &alpha, rsc_->x_desc, dx + x_offset_ * g, rsc_->w_desc,
           w + w_offset_ * g, rsc_->conv_desc.desc, rsc_->fwd_algo, workspace,
-          rsc_->fwd_workspace_size, &beta, rsc_->y_desc, dy + y_offset_ * g));
+          rsc_->fwd_workspace_size(), &beta, rsc_->y_desc, dy + y_offset_ * g));
     }
     if (propagate_down[1]) {
       auto beta = get_cudnn_scalar_arg<T>(accum[1] ? 1 : 0);
@@ -198,7 +199,7 @@ void DeconvolutionCudaCudnn<T>::backward_impl(
       NBLA_CUDNN_CHECK(cudnnConvolutionBackwardFilter(
           cudnn_handle_, &alpha, rsc_->x_desc, dx + x_offset_ * g, rsc_->y_desc,
           y + y_offset_ * g, rsc_->conv_wgrad_desc.desc, rsc_->bwd_filter_algo,
-          workspace, rsc_->bwd_filter_workspace_size, &beta, rsc_->w_desc,
+          workspace, rsc_->bwd_filter_workspace_size(), &beta, rsc_->w_desc,
           dw + w_offset_ * g));
     }
     if (inputs.size() == 3 && propagate_down[2]) {


### PR DESCRIPTION
Handle workspaces for fwd, bwd_data, and bwd_filter differently to reduce memory usage by convolution.