### PR TITLE
fix: pynvml.nvml has no attribute nvml_lib

### DIFF
--- a/python/src/nnabla_ext/cuda/__init__.py
+++ b/python/src/nnabla_ext/cuda/__init__.py
@@ -68,7 +68,7 @@ def load_shared_from_error(err):
 
 def check_gpu_compatibility():
     import os
-    from nnabla.utils.nvml import pynvml
+    import pynvml
 
     def list_local_gpu():
         pynvml.nvmlInit()

--- a/python/src/nnabla_ext/cudnn/__init__.py
+++ b/python/src/nnabla_ext/cudnn/__init__.py
@@ -81,7 +81,7 @@ def check_gpu(device_id):
 
     """
     import os
-    from nnabla.utils.nvml import pynvml
+    import pynvml
     incompatible_gpus = nnabla_ext.cuda.incompatible_gpus
     cuda_ver = nnabla_ext.cuda.__cuda_version__.replace('.', '')
     cudnn_ver = nnabla_ext.cuda.__cudnn_version__[0]


### PR DESCRIPTION
updated pynvml can be handled the placement of nvml.dll correctly, so simply use pynvml.