### PR TITLE
Disable ReLUCudaCudnn and optimize ReLUCuda

### DIFF
--- a/build-tools/code_generator/function_types_cudnn.yaml
+++ b/build-tools/code_generator/function_types_cudnn.yaml
@@ -38,9 +38,9 @@ Sigmoid:
 Tanh:
   float: [float]
   half: [Half]
-ReLU:
-  float: [float]
-  half: [Half]
+# ReLU:
+#   float: [float]
+#   half: [Half]
 # LeakyReLU:
 #   float: [float]
 Softmax:

--- a/include/nbla/cuda/cudnn/function/relu.hpp
+++ b/include/nbla/cuda/cudnn/function/relu.hpp
@@ -21,6 +21,14 @@
 
 namespace nbla {
 
+// This implementation can be activated when the relu in
+// build-tools/code_generator/function_types.yaml is activated.
+// See also src/nbla/cuda/cudnn/function/generic/relu.cu
+//
+// ReLUCudaCudnn requres inputs[0] (x) and outputs[0] (y), but ReLUCuda only
+// requires y. Therefore ReLUCuda has an advantage of memory usage over
+// ReLUCudaCudnn. That is why ReLUCudaCudnn was removed.
+#if 0
 /** @copydoc ReLU
 */
 template <typename T> class ReLUCudaCudnn : public ReLUCuda<T> {
@@ -61,5 +69,6 @@ protected:
                              const vector<bool> &accum);
   virtual bool grad_depends_input_data_impl(int i, int j) const { return true; }
 };
+#endif
 }
 #endif

--- a/src/nbla/cuda/cudnn/function/generic/relu.cu
+++ b/src/nbla/cuda/cudnn/function/generic/relu.cu
@@ -24,6 +24,14 @@
 
 namespace nbla {
 
+// This implementation can be activated when the relu in
+// build-tools/code_generator/function_types.yaml is activated.
+// See also include/nbla/cuda/cudnn/function/generic/relu.cu
+//
+// ReLUCudaCudnn requres inputs[0] (x) and outputs[0] (y), but ReLUCuda only
+// requires y. Therefore ReLUCuda has an advantage of memory usage over
+// ReLUCudaCudnn. That is why ReLUCudaCudnn was removed.
+#if 0
 template <typename T>
 void ReLUCudaCudnn<T>::setup_impl(const Variables &inputs,
                                   const Variables &outputs) {
@@ -81,4 +89,5 @@ void ReLUCudaCudnn<T>::backward_impl(const Variables &inputs,
       this->output_desc_, dy, input_desc_, x, &beta, input_desc_, dx));
 #endif
 }
+#endif
 }


### PR DESCRIPTION
We disable ReLUCudaCudnn and optimize ReLUCuda to improve memory efficiency during backward computation.
We have checked the new ReLUCuda on a par with or faster than the current ReLUCudaCudnn in terms of computational time.

We also update some unit tests for F.relu to support this update. Please refer https://github.com/sony/nnabla/pull/931.