### PR TITLE
Support forward recomputation in backward propagation

### DIFF
--- a/include/nbla/cuda/cudnn/function/batch_normalization.hpp
+++ b/include/nbla/cuda/cudnn/function/batch_normalization.hpp
@@ -82,13 +82,16 @@ protected:
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
   virtual void forward_impl_batch(const Variables &inputs,
-                                  const Variables &outputs);
+                                  const Variables &outputs,
+                                  const bool update_inputs);
   virtual void forward_impl_global(const Variables &inputs,
                                    const Variables &outputs);
   virtual void backward_impl_batch(const Variables &inputs,
                                    const Variables &outputs,
                                    const vector<bool> &propagate_down,
                                    const vector<bool> &accum);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
 };
 }
 #endif

--- a/include/nbla/cuda/cudnn/function/batch_normalization.hpp
+++ b/include/nbla/cuda/cudnn/function/batch_normalization.hpp
@@ -90,8 +90,8 @@ protected:
                                    const Variables &outputs,
                                    const vector<bool> &propagate_down,
                                    const vector<bool> &accum);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 };
 }
 #endif

--- a/include/nbla/cuda/cudnn/function/fused_batch_normalization.hpp
+++ b/include/nbla/cuda/cudnn/function/fused_batch_normalization.hpp
@@ -89,10 +89,15 @@ public:
 protected:
 #if CUDNN_VERSION > 7400
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void fused_batch_norm_forward(const Variables &inputs,
+                                        const Variables &outputs,
+                                        const bool update_inputs);
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
 #endif
 };
 } // namespace nbla

--- a/include/nbla/cuda/cudnn/function/fused_batch_normalization.hpp
+++ b/include/nbla/cuda/cudnn/function/fused_batch_normalization.hpp
@@ -96,8 +96,8 @@ protected:
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 #endif
 };
 } // namespace nbla

--- a/include/nbla/cuda/cudnn/function/sync_batch_normalization.hpp
+++ b/include/nbla/cuda/cudnn/function/sync_batch_normalization.hpp
@@ -87,7 +87,8 @@ public:
 protected:
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl_batch(const Variables &inputs,
-                                  const Variables &outputs) override;
+                                  const Variables &outputs,
+                                  const bool update_inputs) override;
   virtual void forward_impl_global(const Variables &inputs,
                                    const Variables &outputs) override;
 };

--- a/include/nbla/cuda/function/batch_normalization.hpp
+++ b/include/nbla/cuda/function/batch_normalization.hpp
@@ -71,13 +71,16 @@ protected:
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
   virtual void forward_impl_batch(const Variables &inputs,
-                                  const Variables &outputs);
+                                  const Variables &outputs,
+                                  const bool update_inputs);
   virtual void forward_impl_global(const Variables &inputs,
                                    const Variables &outputs);
   virtual void backward_impl_batch(const Variables &inputs,
                                    const Variables &outputs,
                                    const vector<bool> &propagate_down,
                                    const vector<bool> &accum);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
 };
 }
 #endif

--- a/include/nbla/cuda/function/batch_normalization.hpp
+++ b/include/nbla/cuda/function/batch_normalization.hpp
@@ -79,8 +79,8 @@ protected:
                                    const Variables &outputs,
                                    const vector<bool> &propagate_down,
                                    const vector<bool> &accum);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 };
 }
 #endif

--- a/include/nbla/cuda/function/dropout.hpp
+++ b/include/nbla/cuda/function/dropout.hpp
@@ -58,6 +58,10 @@ protected:
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
+
+  void dropout(const Variables &inputs, const Variables &outputs);
 };
 }
 #endif

--- a/include/nbla/cuda/function/dropout.hpp
+++ b/include/nbla/cuda/function/dropout.hpp
@@ -58,8 +58,8 @@ protected:
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 
   void dropout(const Variables &inputs, const Variables &outputs);
 };

--- a/include/nbla/cuda/function/image_augmentation.hpp
+++ b/include/nbla/cuda/function/image_augmentation.hpp
@@ -53,11 +53,18 @@ public:
 
 protected:
   int device_;
+  bool save_output_data_ = false;
+  NdArray output_data_for_recomp_;
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
+  virtual void setup_recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
 };
 }
 

--- a/include/nbla/cuda/function/image_augmentation.hpp
+++ b/include/nbla/cuda/function/image_augmentation.hpp
@@ -18,6 +18,7 @@
 #define __NBLA_CUDA_FUNCTION_IMAGEAUGMENTATION_HPP__
 
 #include <nbla/cuda/cuda.hpp>
+#include <nbla/cuda/utils/random.hpp>
 #include <nbla/function/image_augmentation.hpp>
 namespace nbla {
 /** @copydoc ImageAugmentation

--- a/include/nbla/cuda/function/image_augmentation.hpp
+++ b/include/nbla/cuda/function/image_augmentation.hpp
@@ -61,10 +61,9 @@ protected:
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
   virtual void setup_recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+                                    const Variables &outputs);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 };
 }
 

--- a/include/nbla/cuda/function/mean_subtraction.hpp
+++ b/include/nbla/cuda/function/mean_subtraction.hpp
@@ -55,6 +55,8 @@ protected:
                                     const Variables &outputs,
                                     const vector<bool> &propagate_down,
                                     const vector<bool> &accum);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
 };
 }
 

--- a/include/nbla/cuda/function/mean_subtraction.hpp
+++ b/include/nbla/cuda/function/mean_subtraction.hpp
@@ -55,8 +55,8 @@ protected:
                                     const Variables &outputs,
                                     const vector<bool> &propagate_down,
                                     const vector<bool> &accum);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 };
 }
 

--- a/include/nbla/cuda/function/rand.hpp
+++ b/include/nbla/cuda/function/rand.hpp
@@ -52,11 +52,18 @@ public:
 protected:
   int device_;
   curandGenerator_t curand_generator_;
+  bool save_output_data_ = false;
+  NdArray output_data_for_recomp_;
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
+  virtual void setup_recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
 };
 }
 

--- a/include/nbla/cuda/function/rand.hpp
+++ b/include/nbla/cuda/function/rand.hpp
@@ -60,10 +60,9 @@ protected:
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
   virtual void setup_recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+                                    const Variables &outputs);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 };
 }
 

--- a/include/nbla/cuda/function/randint.hpp
+++ b/include/nbla/cuda/function/randint.hpp
@@ -52,11 +52,18 @@ public:
 protected:
   int device_;
   curandGenerator_t curand_generator_;
+  bool save_output_data_ = false;
+  NdArray output_data_for_recomp_;
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
+  virtual void setup_recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
 };
 }
 

--- a/include/nbla/cuda/function/randint.hpp
+++ b/include/nbla/cuda/function/randint.hpp
@@ -60,10 +60,9 @@ protected:
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
   virtual void setup_recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+                                    const Variables &outputs);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 };
 }
 

--- a/include/nbla/cuda/function/randn.hpp
+++ b/include/nbla/cuda/function/randn.hpp
@@ -59,10 +59,9 @@ protected:
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
   virtual void setup_recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+                                    const Variables &outputs);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 };
 }
 

--- a/include/nbla/cuda/function/randn.hpp
+++ b/include/nbla/cuda/function/randn.hpp
@@ -51,11 +51,18 @@ public:
 protected:
   int device_;
   curandGenerator_t curand_generator_;
+  bool save_output_data_ = false;
+  NdArray output_data_for_recomp_;
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
+  virtual void setup_recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
 };
 }
 

--- a/include/nbla/cuda/function/random_choice.hpp
+++ b/include/nbla/cuda/function/random_choice.hpp
@@ -54,10 +54,9 @@ protected:
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
   virtual void setup_recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+                                    const Variables &outputs);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
   virtual void sample_with_replacement(const Variables &inputs,
                                        const Variables &outputs);
   virtual void sample_without_replace(const Variables &inputs,

--- a/include/nbla/cuda/function/random_choice.hpp
+++ b/include/nbla/cuda/function/random_choice.hpp
@@ -47,10 +47,17 @@ public:
 protected:
   int device_;
   curandGenerator_t curand_generator_;
+  bool save_output_data_ = false;
+  NdArray output_data_for_recomp_;
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
+  virtual void setup_recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
   virtual void sample_with_replacement(const Variables &inputs,
                                        const Variables &outputs);
   virtual void sample_without_replace(const Variables &inputs,

--- a/include/nbla/cuda/function/random_crop.hpp
+++ b/include/nbla/cuda/function/random_crop.hpp
@@ -54,10 +54,9 @@ protected:
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
   virtual void setup_recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+                                    const Variables &outputs);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 };
 }
 #endif

--- a/include/nbla/cuda/function/random_crop.hpp
+++ b/include/nbla/cuda/function/random_crop.hpp
@@ -46,11 +46,18 @@ protected:
   NdArray shape_info_buf_;
   curandGenerator_t curand_generator_;
   shared_ptr<CudaCachedArray> random_values_;
+  bool save_output_data_ = false;
+  NdArray output_data_for_recomp_;
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
+  virtual void setup_recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
 };
 }
 #endif

--- a/include/nbla/cuda/function/random_erase.hpp
+++ b/include/nbla/cuda/function/random_erase.hpp
@@ -55,11 +55,18 @@ protected:
   int device_;
   NdArrayPtr state_;
   curandGenerator_t curand_generator_;
+  bool save_output_data_ = false;
+  NdArray output_data_for_recomp_;
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
+  virtual void setup_recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
 };
 }
 #endif

--- a/include/nbla/cuda/function/random_erase.hpp
+++ b/include/nbla/cuda/function/random_erase.hpp
@@ -63,10 +63,9 @@ protected:
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
   virtual void setup_recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+                                    const Variables &outputs);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 };
 }
 #endif

--- a/include/nbla/cuda/function/random_flip.hpp
+++ b/include/nbla/cuda/function/random_flip.hpp
@@ -48,11 +48,18 @@ protected:
   NdArray flip_flags_;
   NdArray shape_info_buf_;
   NdArray onehot_axses_;
+  bool save_output_data_ = false;
+  NdArray output_data_for_recomp_;
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
+  virtual void setup_recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
 };
 }
 #endif

--- a/include/nbla/cuda/function/random_flip.hpp
+++ b/include/nbla/cuda/function/random_flip.hpp
@@ -56,10 +56,9 @@ protected:
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
   virtual void setup_recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+                                    const Variables &outputs);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 };
 }
 #endif

--- a/include/nbla/cuda/function/spectral_norm.hpp
+++ b/include/nbla/cuda/function/spectral_norm.hpp
@@ -42,10 +42,9 @@ protected:
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
   virtual void setup_recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute);
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute);
+                                    const Variables &outputs);
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs);
 };
 }
 #endif

--- a/include/nbla/cuda/function/spectral_norm.hpp
+++ b/include/nbla/cuda/function/spectral_norm.hpp
@@ -41,6 +41,11 @@ protected:
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,
                              const vector<bool> &accum);
+  virtual void setup_recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute);
+  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute);
 };
 }
 #endif

--- a/include/nbla/cuda/function/sync_batch_normalization.hpp
+++ b/include/nbla/cuda/function/sync_batch_normalization.hpp
@@ -74,7 +74,8 @@ public:
 protected:
   virtual void setup_impl(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl_batch(const Variables &inputs,
-                                  const Variables &outputs) override;
+                                  const Variables &outputs,
+                                  const bool update_inputs) override;
   virtual void forward_impl_global(const Variables &inputs,
                                    const Variables &outputs) override;
   virtual void backward_impl_batch(const Variables &inputs,

--- a/include/nbla/cuda/utils/random.hpp
+++ b/include/nbla/cuda/utils/random.hpp
@@ -16,7 +16,9 @@
 #define __NBLA_CUDA_UTILS_RANDOM_HPP__
 
 #include <curand_kernel.h>
+#include <nbla/array.hpp>
 #include <nbla/cuda/common.hpp>
+#include <nbla/variable.hpp>
 
 namespace nbla {
 
@@ -70,6 +72,23 @@ void curand_generate_randn(curandGenerator_t gen, T mu, T sigma, T *dev_ptr,
 
 void curand_initialize(const int size, const int seed, const int offset,
                        curandState *state);
+
+// Support functions for recomputation
+template <typename T>
+void save_output_data(const Context &ctx, Variable *output, NdArray &buffer) {
+  const Array *y = output->data()->get(get_dtype<T>(), ctx);
+  Array *buffer_array = buffer.cast(get_dtype<T>(), ctx, true);
+  buffer_array->copy_from(y);
+}
+
+template <typename T>
+void restore_output_data(const Context &ctx, NdArray &buffer,
+                         Variable *output) {
+  const Array *buffer_array = buffer.get(get_dtype<T>(), ctx);
+  Array *y = output->data()->cast(get_dtype<T>(), ctx, true);
+  y->copy_from(buffer_array);
+  buffer.array()->clear();
+}
 }
 
 #endif

--- a/src/nbla/cuda/cudnn/function/generic/batch_normalization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/batch_normalization.cu
@@ -155,9 +155,8 @@ void BatchNormalizationCudaCudnn<T>::forward_impl(const Variables &inputs,
 }
 
 template <class T>
-void BatchNormalizationCudaCudnn<T>::recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+void BatchNormalizationCudaCudnn<T>::recompute_impl(const Variables &inputs,
+                                                    const Variables &outputs) {
   cuda_set_device(std::stoi(this->ctx_.device_id));
   if (this->batch_stat_) { // Training mode.
     forward_impl_batch(inputs, outputs, false /* update_inputs */);

--- a/src/nbla/cuda/cudnn/function/generic/batch_normalization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/batch_normalization.cu
@@ -148,7 +148,19 @@ void BatchNormalizationCudaCudnn<T>::forward_impl(const Variables &inputs,
                                                   const Variables &outputs) {
   cuda_set_device(std::stoi(this->ctx_.device_id));
   if (this->batch_stat_) { // Training mode.
-    forward_impl_batch(inputs, outputs);
+    forward_impl_batch(inputs, outputs, true /* update_inputs */);
+  } else { // Testing mode.
+    forward_impl_global(inputs, outputs);
+  }
+}
+
+template <class T>
+void BatchNormalizationCudaCudnn<T>::recompute_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &need_recompute) {
+  cuda_set_device(std::stoi(this->ctx_.device_id));
+  if (this->batch_stat_) { // Training mode.
+    forward_impl_batch(inputs, outputs, false /* update_inputs */);
   } else { // Testing mode.
     forward_impl_global(inputs, outputs);
   }
@@ -156,7 +168,8 @@ void BatchNormalizationCudaCudnn<T>::forward_impl(const Variables &inputs,
 
 template <class T>
 void BatchNormalizationCudaCudnn<T>::forward_impl_batch(
-    const Variables &inputs, const Variables &outputs) {
+    const Variables &inputs, const Variables &outputs,
+    const bool update_inputs) {
   // Check whether it outputs batch mean and var.
   Variable *batch_mean = &this->mean_;
   Variable *batch_var = &this->var_;
@@ -201,14 +214,14 @@ void BatchNormalizationCudaCudnn<T>::forward_impl_batch(
                 ->cast(DRV_BN_T(), this->ctx_, true)
                 ->pointer(); // batch var
   // Inputs/Outputs
-  void *rm = inputs[this->m_idx_]
-                 ->data()
-                 ->cast(DRV_BN_T(), this->ctx_)
-                 ->pointer(); // running mean
-  void *rv = inputs[this->v_idx_]
-                 ->data()
-                 ->cast(DRV_BN_T(), this->ctx_)
-                 ->pointer(); // running var
+  void *rm = !update_inputs ? nullptr : inputs[this->m_idx_]
+                                            ->data()
+                                            ->cast(DRV_BN_T(), this->ctx_)
+                                            ->pointer(); // running mean
+  void *rv = !update_inputs ? nullptr : inputs[this->v_idx_]
+                                            ->data()
+                                            ->cast(DRV_BN_T(), this->ctx_)
+                                            ->pointer(); // running var
 
   auto a = get_cudnn_scalar_arg<T>(1);
   auto b = get_cudnn_scalar_arg<T>(0);

--- a/src/nbla/cuda/cudnn/function/generic/fused_batch_normalization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/fused_batch_normalization.cu
@@ -217,8 +217,7 @@ void FusedBatchNormalizationCudaCudnn<T>::forward_impl(
 
 template <class T>
 void FusedBatchNormalizationCudaCudnn<T>::recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+    const Variables &inputs, const Variables &outputs) {
   fused_batch_norm_forward(inputs, outputs, false /* update_inputs */);
 }
 

--- a/src/nbla/cuda/function/generic/batch_normalization.cu
+++ b/src/nbla/cuda/function/generic/batch_normalization.cu
@@ -94,9 +94,8 @@ void BatchNormalizationCuda<T>::forward_impl(const Variables &inputs,
 }
 
 template <class T>
-void BatchNormalizationCuda<T>::recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+void BatchNormalizationCuda<T>::recompute_impl(const Variables &inputs,
+                                               const Variables &outputs) {
   cuda_set_device(std::stoi(this->ctx_.device_id));
   if (this->batch_stat_) { // Training mode.
     forward_impl_batch(inputs, outputs, false /* update_inputs */);

--- a/src/nbla/cuda/function/generic/batch_normalization.cu
+++ b/src/nbla/cuda/function/generic/batch_normalization.cu
@@ -87,7 +87,19 @@ void BatchNormalizationCuda<T>::forward_impl(const Variables &inputs,
                                              const Variables &outputs) {
   cuda_set_device(std::stoi(this->ctx_.device_id));
   if (this->batch_stat_) { // Training mode.
-    forward_impl_batch(inputs, outputs);
+    forward_impl_batch(inputs, outputs, true /* update_inputs */);
+  } else { // Testing mode.
+    forward_impl_global(inputs, outputs);
+  }
+}
+
+template <class T>
+void BatchNormalizationCuda<T>::recompute_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &need_recompute) {
+  cuda_set_device(std::stoi(this->ctx_.device_id));
+  if (this->batch_stat_) { // Training mode.
+    forward_impl_batch(inputs, outputs, false /* update_inputs */);
   } else { // Testing mode.
     forward_impl_global(inputs, outputs);
   }
@@ -95,7 +107,8 @@ void BatchNormalizationCuda<T>::forward_impl(const Variables &inputs,
 
 template <class T>
 void BatchNormalizationCuda<T>::forward_impl_batch(const Variables &inputs,
-                                                   const Variables &outputs) {
+                                                   const Variables &outputs,
+                                                   const bool update_inputs) {
   // Check whether it outputs batch mean and var.
   Variable *batch_mean = &this->mean_;
   Variable *batch_var = &this->var_;
@@ -123,9 +136,11 @@ void BatchNormalizationCuda<T>::forward_impl_batch(const Variables &inputs,
       batch_var->cast_data_and_get_pointer<Tc>(this->ctx_, true); // batch varf
   // Inputs/Outputs
   Tc *rm =
-      inputs[m_idx]->cast_data_and_get_pointer<Tc>(this->ctx_); // running mean
+      !update_inputs ? nullptr : inputs[m_idx]->cast_data_and_get_pointer<Tc>(
+                                     this->ctx_); // running mean
   Tc *rv =
-      inputs[v_idx]->cast_data_and_get_pointer<Tc>(this->ctx_); // running var
+      !update_inputs ? nullptr : inputs[v_idx]->cast_data_and_get_pointer<Tc>(
+                                     this->ctx_); // running var
 
 #ifdef BATCH_NORMALIZATION_USE_PARALLEL_REDUCTION
   const int ndim = inputs[0]->ndim();

--- a/src/nbla/cuda/function/generic/dropout.cu
+++ b/src/nbla/cuda/function/generic/dropout.cu
@@ -64,8 +64,7 @@ void DropoutCuda<T>::forward_impl(const Variables &inputs,
 
 template <class T>
 void DropoutCuda<T>::recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute) {
+                                    const Variables &outputs) {
   cuda_set_device(std::stoi(this->ctx_.device_id));
   const Tc *x = inputs[0]->get_data_pointer<Tc>(this->ctx_);
   Tc *y = outputs[0]->cast_data_and_get_pointer<Tc>(this->ctx_, true);

--- a/src/nbla/cuda/function/generic/dropout.cu
+++ b/src/nbla/cuda/function/generic/dropout.cu
@@ -63,6 +63,19 @@ void DropoutCuda<T>::forward_impl(const Variables &inputs,
 }
 
 template <class T>
+void DropoutCuda<T>::recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute) {
+  cuda_set_device(std::stoi(this->ctx_.device_id));
+  const Tc *x = inputs[0]->get_data_pointer<Tc>(this->ctx_);
+  Tc *y = outputs[0]->cast_data_and_get_pointer<Tc>(this->ctx_, true);
+  Variable &mask = this->mask_;
+  float *m = mask.cast_data_and_get_pointer<float>(this->ctx_, true);
+  NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_dropout_forward, inputs[0]->size(),
+                                 this->scale_, this->p_, x, y, m);
+}
+
+template <class T>
 void DropoutCuda<T>::backward_impl(const Variables &inputs,
                                    const Variables &outputs,
                                    const vector<bool> &propagate_down,

--- a/src/nbla/cuda/function/generic/image_augmentation.cu
+++ b/src/nbla/cuda/function/generic/image_augmentation.cu
@@ -138,9 +138,8 @@ void ImageAugmentationCuda<T>::setup_impl(const Variables &inputs,
 }
 
 template <typename T>
-void ImageAugmentationCuda<T>::setup_recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+void ImageAugmentationCuda<T>::setup_recompute_impl(const Variables &inputs,
+                                                    const Variables &outputs) {
   save_output_data_ = true;
 }
 
@@ -294,9 +293,8 @@ void ImageAugmentationCuda<T>::forward_impl(const Variables &inputs,
 }
 
 template <typename T>
-void ImageAugmentationCuda<T>::recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+void ImageAugmentationCuda<T>::recompute_impl(const Variables &inputs,
+                                              const Variables &outputs) {
   // Restore output data of previous forward execution.
   restore_output_data<Tc>(this->ctx_, output_data_for_recomp_, outputs[0]);
   save_output_data_ = false;

--- a/src/nbla/cuda/function/generic/kernel/batch_normalization.cu
+++ b/src/nbla/cuda/function/generic/kernel/batch_normalization.cu
@@ -97,7 +97,7 @@ void forward_batch_parallel_reduction(
         tmp_mean_buffer_per_block, tmp_variance_buffer_per_block, blocks,
         decay_rate, 1. / N, (float)N / (N - 1),
         /* Output */
-        m + i, v + i, rm + i, rv + i);
+        m + i, v + i, rm ? rm + i : nullptr, rv ? rv + i : nullptr);
   }
 #endif
   NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(forward_batch_kernel_gamma_beta_trans,

--- a/src/nbla/cuda/function/generic/mean_subtraction.cu
+++ b/src/nbla/cuda/function/generic/mean_subtraction.cu
@@ -32,6 +32,14 @@ void MeanSubtractionCuda<T>::forward_impl(const Variables &inputs,
 }
 
 template <typename T>
+void MeanSubtractionCuda<T>::recompute_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &need_recompute) {
+  cuda_set_device(std::stoi(this->ctx_.device_id));
+  forward_impl_global(inputs, outputs);
+}
+
+template <typename T>
 __global__ void kernel_mean_subtraction_inc_t(T *t, const int max) {
   if (t[0] < max) {
     t[0] = t[0] + 1;

--- a/src/nbla/cuda/function/generic/mean_subtraction.cu
+++ b/src/nbla/cuda/function/generic/mean_subtraction.cu
@@ -32,9 +32,8 @@ void MeanSubtractionCuda<T>::forward_impl(const Variables &inputs,
 }
 
 template <typename T>
-void MeanSubtractionCuda<T>::recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+void MeanSubtractionCuda<T>::recompute_impl(const Variables &inputs,
+                                            const Variables &outputs) {
   cuda_set_device(std::stoi(this->ctx_.device_id));
   forward_impl_global(inputs, outputs);
 }

--- a/src/nbla/cuda/function/generic/rand.cu
+++ b/src/nbla/cuda/function/generic/rand.cu
@@ -29,8 +29,7 @@ void RandCuda<T>::setup_impl(const Variables &inputs,
 
 template <typename T>
 void RandCuda<T>::setup_recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute) {
+                                       const Variables &outputs) {
   save_output_data_ = true;
 }
 
@@ -55,8 +54,7 @@ void RandCuda<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandCuda<T>::recompute_impl(const Variables &inputs,
-                                 const Variables &outputs,
-                                 const vector<bool> &need_recompute) {
+                                 const Variables &outputs) {
   // Restore output data of previous forward execution.
   typedef typename CudaTypeForceFloat<T>::type Tc;
   restore_output_data<Tc>(this->ctx_, output_data_for_recomp_, outputs[0]);

--- a/src/nbla/cuda/function/generic/rand.cu
+++ b/src/nbla/cuda/function/generic/rand.cu
@@ -24,6 +24,14 @@ template <typename T>
 void RandCuda<T>::setup_impl(const Variables &inputs,
                              const Variables &outputs) {
   Rand<T>::setup_impl(inputs, outputs);
+  output_data_for_recomp_.reshape(outputs[0]->shape(), true);
+}
+
+template <typename T>
+void RandCuda<T>::setup_recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute) {
+  save_output_data_ = true;
 }
 
 template <typename T>
@@ -38,6 +46,21 @@ void RandCuda<T>::forward_impl(const Variables &inputs,
   Tc *y = outputs[0]->cast_data_and_get_pointer<Tc>(this->ctx_, true);
   curand_generate_rand<float>(gen, this->low_, this->high_, y,
                               outputs[0]->size());
+
+  // Save output data for recomputation.
+  if (save_output_data_) {
+    save_output_data<Tc>(this->ctx_, outputs[0], output_data_for_recomp_);
+  }
+}
+
+template <typename T>
+void RandCuda<T>::recompute_impl(const Variables &inputs,
+                                 const Variables &outputs,
+                                 const vector<bool> &need_recompute) {
+  // Restore output data of previous forward execution.
+  typedef typename CudaTypeForceFloat<T>::type Tc;
+  restore_output_data<Tc>(this->ctx_, output_data_for_recomp_, outputs[0]);
+  save_output_data_ = false;
 }
 
 template <typename T>

--- a/src/nbla/cuda/function/generic/randint.cu
+++ b/src/nbla/cuda/function/generic/randint.cu
@@ -29,8 +29,7 @@ void RandintCuda<T>::setup_impl(const Variables &inputs,
 
 template <typename T>
 void RandintCuda<T>::setup_recompute_impl(const Variables &inputs,
-                                          const Variables &outputs,
-                                          const vector<bool> &need_recompute) {
+                                          const Variables &outputs) {
   save_output_data_ = true;
 }
 
@@ -53,8 +52,7 @@ void RandintCuda<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandintCuda<T>::recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute) {
+                                    const Variables &outputs) {
   // Restore output data of previous forward execution.
   restore_output_data<int>(this->ctx_, output_data_for_recomp_, outputs[0]);
   save_output_data_ = false;

--- a/src/nbla/cuda/function/generic/randn.cu
+++ b/src/nbla/cuda/function/generic/randn.cu
@@ -28,8 +28,7 @@ void RandnCuda<T>::setup_impl(const Variables &inputs,
 
 template <typename T>
 void RandnCuda<T>::setup_recompute_impl(const Variables &inputs,
-                                        const Variables &outputs,
-                                        const vector<bool> &need_recompute) {
+                                        const Variables &outputs) {
   save_output_data_ = true;
   output_data_for_recomp_.reshape(outputs[0]->shape(), true);
 }
@@ -54,8 +53,7 @@ void RandnCuda<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandnCuda<T>::recompute_impl(const Variables &inputs,
-                                  const Variables &outputs,
-                                  const vector<bool> &need_recompute) {
+                                  const Variables &outputs) {
   // Restore output data of previous forward execution.
   typedef typename CudaTypeForceFloat<T>::type Tc;
   restore_output_data<Tc>(this->ctx_, output_data_for_recomp_, outputs[0]);

--- a/src/nbla/cuda/function/generic/random_choice.cu
+++ b/src/nbla/cuda/function/generic/random_choice.cu
@@ -100,9 +100,8 @@ __global__ void add_gradient(const size_t size, const size_t w_size,
 } // namespace random_choice_cuda
 
 template <typename T>
-void RandomChoiceCuda<T>::setup_recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+void RandomChoiceCuda<T>::setup_recompute_impl(const Variables &inputs,
+                                               const Variables &outputs) {
   save_output_data_ = true;
   output_data_for_recomp_.reshape(outputs[0]->shape(), true);
 }
@@ -125,8 +124,7 @@ void RandomChoiceCuda<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandomChoiceCuda<T>::recompute_impl(const Variables &inputs,
-                                         const Variables &outputs,
-                                         const vector<bool> &need_recompute) {
+                                         const Variables &outputs) {
   // Restore output data of previous forward execution.
   restore_output_data<Tcu>(this->ctx_, output_data_for_recomp_, outputs[0]);
   save_output_data_ = false;

--- a/src/nbla/cuda/function/generic/random_choice.cu
+++ b/src/nbla/cuda/function/generic/random_choice.cu
@@ -100,6 +100,14 @@ __global__ void add_gradient(const size_t size, const size_t w_size,
 } // namespace random_choice_cuda
 
 template <typename T>
+void RandomChoiceCuda<T>::setup_recompute_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &need_recompute) {
+  save_output_data_ = true;
+  output_data_for_recomp_.reshape(outputs[0]->shape(), true);
+}
+
+template <typename T>
 void RandomChoiceCuda<T>::forward_impl(const Variables &inputs,
                                        const Variables &outputs) {
   cuda_set_device(this->device_);
@@ -108,6 +116,20 @@ void RandomChoiceCuda<T>::forward_impl(const Variables &inputs,
   } else {
     this->sample_without_replace(inputs, outputs);
   }
+
+  // Save output data for recomputation.
+  if (save_output_data_) {
+    save_output_data<Tcu>(this->ctx_, outputs[0], output_data_for_recomp_);
+  }
+}
+
+template <typename T>
+void RandomChoiceCuda<T>::recompute_impl(const Variables &inputs,
+                                         const Variables &outputs,
+                                         const vector<bool> &need_recompute) {
+  // Restore output data of previous forward execution.
+  restore_output_data<Tcu>(this->ctx_, output_data_for_recomp_, outputs[0]);
+  save_output_data_ = false;
 }
 
 template <typename T>

--- a/src/nbla/cuda/function/generic/random_crop.cu
+++ b/src/nbla/cuda/function/generic/random_crop.cu
@@ -45,6 +45,8 @@ void RandomCropCuda<T>::setup_impl(const Variables &inputs,
     shape_info_cpu[i * 5 + 3] = inputs[0]->shape()[i];   // input_shape
     shape_info_cpu[i * 5 + 4] = inputs[0]->strides()[i]; // input_stride
   }
+
+  output_data_for_recomp_.reshape(outputs[0]->shape(), true);
 }
 
 template <typename T, bool is_backward>
@@ -106,6 +108,13 @@ __global__ void kernel_random_crop(const int num, const int dim, T *dst,
 }
 
 template <typename T>
+void RandomCropCuda<T>::setup_recompute_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &need_recompute) {
+  save_output_data_ = true;
+}
+
+template <typename T>
 void RandomCropCuda<T>::forward_impl(const Variables &inputs,
                                      const Variables &outputs) {
   cuda_set_device(this->device_);
@@ -128,6 +137,20 @@ void RandomCropCuda<T>::forward_impl(const Variables &inputs,
                                  inputs[0]->ndim(), y, x, shape_info_gpu,
                                  random_values, this->base_axis_, this->size_,
                                  this->shape_.size(), this->dim_offset_);
+
+  // Save output data for recomputation.
+  if (save_output_data_) {
+    save_output_data<Tcu>(this->ctx_, outputs[0], output_data_for_recomp_);
+  }
+}
+
+template <typename T>
+void RandomCropCuda<T>::recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute) {
+  // Restore output data of previous forward execution.
+  restore_output_data<Tcu>(this->ctx_, output_data_for_recomp_, outputs[0]);
+  save_output_data_ = false;
 }
 
 template <typename T>

--- a/src/nbla/cuda/function/generic/random_crop.cu
+++ b/src/nbla/cuda/function/generic/random_crop.cu
@@ -108,9 +108,8 @@ __global__ void kernel_random_crop(const int num, const int dim, T *dst,
 }
 
 template <typename T>
-void RandomCropCuda<T>::setup_recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+void RandomCropCuda<T>::setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs) {
   save_output_data_ = true;
 }
 
@@ -146,8 +145,7 @@ void RandomCropCuda<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandomCropCuda<T>::recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute) {
+                                       const Variables &outputs) {
   // Restore output data of previous forward execution.
   restore_output_data<Tcu>(this->ctx_, output_data_for_recomp_, outputs[0]);
   save_output_data_ = false;

--- a/src/nbla/cuda/function/generic/random_erase.cu
+++ b/src/nbla/cuda/function/generic/random_erase.cu
@@ -168,9 +168,8 @@ void RandomEraseCuda<T>::setup_impl(const Variables &inputs,
 }
 
 template <typename T>
-void RandomEraseCuda<T>::setup_recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+void RandomEraseCuda<T>::setup_recompute_impl(const Variables &inputs,
+                                              const Variables &outputs) {
   save_output_data_ = true;
 }
 
@@ -258,8 +257,7 @@ void RandomEraseCuda<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandomEraseCuda<T>::recompute_impl(const Variables &inputs,
-                                        const Variables &outputs,
-                                        const vector<bool> &need_recompute) {
+                                        const Variables &outputs) {
   // Restore output data of previous forward execution.
   restore_output_data<Tcu>(this->ctx_, output_data_for_recomp_, outputs[0]);
   save_output_data_ = false;

--- a/src/nbla/cuda/function/generic/random_flip.cu
+++ b/src/nbla/cuda/function/generic/random_flip.cu
@@ -77,9 +77,8 @@ __global__ void kernel_random_flip(const int num, const int dim, T *y,
 }
 
 template <typename T>
-void RandomFlipCuda<T>::setup_recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+void RandomFlipCuda<T>::setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs) {
   save_output_data_ = true;
 }
 
@@ -118,8 +117,7 @@ void RandomFlipCuda<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandomFlipCuda<T>::recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute) {
+                                       const Variables &outputs) {
   // Restore output data of previous forward execution.
   restore_output_data<Tcu>(this->ctx_, output_data_for_recomp_, outputs[0]);
   save_output_data_ = false;

--- a/src/nbla/cuda/function/generic/random_flip.cu
+++ b/src/nbla/cuda/function/generic/random_flip.cu
@@ -42,6 +42,8 @@ void RandomFlipCuda<T>::setup_impl(const Variables &inputs,
     auto itr = std::find(this->axes_.begin(), this->axes_.end(), i);
     onehot_axses_cpu[i] = itr != this->axes_.end();
   }
+
+  output_data_for_recomp_.reshape(outputs[0]->shape(), true);
 }
 
 template <typename T, bool accum>
@@ -75,6 +77,13 @@ __global__ void kernel_random_flip(const int num, const int dim, T *y,
 }
 
 template <typename T>
+void RandomFlipCuda<T>::setup_recompute_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &need_recompute) {
+  save_output_data_ = true;
+}
+
+template <typename T>
 void RandomFlipCuda<T>::forward_impl(const Variables &inputs,
                                      const Variables &outputs) {
   cuda_set_device(this->device_);
@@ -100,6 +109,20 @@ void RandomFlipCuda<T>::forward_impl(const Variables &inputs,
                                  inputs[0]->ndim(), y, x, shape_info_gpu,
                                  flip_flags, onehot_axses_gpu, this->base_axis_,
                                  this->size_);
+
+  // Save output data for recomputation.
+  if (save_output_data_) {
+    save_output_data<Tcu>(this->ctx_, outputs[0], output_data_for_recomp_);
+  }
+}
+
+template <typename T>
+void RandomFlipCuda<T>::recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute) {
+  // Restore output data of previous forward execution.
+  restore_output_data<Tcu>(this->ctx_, output_data_for_recomp_, outputs[0]);
+  save_output_data_ = false;
 }
 
 template <typename T>

--- a/src/nbla/cuda/function/generic/spectral_norm.cu
+++ b/src/nbla/cuda/function/generic/spectral_norm.cu
@@ -27,11 +27,10 @@ void SpectralNormCuda<T>::setup_impl(const Variables &inputs,
 }
 
 template <typename T>
-void SpectralNormCuda<T>::setup_recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+void SpectralNormCuda<T>::setup_recompute_impl(const Variables &inputs,
+                                               const Variables &outputs) {
   cuda_set_device(this->device_);
-  SpectralNorm<T>::setup_recompute_impl(inputs, outputs, need_recompute);
+  SpectralNorm<T>::setup_recompute_impl(inputs, outputs);
 }
 
 template <typename T>
@@ -43,10 +42,9 @@ void SpectralNormCuda<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void SpectralNormCuda<T>::recompute_impl(const Variables &inputs,
-                                         const Variables &outputs,
-                                         const vector<bool> &need_recompute) {
+                                         const Variables &outputs) {
   cuda_set_device(this->device_);
-  SpectralNorm<T>::recompute_impl(inputs, outputs, need_recompute);
+  SpectralNorm<T>::recompute_impl(inputs, outputs);
 }
 
 template <typename T>

--- a/src/nbla/cuda/function/generic/spectral_norm.cu
+++ b/src/nbla/cuda/function/generic/spectral_norm.cu
@@ -27,10 +27,26 @@ void SpectralNormCuda<T>::setup_impl(const Variables &inputs,
 }
 
 template <typename T>
+void SpectralNormCuda<T>::setup_recompute_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &need_recompute) {
+  cuda_set_device(this->device_);
+  SpectralNorm<T>::setup_recompute_impl(inputs, outputs, need_recompute);
+}
+
+template <typename T>
 void SpectralNormCuda<T>::forward_impl(const Variables &inputs,
                                        const Variables &outputs) {
   cuda_set_device(this->device_);
   SpectralNorm<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void SpectralNormCuda<T>::recompute_impl(const Variables &inputs,
+                                         const Variables &outputs,
+                                         const vector<bool> &need_recompute) {
+  cuda_set_device(this->device_);
+  SpectralNorm<T>::recompute_impl(inputs, outputs, need_recompute);
 }
 
 template <typename T>

--- a/src/nbla/cuda/function/generic/sync_batch_normalization.cu
+++ b/src/nbla/cuda/function/generic/sync_batch_normalization.cu
@@ -37,7 +37,8 @@ void SyncBatchNormalizationCuda<T>::setup_impl(const Variables &inputs,
 
 template <class T>
 void SyncBatchNormalizationCuda<T>::forward_impl_batch(
-    const Variables &inputs, const Variables &outputs) {
+    const Variables &inputs, const Variables &outputs,
+    const bool update_inputs) {
   // Check whether it outputs batch mean and var.
   Variable *batch_mean = &this->mean_;
   Variable *batch_var = &this->var_;
@@ -56,8 +57,10 @@ void SyncBatchNormalizationCuda<T>::forward_impl_batch(
   Tc *v =
       batch_var->cast_data_and_get_pointer<Tc>(this->ctx_, true); // batch varf
   // Inputs/Outputs
-  Tc *rm = inputs[3]->cast_data_and_get_pointer<Tc>(this->ctx_); // running mean
-  Tc *rv = inputs[4]->cast_data_and_get_pointer<Tc>(this->ctx_); // running var
+  Tc *rm = !update_inputs ? nullptr : inputs[3]->cast_data_and_get_pointer<Tc>(
+                                          this->ctx_); // running mean
+  Tc *rv = !update_inputs ? nullptr : inputs[4]->cast_data_and_get_pointer<Tc>(
+                                          this->ctx_); // running var
 
   // Calculate mean and squared-mean
   NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(forward_batch_mean_sqmean_kernel,


### PR DESCRIPTION
All cleared buffers during forward computation will be re-calculated in the middle of backward propagation if it's needed to compute gradient.

nnabla: https://github.com/sony/nnabla/pull/879