### PR TITLE
Add PYTEST_OPTS for pytest parallel execution

### DIFF
--- a/build-tools/make/build.mk
+++ b/build-tools/make/build.mk
@@ -143,8 +143,8 @@ nnabla-ext-cuda-test:
 nnabla-ext-cuda-test-local: nnabla-install nnabla-ext-cuda-install
 	cd $(BUILD_EXT_CUDA_DIRECTORY_WHEEL) \
 	&& PYTHONPATH=$(NNABLA_EXT_CUDA_DIRECTORY)/python/test \
-	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh $(NNABLA_DIRECTORY)/python/test \
-	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh $(NNABLA_EXT_CUDA_DIRECTORY)/python/test
+	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh ${PYTEST_OPTS} $(NNABLA_DIRECTORY)/python/test \
+	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh ${PYTEST_OPTS} $(NNABLA_EXT_CUDA_DIRECTORY)/python/test
 
 .PHONY: nnabla-ext-cuda-multi-gpu-test-local
 nnabla-ext-cuda-multi-gpu-test-local: nnabla-install nnabla-ext-cuda-install
@@ -156,8 +156,8 @@ nnabla-ext-cuda-multi-gpu-test-local: nnabla-install nnabla-ext-cuda-install
 			--communicator-gpus=0,1 \
 			$(NNABLA_DIRECTORY)/python/test/communicator
 	cd $(BUILD_EXT_CUDA_DIRECTORY_WHEEL) \
-	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh $(NNABLA_DIRECTORY)/python/test \
-	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh $(NNABLA_EXT_CUDA_DIRECTORY)/python/test
+	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh ${PYTEST_OPTS} $(NNABLA_DIRECTORY)/python/test \
+	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh ${PYTEST_OPTS} $(NNABLA_EXT_CUDA_DIRECTORY)/python/test
 
 .PHONY: update-gpu-list
 update-gpu-list:

--- a/build-tools/msvc/test.bat
+++ b/build-tools/msvc/test.bat
@@ -36,7 +36,7 @@ pip install %PIP_INS_OPTS% --no-deps %WHLCUDA% || GOTO :error
 pip install %PIP_INS_OPTS% pytest pytest-xdist[psutil]
 
 SET PYTHONPATH=%nnabla_ext_cuda_root%\python\test;%VENV%\Lib\site-packages;%PYTHONPATH%
-python -m pytest %nnabla_root%\python\test || GOTO :error
+python -m pytest %PYTEST_OPTS% %nnabla_root%\python\test || GOTO :error
 
 CALL deactivate.bat || GOTO :error
 

--- a/python/pytest.ini
+++ b/python/pytest.ini
@@ -16,5 +16,7 @@
 #addopts = -s -x test/test_save_load.py test/utils/test_data_iterator.py
 #addopts = -s -k test_save_load
 
-## Parallelly exec
-addopts = --numprocesses auto --dist loadscope
+## Parallelly execution
+# Uncomment below option to enable. Adjust 'auto' to proper number
+# suits for your environment (E.g, 4). 'auto' is exhaustive.
+# addopts = --numprocesses auto --dist loadscope


### PR DESCRIPTION
Comment out pytest-xdist options from python/pytest.ini. Leave this file as the interface for feature developers. They can decide to uncomment options inside according to the actual environment.
