### PR TITLE
Fix buffer overrun with cudnnBatchNormalizationForwardTraining

### DIFF
--- a/src/nbla/cuda/cudnn/function/generic/batch_normalization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/batch_normalization.cu
@@ -56,7 +56,8 @@ void BatchNormalizationCudaCudnn<T>::setup_impl(const Variables &inputs,
   mode_ = CUDNN_BATCHNORM_SPATIAL;
   // Channel last is restricted for spatial input
   bool channel_last = this->axes_[0] == inputs[0]->ndim() - 1;
-  if (inputs[0]->ndim() == 2) { // typical 1-d affine output with shape (N, C)
+  if (inputs[0]->ndim() == 2 && H == 1 && W == 1) {
+    // typical 1-d affine output with shape (N, C)
     mode_ = CUDNN_BATCHNORM_PER_ACTIVATION;
     NBLA_CUDNN_CHECK(
         cudnnSetTensor4dDescriptor(input_desc_.desc, CUDNN_TENSOR_NHWC,


### PR DESCRIPTION
Fix buffer overrun caused by buffer size mismatch between internal variable and cudnn tensor descriptor. This bug sometimes affected the functions: LayerNormalization, InstanceNormalization, GroupNormalization which use the batch normalization internally.