### PR TITLE
 Boolean Indexing Functions

### DIFF
--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -576,6 +576,15 @@ ScatterNd:
 ScatterAdd:
   float: [float]
   half: [Half]
+BoolGather:
+  float: [float]
+  half: [Half]
+BoolScatter:
+  float: [float]
+  half: [Half]
+BoolFill:
+  float: [float]
+  half: [Half]
 MaxPoolingBackward:
   float: [float]
   half: [Half]

--- a/include/nbla/cuda/function/bool_fill.hpp
+++ b/include/nbla/cuda/function/bool_fill.hpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_BOOL_FILL_HPP
+#define NBLA_CUDA_FUNCTION_BOOL_FILL_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/bool_fill.hpp>
+
+namespace nbla {
+
+template <typename T> class BoolFillCuda : public BoolFill<T> {
+public:
+  /* TODO: remove this help message.
+  Typedef of CUDA scalar types used in source file.
+  This template function class might be instantiated for each CPU scalar types
+  (double, float, nbla::Half), however, for Half, CUDA kernel functions
+  must use nbla::HalfCuda in which a bunch of device operator functions are
+  overloaded. nbla::CudaType<T>::type will translate nbla::Half
+  to nbla::HalfCuda. For other types, it will keep it as-is.
+  See nbla/cuda/half.hpp for other template utilities.
+  */
+  typedef typename CudaType<T>::type Tcu;
+
+  explicit BoolFillCuda(const Context &ctx, float value)
+      : BoolFill<T>(ctx, value), device_(std::stoi(ctx.device_id)) {}
+  virtual ~BoolFillCuda() {}
+  virtual string name() { return "BoolFillCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/function/bool_gather.hpp
+++ b/include/nbla/cuda/function/bool_gather.hpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_BOOL_GATHER_HPP
+#define NBLA_CUDA_FUNCTION_BOOL_GATHER_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/bool_gather.hpp>
+
+namespace nbla {
+
+template <typename T> class BoolGatherCuda : public BoolGather<T> {
+public:
+  typedef typename CudaType<T>::type Tcu;
+
+  explicit BoolGatherCuda(const Context &ctx)
+      : BoolGather<T>(ctx), device_(std::stoi(ctx.device_id)) {}
+  virtual ~BoolGatherCuda() {}
+  virtual string name() { return "BoolGatherCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/function/bool_scatter.hpp
+++ b/include/nbla/cuda/function/bool_scatter.hpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_BOOL_SCATTER_HPP
+#define NBLA_CUDA_FUNCTION_BOOL_SCATTER_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/bool_scatter.hpp>
+
+namespace nbla {
+
+template <typename T> class BoolScatterCuda : public BoolScatter<T> {
+public:
+  typedef typename CudaType<T>::type Tcu;
+
+  explicit BoolScatterCuda(const Context &ctx)
+      : BoolScatter<T>(ctx), device_(std::stoi(ctx.device_id)) {}
+  virtual ~BoolScatterCuda() {}
+  virtual string name() { return "BoolScatterCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/cuda/function/utils/bool_indexing.cuh
+++ b/include/nbla/cuda/function/utils/bool_indexing.cuh
@@ -1,0 +1,68 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** Base class of unary operations for CUDA.
+ */
+#ifndef __NBLA_CUDA_FUNCTION_BOOL_INDEXING_CUH__
+#define __NBLA_CUDA_FUNCTION_BOOL_INDEXING_CUH__
+
+namespace nbla {
+
+namespace bool_indexing_cuda {
+
+template <typename T, bool accum = false>
+__global__ void kernel_bool_gather(int D, int B, int nnz, T *sdata,
+                                   const T *gdata, const T *mask) {
+  NBLA_CUDA_KERNEL_LOOP(d, D) {
+    auto idx_nnz = 0;
+    for (int b = 0; b < B && idx_nnz < nnz; ++b) {
+      auto mask_b = int(mask[b] != T(0));
+      auto masked_gdata = mask_b * gdata[b * D + d];
+      // After written, increment idx_nnz, thus no overwrite to the previously
+      // written value.
+      sdata[idx_nnz * D + d] =
+          accum ? sdata[idx_nnz * D + d] + masked_gdata : masked_gdata;
+      idx_nnz += mask_b;
+    }
+  }
+}
+
+template <typename T, bool accum = false, bool inplace = false>
+__global__ void kernel_bool_scatter(int D, int B, int nnz, T *gdata,
+                                    const T *sdata, const T *mask) {
+  NBLA_CUDA_KERNEL_LOOP(d, D) {
+    int idx_nnz = 0;
+    for (int b = 0; b < B; ++b) {
+      auto mask_b = int(mask[b] != T(0));
+      auto sdata_i = sdata[idx_nnz * D + d];
+      auto masked_sdata_i = mask_b * sdata_i;
+      if (inplace) {
+        // (1 - mask_b)-multiply trick does not work if gdata is in {-inf, inf,
+        // nan}
+        masked_sdata_i = mask_b ? masked_sdata_i : gdata[b * D + d];
+      }
+
+      if (accum)
+        gdata[b * D + d] += masked_sdata_i;
+      else
+        gdata[b * D + d] = masked_sdata_i;
+      idx_nnz += mask_b;
+      idx_nnz = min(idx_nnz, nnz - 1); // prevent illegal memory access
+    }
+  }
+}
+}
+}
+
+#endif

--- a/src/nbla/cuda/function/generic/bool_fill.cu
+++ b/src/nbla/cuda/function/generic/bool_fill.cu
@@ -1,0 +1,112 @@
+
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/bool_fill.hpp>
+#include <nbla/imperative.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+namespace bool_fill_cuda {
+
+template <typename T>
+__global__ void kernel_bool_fill_forward(const int N, T *output, const T *data,
+                                         const T *mask, const T value) {
+  NBLA_CUDA_KERNEL_LOOP(i, N) {
+    output[i] = (mask[i] != 0) ? T(value) : data[i];
+  }
+}
+
+template <typename T, bool accum = false>
+__global__ void kernel_bool_fill_data_backward(const int N, T *g_data,
+                                               const T *g_output,
+                                               const T *mask) {
+  NBLA_CUDA_KERNEL_LOOP(i, N) {
+    auto mask_i = T(mask[i] != T(0));
+    g_data[i] = accum ? g_data[i] + g_output[i] * (T(1) - mask_i)
+                      : g_output[i] * (T(1) - mask_i);
+  }
+}
+}
+
+template <typename T>
+void BoolFillCuda<T>::setup_impl(const Variables &inputs,
+                                 const Variables &outputs) {
+  BoolFill<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void BoolFillCuda<T>::forward_impl(const Variables &inputs,
+                                   const Variables &outputs) {
+  cuda_set_device(this->device_);
+
+  auto data = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+  auto mask = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+  auto output = outputs[0]->cast_data_and_get_pointer<Tcu>(this->ctx_);
+
+  auto N = inputs[0]->size();
+  if (this->broadcast_func_ != nullptr) {
+    Variable bmask;
+    nbla::execute(this->broadcast_func_, {inputs[1]}, {&bmask});
+    mask = bmask.get_data_pointer<Tcu>(this->ctx_);
+    auto kernel = bool_fill_cuda::kernel_bool_fill_forward<Tcu>;
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, N, output, data, mask,
+                                   T(this->value_));
+  } else {
+    auto kernel = bool_fill_cuda::kernel_bool_fill_forward<Tcu>;
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, N, output, data, mask,
+                                   T(this->value_));
+  }
+}
+
+template <typename T>
+void BoolFillCuda<T>::backward_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &propagate_down,
+                                    const vector<bool> &accum) {
+  if (!(propagate_down[0] || propagate_down[1])) {
+    return;
+  }
+  cuda_set_device(this->device_);
+
+  auto data = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+  auto mask = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+
+  auto g_data =
+      inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[0]);
+  auto g_output = outputs[0]->get_grad_pointer<Tcu>(this->ctx_);
+  auto N = inputs[0]->size();
+
+  if (propagate_down[0]) {
+    if (this->broadcast_func_ != nullptr) {
+      Variable bmask;
+      nbla::execute(this->broadcast_func_, {inputs[1]}, {&bmask});
+      mask = bmask.get_data_pointer<Tcu>(this->ctx_);
+      auto kernel =
+          accum[0] ? bool_fill_cuda::kernel_bool_fill_data_backward<Tcu, true>
+                   : bool_fill_cuda::kernel_bool_fill_data_backward<Tcu, false>;
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, N, g_data, g_output, mask);
+    } else {
+      auto kernel =
+          accum[0] ? bool_fill_cuda::kernel_bool_fill_data_backward<Tcu, true>
+                   : bool_fill_cuda::kernel_bool_fill_data_backward<Tcu, false>;
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, N, g_data, g_output, mask);
+    }
+  }
+}
+}

--- a/src/nbla/cuda/function/generic/bool_gather.cu
+++ b/src/nbla/cuda/function/generic/bool_gather.cu
@@ -1,0 +1,74 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/bool_gather.hpp>
+#include <nbla/cuda/function/utils/bool_indexing.cuh>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void BoolGatherCuda<T>::setup_impl(const Variables &inputs,
+                                   const Variables &outputs) {
+  BoolGather<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void BoolGatherCuda<T>::forward_impl(const Variables &inputs,
+                                     const Variables &outputs) {
+  cuda_set_device(this->device_);
+
+  // Outputs
+  auto mshape = inputs[1]->shape();
+  auto B = inputs[1]->size();
+  auto nnz = outputs[0]->shape()[0];
+  auto D = outputs[0]->size() / nnz;
+  Tcu *sdata = outputs[0]->cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+  const Tcu *gdata = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+  const Tcu *mask = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+
+  auto kernel = bool_indexing_cuda::kernel_bool_gather<Tcu>;
+  NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, D, B, nnz, sdata, gdata, mask);
+}
+
+template <typename T>
+void BoolGatherCuda<T>::backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum) {
+  if (!(propagate_down[0] || propagate_down[1])) {
+    return;
+  }
+  cuda_set_device(this->device_);
+
+  auto mshape = inputs[1]->shape();
+  auto B = inputs[1]->size();
+  auto nnz = outputs[0]->shape()[0];
+  auto D = outputs[0]->size() / nnz;
+  const Tcu *g_sdata = outputs[0]->get_grad_pointer<Tcu>(this->ctx_);
+  const Tcu *mask = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+
+  if (propagate_down[0]) {
+    auto g_gdata =
+        inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[0]);
+    auto kernel = accum[0]
+                      ? bool_indexing_cuda::kernel_bool_scatter<Tcu, true>
+                      : bool_indexing_cuda::kernel_bool_scatter<Tcu, false>;
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, D, B, nnz, g_gdata, g_sdata, mask);
+  }
+}
+}

--- a/src/nbla/cuda/function/generic/bool_scatter.cu
+++ b/src/nbla/cuda/function/generic/bool_scatter.cu
@@ -1,0 +1,108 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/bool_scatter.hpp>
+#include <nbla/cuda/function/utils/bool_indexing.cuh>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void BoolScatterCuda<T>::setup_impl(const Variables &inputs,
+                                    const Variables &outputs) {
+  BoolScatter<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void BoolScatterCuda<T>::forward_impl(const Variables &inputs,
+                                      const Variables &outputs) {
+  cuda_set_device(this->device_);
+
+  auto mshape = inputs[1]->shape();
+  auto gshape = outputs[0]->shape();
+  auto B = inputs[1]->size();
+  auto nnz = inputs[0]->shape()[0];
+  auto D = inputs[0]->size() / nnz;
+
+  auto inplace = (inputs.size() > 2);
+
+  auto sdata = inputs[0]->get_data_pointer<Tcu>(this->ctx_);
+  auto mask = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+  auto gdata = outputs[0]->cast_data_and_get_pointer<Tcu>(this->ctx_, !inplace);
+
+  auto kernel =
+      inplace ? bool_indexing_cuda::kernel_bool_scatter<Tcu, false, true>
+              : bool_indexing_cuda::kernel_bool_scatter<Tcu, false, false>;
+  NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, D, B, nnz, gdata, sdata, mask);
+}
+
+namespace bool_scatter_cuda {
+
+template <typename T, bool accum = false>
+__global__ void kernel_masked_identity(int B, int D, T *g_gdata_inp,
+                                       const T *g_gdata_out, const T *mask) {
+  NBLA_CUDA_KERNEL_LOOP(b, B) {
+    auto umask_b = T(mask[b] == T(0));
+    for (int d = 0; d < D; ++d) {
+      if (accum)
+        g_gdata_inp[b * D + d] += umask_b * g_gdata_out[b * D + d];
+      else
+        g_gdata_inp[b * D + d] = umask_b * g_gdata_out[b * D + d];
+    }
+  }
+}
+}
+
+template <typename T>
+void BoolScatterCuda<T>::backward_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &propagate_down,
+                                       const vector<bool> &accum) {
+  if (!(propagate_down[0] || propagate_down[1] ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+  cuda_set_device(this->device_);
+
+  auto mshape = inputs[1]->shape();
+  auto gshape = outputs[0]->shape();
+  auto B = inputs[1]->size();
+  auto nnz = inputs[0]->shape()[0];
+  auto D = inputs[0]->size() / nnz;
+
+  auto g_gdata = outputs[0]->get_grad_pointer<Tcu>(this->ctx_);
+  auto mask = inputs[1]->get_data_pointer<Tcu>(this->ctx_);
+
+  if (propagate_down[0]) {
+    auto g_sdata =
+        inputs[0]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[0]);
+    auto kernel = accum[0] ? bool_indexing_cuda::kernel_bool_gather<Tcu, true>
+                           : bool_indexing_cuda::kernel_bool_gather<Tcu, false>;
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, D, B, nnz, g_sdata, g_gdata, mask);
+  }
+
+  // inplace
+  if (inputs.size() > 2 && propagate_down[2]) {
+    auto g_gdata_inp =
+        inputs[2]->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum[2]);
+    auto kernel = accum[2]
+                      ? bool_scatter_cuda::kernel_masked_identity<Tcu, true>
+                      : bool_scatter_cuda::kernel_masked_identity<Tcu, false>;
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, B, D, g_gdata_inp, g_gdata, mask);
+  }
+}
+}

--- a/src/nbla/cuda/function/generic/broadcast.cu
+++ b/src/nbla/cuda/function/generic/broadcast.cu
@@ -31,7 +31,7 @@ void BroadcastCuda<T>::setup_impl(const Variables &inputs,
                                   const Variables &outputs) {
   Broadcast<T>::setup_impl(inputs, outputs);
   int ndim = outputs[0]->ndim();
-  auto inshape = inputs[0]->shape();
+  auto eshape = expand_shape(inputs[0]->shape(), ndim);
   vector<int> broadcast_dims;
   if (inputs[0]->ndim() == 0) {
     // If input is a scalar.
@@ -39,7 +39,7 @@ void BroadcastCuda<T>::setup_impl(const Variables &inputs,
     std::iota(broadcast_dims.begin(), broadcast_dims.end(), 0);
   } else {
     for (int d = 0; d < ndim; ++d) {
-      if (this->shape_[d] != inshape[d])
+      if (this->shape_[d] != eshape[d])
         broadcast_dims.push_back(d);
     }
   }
@@ -134,8 +134,11 @@ void BroadcastCuda<T>::forward_impl(const Variables &inputs,
     return v.get_data_pointer<int>(this->ctx_);
   };
   const int *stride_x = _iarr(this->stride_x_);
+  // for (int i = 0; i < this->stride_x_.ndim(); i++) {
+  //   printf("stride_x[%d] = %d\n", i, stride_x[i]);
+  // }
   const int *shape_y = _iarr(this->shape_y_);
-  int ndim = inputs[0]->ndim();
+  int ndim = outputs[0]->ndim();
   int size = outputs[0]->size();
   cuda_set_device(device_);
   switch_broadcast_cuda<NBLA_BROADCAST_MAX_DIM, Tc>::call(ndim, size, x,


### PR DESCRIPTION
Issue: https://github.com/nnabla/nnabla/issues/483

The following functions are added.

- BoolGather
- BoolScatter
- BoolFill

The first two are forward/backward correspondences and typically used like

```python

import numpy as np
import nnabla as nn
import nnabla.functions as F

nn.set_auto_forward(True)

input0 = nn.Variable.from_numpy_array([[1, 2], [3, 4], [5, 6]])
mask = nn.Variable.from_numpy_array([1, 0, 1])
output0 = F.bool_gather(input0, mask)

input1 = output0 + 10 # do whatever for reduced array

output1 = F.bool_scatter(input1, mask)

print(output1.d)  # [[11, 12], [0, 0], [15, 16]]

```


BoolFill can be inplaced like

```python
import numpy as np
import nnabla as nn
import nnabla.functions as F

nn.set_auto_forward(True)

input = nn.Variable.from_numpy_array([[np.inf, 2], [3, np.nan]])
mask = nn.Variable.from_numpy_array([[1, 0], [0, 1]])
output = input.bool_fill(mask, 0)

print(output.d) # inf/nan are replaced with 0, and input.d == output.d

```

---

新規性、秘密情報、パテント情報なしです。
