### PR TITLE
Memory optimization for SpectralNorm

### DIFF
--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -121,6 +121,9 @@ WeightNormalization:
 WeightStandardization:
   float: [float]
   half: [Half]
+SpectralNorm:
+  float: [float]
+  half: [Half]
 MeanSubtraction:
   float: [float]
   half: [Half]

--- a/include/nbla/cuda/function/spectral_norm.hpp
+++ b/include/nbla/cuda/function/spectral_norm.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_SPECTRAL_NORM_HPP
+#define NBLA_CUDA_FUNCTION_SPECTRAL_NORM_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/spectral_norm.hpp>
+
+namespace nbla {
+
+template <typename T> class SpectralNormCuda : public SpectralNorm<T> {
+public:
+  typedef typename CudaType<T>::type Tcu;
+
+  explicit SpectralNormCuda(const Context &ctx, int dim, int itr, float eps,
+                            bool test)
+      : SpectralNorm<T>(ctx, dim, itr, eps, test),
+        device_(std::stoi(ctx.device_id)) {}
+  virtual ~SpectralNormCuda() {}
+  virtual string name() { return "SpectralNormCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/src/nbla/cuda/function/generic/spectral_norm.cu
+++ b/src/nbla/cuda/function/generic/spectral_norm.cu
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/spectral_norm.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void SpectralNormCuda<T>::setup_impl(const Variables &inputs,
+                                     const Variables &outputs) {
+  SpectralNorm<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void SpectralNormCuda<T>::forward_impl(const Variables &inputs,
+                                       const Variables &outputs) {
+  cuda_set_device(this->device_);
+  SpectralNorm<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void SpectralNormCuda<T>::backward_impl(const Variables &inputs,
+                                        const Variables &outputs,
+                                        const vector<bool> &propagate_down,
+                                        const vector<bool> &accum) {
+  if (!(propagate_down[0] || propagate_down[1])) {
+    return;
+  }
+  SpectralNorm<T>::backward_impl(inputs, outputs, propagate_down, accum);
+}
+}


### PR DESCRIPTION
We ported the python-based implementation of SpectralNorm to the cpp-side and optimized it in memory and computation tradeoff.