### PR TITLE
set h5py version <= 3.1.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,7 @@ PyYAML
 # Runtime
 Cython
 boto3
-h5py==3.1.0
+h5py<=3.1.0
 numpy==1.19.5
 onnx
 protobuf


### PR DESCRIPTION
Allow h5py version limitation to 3.1.0 or lower.