### PR TITLE
 Higher-order gradients for normalization functions

### DIFF
--- a/include/nbla/cuda/function/spectral_norm.hpp
+++ b/include/nbla/cuda/function/spectral_norm.hpp
@@ -25,8 +25,8 @@ public:
   typedef typename CudaType<T>::type Tcu;
 
   explicit SpectralNormCuda(const Context &ctx, int dim, int itr, float eps,
-                            bool test)
-      : SpectralNorm<T>(ctx, dim, itr, eps, test),
+                            bool test, bool output_u)
+      : SpectralNorm<T>(ctx, dim, itr, eps, test, output_u),
         device_(std::stoi(ctx.device_id)) {}
   virtual ~SpectralNormCuda() {}
   virtual string name() { return "SpectralNormCuda"; }


### PR DESCRIPTION
We implemented backward_functions for the following functions to support higher-order gradients.

- layer-normalization
- instance-normalization
- group-normalization
- norm
- norm-normalization
- weight-normalization
- weight-standardization
- spectral-normalization