### PR TITLE
fix conv segment fault error

### DIFF
--- a/include/nbla/cuda/cuda.hpp
+++ b/include/nbla/cuda/cuda.hpp
@@ -129,7 +129,6 @@ public:
 protected:
   std::mutex mtx_cublas_;
   std::mutex mtx_curand_;
-  std::mutex mtx_event_;
   std::mutex mtx_stream;
   unordered_map<int, cublasHandle_t>
       cublas_handles_; ///< cuBLAS handles for each device.

--- a/src/nbla/cuda/cuda.cpp
+++ b/src/nbla/cuda/cuda.cpp
@@ -96,58 +96,20 @@ std::shared_ptr<cudaEvent_t> Cuda::cuda_event(unsigned int flags, int device) {
     device = cuda_get_device();
   }
 
-  /* Find an unused cudaEvent_t with the proper flags and device. */
-  std::lock_guard<decltype(this->mtx_event_)> lock(this->mtx_event_);
-  auto all_events = this->cuda_unused_events_.find(device);
-  if (all_events == this->cuda_unused_events_.end()) {
-    /* Insert an empty set if there is no set corresponding to the device. */
-    this->cuda_unused_events_.insert(
-        {device, unordered_map<unsigned int, vector<cudaEvent_t>>()});
-    all_events = this->cuda_unused_events_.find(device);
-  }
-
-  auto it = all_events->second.find(flags);
-  if (it == all_events->second.end()) {
-    /* Insert an empty set if there is no set corresponding to the flags. */
-    all_events->second.insert({flags, {}});
-    it = all_events->second.find(flags);
-  }
-
-  cudaEvent_t event;
-  if (it->second.empty()) {
-    /* Create a new cudaEvent_t */
-    NBLA_CUDA_CHECK(cudaEventCreateWithFlags(&event, flags));
-  } else {
-    /* Re-use the existing unused cudaEvent_t */
-    event = it->second.back();
-    it->second.pop_back();
-  }
-
   std::default_delete<cudaEvent_t> deleter;
+  cudaEvent_t event;
+  NBLA_CUDA_CHECK(cudaEventCreateWithFlags(&event, flags));
   return std::shared_ptr<cudaEvent_t>(
-      new cudaEvent_t(event), [this, device, flags, deleter](cudaEvent_t *ptr) {
+      new cudaEvent_t(event), [deleter](cudaEvent_t *ptr) {
         /* This lambda function is a custom deleter of the std::shared_ptr.
          * It is invoked when deleting the managed cudaEvent_t.
          */
+        static std::mutex mtx_event;
 
-        /* Prepare empty set if there is no corresponding set */
-        std::lock_guard<decltype(this->mtx_event_)> lock(this->mtx_event_);
-        auto all_events = this->cuda_unused_events_.find(device);
-        if (all_events == this->cuda_unused_events_.end()) {
-          this->cuda_unused_events_.insert(
-              {device, unordered_map<unsigned int, vector<cudaEvent_t>>()});
-          all_events = this->cuda_unused_events_.find(device);
-        }
+        std::lock_guard<decltype(mtx_event)> lock(mtx_event);
 
-        auto it = all_events->second.find(flags);
-        if (it == all_events->second.end()) {
-          all_events->second.insert({flags, {}});
-          it = all_events->second.find(flags);
-        }
-
-        /* Push the managed cudaEvent_t to the unused set because nobody uses
-         * this cudaEvent_t. */
-        it->second.push_back(*ptr);
+        /* Destroy event */
+        NBLA_CUDA_CHECK(cudaEventDestroy(*ptr));
 
         /* Delete the raw pointer of the cudaEvent_t. */
         deleter(ptr);


### PR DESCRIPTION
Fix convolution segment fault error by addressing the problem:
In callback function, *this might have already been destroyed.
The shared_ptr will pass the owner-ship outside of cuda object, this object lived even when cuda object is destroyed, hence, when this object is destroyed, any attempts to access the member of cuda object will fail. 