### PR TITLE
limit h5py version to 3.1.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,7 @@ PyYAML
 # Runtime
 Cython
 boto3
-h5py
+h5py==3.1.0
 numpy==1.19.5
 onnx
 protobuf


### PR DESCRIPTION
On some environment, build was failed because latest h5py no longer supports python3.6.
So, fixed h5py to v3.1.0.