### PR TITLE
Limit numpy version to 1.19.5

### DIFF
--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -149,7 +149,6 @@ RUN umask 0 \
     && . /opt/miniconda3/bin/activate \
     && conda create -n nnabla-build python=${PYVERNAME} \
     && conda activate nnabla-build \
-    && pip install numpy pynvml\
     && pip install -U -r /tmp/deps/requirements.txt \
     && pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda${CUDA_VERSION_MAJOR}${CUDA_VERSION_MINOR} \
        || echo "Skip DALI installation (CUDA=${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR})" \

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -186,7 +186,6 @@ RUN umask 0 \
     && . /opt/miniconda3/bin/activate \
     && conda create -n nnabla-build python=${PYVERNAME} \
     && conda activate nnabla-build \
-    && pip install numpy pynvml\
     && pip install -U -r /tmp/deps/requirements.txt \
     && pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda${CUDA_VERSION_MAJOR}${CUDA_VERSION_MINOR} \
        || echo "Skip DALI installation (CUDA=${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR})" \

--- a/docker/development/Dockerfile.build-mpi-ppc64le
+++ b/docker/development/Dockerfile.build-mpi-ppc64le
@@ -181,8 +181,6 @@ RUN umask 0 \
     && conda create -n nnabla-build python=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} \
     && conda activate nnabla-build \
     && conda update --all -y \
-    && conda install -y numpy scipy scikit-image six \
-    && pip install pynvml \
     && pip install -r /tmp/deps/requirements.txt \
     && conda clean -y --all \
     && cd / \

--- a/docker/development/Dockerfile.build-ppc64le
+++ b/docker/development/Dockerfile.build-ppc64le
@@ -144,8 +144,6 @@ RUN umask 0 \
     && conda create -n nnabla-build python=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} \
     && conda activate nnabla-build \
     && conda update --all -y \
-    && conda install numpy scipy scikit-image six \
-    && pip install pynvml \
     && pip install -r /tmp/deps/requirements.txt \
     && conda clean -y --all \
     && cd / \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@ PyYAML
 Cython
 boto3
 h5py
-numpy
+numpy==1.19.5
 onnx
 protobuf
 requests


### PR DESCRIPTION
When compiling nnabla on numpy >= 1.20.x, the nnabla wheel will not run on numpy <= 1.19.x. In order to maximize the compability of nnabla package, we required compile nnabla on a relative low numpy version, for example, numpy== 1.19.5. In this fix, we tend to limit numpy in build docker to 1.19.5 so that we can build a version can work on numpy 1.19.x.