### PR TITLE
Fix initializer ambiguity in cuda kernel

### DIFF
--- a/src/nbla/cuda/function/generic/group_normalization.cu
+++ b/src/nbla/cuda/function/generic/group_normalization.cu
@@ -77,8 +77,8 @@ void GroupNormalizationCuda<T>::setup_impl(const Variables &inputs,
   sum_dy_.reshape({batch_size_ * channel_size_}, true);
   sum_dyx_.reshape({batch_size_ * channel_size_}, true);
   gamma_invstd_.reshape({batch_size_ * channel_size_}, true);
-  factor1_.reshape({batch_size_ * this->num_groups_}, true);
-  factor2_.reshape({batch_size_ * this->num_groups_}, true);
+  factor1_.reshape({{batch_size_ * this->num_groups_}}, true);
+  factor2_.reshape({{batch_size_ * this->num_groups_}}, true);
 }
 
 template <typename T>


### PR DESCRIPTION
Adds extra braces around the vector initializer-list to avoid compile
time error on some setups.

This commit fixes what I suspect is a parsing ambiguity in the initialization of the kernel. With my setup of CUDA 11.2 and g++ 7.5.0 the extensions fail to compile. I have verified the fix in 1.21.0, 1.22.0 and master.

Line 80 and 81 causes a compile time error when trying to initilize the first argument vector. I suspect the problem is in regards to brace elision, but I can unfortunately not pinpoint why it's not a problem on the three lines 77-79. The difference is that 80-81 contains an implicit conversion since this->num_groups_ is an int while channel_size_ is a nbla::Size_t just like batch_size_.

Here is the error from the compiler before the changes:

```
[ 36%] Building NVCC (Device) object src/nbla/cuda/CMakeFiles/cuda_compile_1.dir/function/cuda_compile_1_generated_group_normalization.cu.o                                                                         

/home/daniel/src/nnabla-ext-cuda-2/src/nbla/cuda/function/./generic/group_normalization.cu: In instantiation of ‘void nbla::GroupNormalizationCuda<T>::setup_impl(const Variables&, const Variables&) [with T = flo 

at; nbla::Variables = std::vector<nbla::Variable*>]’:                                                                                                                                                               

/home/daniel/src/nnabla-ext-cuda-2/src/nbla/cuda/function/group_normalization.cu:26:16:   required from here                                                                                                        

/home/daniel/src/nnabla-ext-cuda-2/src/nbla/cuda/function/./generic/group_normalization.cu:80:34: error: cannot convert ‘nbla::Size_t’ {aka ‘long int’} to ‘const std::vector<long int>&’                           

   80 |   factor1_.reshape({batch_size_ * this->num_groups_}, true);                                                                                                                                                

      |                    ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~                                                                                                                                                      

      |                                  |                                                                                                                                                                          

      |                                  nbla::Size_t {aka long int}

```

Here is the nvcc version I have tested with:
```
$ nvcc --version 
nvcc: NVIDIA (R) Cuda compiler driver 
Copyright (c) 2005-2020 NVIDIA Corporation 
Built on Mon_Nov_30_19:08:53_PST_2020 
Cuda compilation tools, release 11.2, V11.2.67 
Build cuda_11.2.r11.2/compiler.29373293_0
```

and the g++ version:
```
$ g++ --version 
g++ (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0
```