### PR TITLE
 Bugfix the higher-order gradient of gather_nd

### DIFF
--- a/include/nbla/cuda/function/scatter_nd.hpp
+++ b/include/nbla/cuda/function/scatter_nd.hpp
@@ -24,8 +24,9 @@ template <typename T> class ScatterNdCuda : public ScatterNd<T> {
 public:
   typedef typename CudaType<T>::type Tcu;
 
-  explicit ScatterNdCuda(const Context &ctx, const vector<int> &shape)
-      : ScatterNd<T>(ctx, shape), device_(std::stoi(ctx.device_id)) {}
+  explicit ScatterNdCuda(const Context &ctx, const vector<int> &shape,
+                         const bool add)
+      : ScatterNd<T>(ctx, shape, add), device_(std::stoi(ctx.device_id)) {}
   virtual ~ScatterNdCuda() {}
   virtual string name() { return "ScatterNdCuda"; }
   virtual vector<string> allowed_array_classes() {

--- a/src/nbla/cuda/function/generic/scatter_nd.cu
+++ b/src/nbla/cuda/function/generic/scatter_nd.cu
@@ -45,7 +45,7 @@ __global__ void forward(const int x_size, const T *x_data, const int y_size,
       // Scatter indices are supposed to be unique, i.e. not to scatter
       // different values into the same positions. Otherwise it is the last
       // update that survives which for parallel execution is unpredictable.
-      y_data[y_offset] = x_data[tid];
+      atomic_add(&y_data[y_offset], x_data[tid]);
     }
   }
 }


### PR DESCRIPTION
The race condition happened before when we had overlapping indices of F.gather_nd (i.e., advanced indexing) used by nn.grad. This is fixed by this PR, so the interpolation by the composite function works fine now by nn.grad, too.