### PR TITLE
Make ISTFT consistent with PyTorch implementation (NOLA condition)

### DIFF
--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -39,7 +39,7 @@ RUN eval ${YUM_OPTS} \
         hdf5-devel \
         lapack-devel \
         libjpeg-devel \
-        liblzma-devel \
+        xz-devel \
         libpng-devel \
         redhat-lsb-core \
         rpm-build \

--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -55,6 +55,7 @@ RUN eval ${YUM_OPTS} \
         bzip2-devel \
         libffi-devel \
         libsndfile \
+        python-backports-lzma \
     && yum group install -y "Development Tools" \
     && yum clean all
 

--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -54,6 +54,7 @@ RUN eval ${YUM_OPTS} \
         openssl-devel \
         bzip2-devel \
         libffi-devel \
+        libsndfile \
     && yum group install -y "Development Tools" \
     && yum clean all
 

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -94,6 +94,7 @@ RUN eval ${YUM_OPTS} \
         libffi-devel \
         nsight-systems-2021.1.3 \
         libsndfile \
+        python-backports-lzma \
     && yum group install -y "Development Tools" \
     && yum clean all
 

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -93,6 +93,7 @@ RUN eval ${YUM_OPTS} \
         bzip2-devel \
         libffi-devel \
         nsight-systems-2021.1.3 \
+        libsndfile \
     && yum group install -y "Development Tools" \
     && yum clean all
 

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -77,7 +77,7 @@ RUN eval ${YUM_OPTS} \
         hdf5-devel \
         lapack-devel \
         libjpeg-devel \
-        liblzma-devel \
+        xz-devel \
         libpng-devel \
         redhat-lsb-core \
         rpm-build \

--- a/docker/development/Dockerfile.build-mpi-ppc64le
+++ b/docker/development/Dockerfile.build-mpi-ppc64le
@@ -92,6 +92,7 @@ RUN eval ${YUM_OPTS} \
         openssl-devel \
         bzip2-devel \
         libffi-devel \
+        libsndfile \
     && yum group install -y "Development Tools" \
     && yum clean all
 

--- a/docker/development/Dockerfile.build-mpi-ppc64le
+++ b/docker/development/Dockerfile.build-mpi-ppc64le
@@ -93,6 +93,7 @@ RUN eval ${YUM_OPTS} \
         bzip2-devel \
         libffi-devel \
         libsndfile \
+        python-backports-lzma \
     && yum group install -y "Development Tools" \
     && yum clean all
 

--- a/docker/development/Dockerfile.build-mpi-ppc64le
+++ b/docker/development/Dockerfile.build-mpi-ppc64le
@@ -77,7 +77,7 @@ RUN eval ${YUM_OPTS} \
         hdf5-devel \
         lapack-devel \
         libjpeg-devel \
-        liblzma-devel \
+        xz-devel \
         libpng-devel \
         redhat-lsb-core \
         rpm-build \

--- a/docker/development/Dockerfile.build-ppc64le
+++ b/docker/development/Dockerfile.build-ppc64le
@@ -39,7 +39,7 @@ RUN eval ${YUM_OPTS} \
         hdf5-devel \
         lapack-devel \
         libjpeg-devel \
-        liblzma-devel \
+        xz-devel \
         libpng-devel \
         redhat-lsb-core \
         rpm-build \

--- a/docker/development/Dockerfile.build-ppc64le
+++ b/docker/development/Dockerfile.build-ppc64le
@@ -55,6 +55,7 @@ RUN eval ${YUM_OPTS} \
         bzip2-devel \
         libffi-devel \
         libsndfile \
+        python-backports-lzma \
     && yum group install -y "Development Tools" \
     && yum clean all
 

--- a/docker/development/Dockerfile.build-ppc64le
+++ b/docker/development/Dockerfile.build-ppc64le
@@ -54,6 +54,7 @@ RUN eval ${YUM_OPTS} \
         openssl-devel \
         bzip2-devel \
         libffi-devel \
+        libsndfile \
     && yum group install -y "Development Tools" \
     && yum clean all
 

--- a/include/nbla/cuda/function/kernel/istft.cuh
+++ b/include/nbla/cuda/function/kernel/istft.cuh
@@ -1,0 +1,101 @@
+// Copyright 2021 Sony Group Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// All of the following CUDA kernels and constants are copied from PyTorch (link
+// below) and modified/optimized for NNabla.
+// https://github.com/pytorch/pytorch/blob/32b37ba2462d9d87337a4fe332f95524a4c49777/aten/src/ATen/native/cuda/Normalization.cuh
+
+#include <nbla/cuda/common.hpp>
+
+namespace nbla {
+
+template <typename T>
+__global__ void kernel_inv_window(const int size, const int fft_size,
+                                  const int stride, const T *window,
+                                  T *inv_window) {
+  NBLA_CUDA_KERNEL_LOOP(idx, size) {
+    inv_window[idx] = T(0);
+
+    for (int i = 0; i < fft_size / stride; i++) {
+      const int w_idx = (idx + fft_size - i * stride) % fft_size;
+      const bool right = idx - w_idx >= 0;
+      const bool left = idx + (fft_size - w_idx - 1) < size;
+      if (right && left) {
+        const T w = window[w_idx];
+        inv_window[idx] += w * w;
+      }
+    }
+  }
+}
+
+template <typename T, bool center>
+__global__ void
+kernel_apply_inv_window_forward(const int x_size, const int inv_window_size,
+                                const T *x, T *y, const T *inv_window,
+                                const int fft_size) {
+  NBLA_CUDA_KERNEL_LOOP(idx, x_size) {
+    if (center) {
+      if (fft_size / 2 <= idx % inv_window_size &&
+          idx % inv_window_size < inv_window_size - fft_size / 2) {
+        y[idx] = x[idx] / inv_window[idx % inv_window_size];
+      }
+    } else {
+      y[idx] = x[idx] / inv_window[idx % inv_window_size];
+    }
+  }
+}
+
+template <typename T, bool center, bool accum>
+__global__ void
+kernel_apply_inv_window_backward(const int x_size, const int inv_window_size,
+                                 const int pad_size, T *gx, const T *gy,
+                                 const T *inv_window) {
+  NBLA_CUDA_KERNEL_LOOP(idx, x_size) {
+    const int iw_idx = idx % inv_window_size;
+    if (center) {
+      if (iw_idx < pad_size || inv_window_size - pad_size <= iw_idx) {
+        // Avoid division by zero for padding region.
+        gx[idx] = T(0);
+      } else {
+        gx[idx] = gy[idx] / inv_window[iw_idx] + (accum ? gx[idx] : (T)0);
+      }
+    } else {
+      gx[idx] = gy[idx] / inv_window[iw_idx] + (accum ? gx[idx] : (T)0);
+    }
+  }
+}
+
+template <typename T>
+__global__ void kernel_conv_weight(const int fft_size, const int stride,
+                                   const int weight_size, const T *window,
+                                   T *conv_r, T *conv_i) {
+  NBLA_CUDA_KERNEL_LOOP(idx, weight_size) {
+    const auto w_idx = idx / fft_size;
+    const auto t_idx = idx - w_idx * fft_size; // idx % fft_size
+
+    // Window
+    const T w = window[t_idx];
+
+    // Calculate inverse STFT filter coefficients
+    const auto r_fft_size = 1.0f / fft_size;
+    const auto alpha =
+        (w_idx == 0 || w_idx == fft_size / 2 ? (T)1.0 : (T)2.0) * r_fft_size;
+    const auto mat_cos = alpha * cospif(2.0f * w_idx * t_idx * r_fft_size);
+    const auto mat_sin = alpha * -sinpif(2.0f * w_idx * t_idx * r_fft_size);
+
+    conv_r[idx] = mat_cos * w;
+    conv_i[idx] = mat_sin * w;
+  }
+}
+}

--- a/include/nbla/cuda/function/utils/stft.cuh
+++ b/include/nbla/cuda/function/utils/stft.cuh
@@ -18,23 +18,22 @@
 #include <nbla/cuda/function/utils/stft.hpp>
 
 template <typename T, stft::WINDOW_TYPE window_type>
-__global__ void kernel_window_func(const int window_size, const int fft_size,
-                                   T *wf) {
+__global__ void kernel_window(const int window_size, const int fft_size, T *w) {
   NBLA_CUDA_KERNEL_LOOP(idx, fft_size) {
     const auto left_pad = (fft_size - window_size) / 2;
-    const auto wf_idx = idx - left_pad;
+    const auto w_idx = idx - left_pad;
 
     const auto r_window_size = 1.0f / window_size;
-    if (0 <= wf_idx && wf_idx < window_size) {
+    if (0 <= w_idx && w_idx < window_size) {
       if (window_type == stft::WINDOW_TYPE::hanning) {
-        wf[idx] = (T)0.5 - (T)0.5 * cospif(2.0f * wf_idx * r_window_size);
+        w[idx] = (T)0.5 - (T)0.5 * cospif(2.0f * w_idx * r_window_size);
       } else if (window_type == stft::WINDOW_TYPE::hamming) {
-        wf[idx] = (T)0.54 - (T)0.46 * cospif(2.0f * wf_idx * r_window_size);
+        w[idx] = (T)0.54 - (T)0.46 * cospif(2.0f * w_idx * r_window_size);
       } else { // window_type == istft::WINDOW_TYPE::rectangular
-        wf[idx] = (T)1;
+        w[idx] = (T)1;
       }
     } else {
-      wf[idx] = (T)0;
+      w[idx] = (T)0;
     }
   }
 }

--- a/src/nbla/cuda/function/generic/istft.cu
+++ b/src/nbla/cuda/function/generic/istft.cu
@@ -15,91 +15,147 @@
 #include <nbla/array.hpp>
 #include <nbla/cuda/common.hpp>
 #include <nbla/cuda/function/istft.hpp>
+#include <nbla/cuda/function/kernel/istft.cuh>
 #include <nbla/cuda/function/utils/stft.cuh>
 #include <nbla/variable.hpp>
+
+#include <nbla/cuda/function/stft.hpp>
 
 namespace nbla {
 
 template <typename T>
 void ISTFTCuda<T>::setup_impl(const Variables &inputs,
                               const Variables &outputs) {
+  this->window_type_t_ = string_to_window_type(this->window_type_);
+
   ISTFT<T>::setup_impl(inputs, outputs);
   cuda_set_device(this->device_);
 
-  this->window_type_t_ = string_to_window_type(this->window_type_);
-}
-
-template <typename T>
-__global__ void kernel_conv_weight(const int fft_size, const int stride,
-                                   const int weight_size, const T *window_func,
-                                   T *conv_r, T *conv_i) {
-  NBLA_CUDA_KERNEL_LOOP(idx, weight_size) {
-    const auto w_idx = idx / fft_size;
-    const auto t_idx = idx - w_idx * fft_size; // idx % fft_size
-
-    // window func
-    const T wf = window_func[t_idx];
-
-    // inv window func
-    T iwf = (T)0;
-    auto rolled_wf_idx = t_idx;
-    for (int i = 0; i < fft_size; i += stride) {
-      const auto rolled_wf = window_func[rolled_wf_idx];
-      iwf += rolled_wf * rolled_wf;
-      rolled_wf_idx -= stride;
-      if (rolled_wf_idx < 0) {
-        rolled_wf_idx += fft_size;
-      }
-    }
-
-    // calculate inverse STFT filter coefficients
-    const auto r_fft_size = 1.0f / fft_size;
-    const auto alpha =
-        (w_idx == 0 || w_idx == fft_size / 2 ? (T)1.0 : (T)2.0) * r_fft_size;
-    const auto mat_cos = alpha * cospif(2.0f * w_idx * t_idx * r_fft_size);
-    const auto mat_sin = alpha * sinpif(2.0f * w_idx * t_idx * r_fft_size);
-
-    const auto r_iwf = 1.0f / iwf;
-    conv_r[idx] = mat_cos * wf * r_iwf;
-    conv_i[idx] = mat_sin * wf * r_iwf;
+  if (this->as_stft_backward_) {
+    // For the use of some STFTCuda methods.
+    stft_cuda_ = make_shared<STFTCuda<T>>(
+        this->ctx_, this->window_size_, this->stride_, this->fft_size_,
+        this->window_type_, this->center_, this->pad_mode_,
+        false /* as_istft_backward */);
+    Variable dummy_x(outputs[0]->shape()), dummy_y_r(inputs[0]->shape()),
+        dummy_y_i(inputs[1]->shape());
+    stft_cuda_->setup({&dummy_x}, {&dummy_y_r, &dummy_y_i});
   }
 }
 
 template <typename T>
-void ISTFTCuda<T>::calculate_conv_weight(Variable &conv_cos,
-                                         Variable &conv_sin) {
-  // compute window func
-  Variable window_func({this->fft_size_});
-  auto wf_ptr = window_func.cast_data_and_get_pointer<Tcu>(this->ctx_);
-
+void ISTFTCuda<T>::calculate_window(Context &ctx, Variable *window) const {
   using WINDOW_TYPE = stft::WINDOW_TYPE;
   constexpr auto hanning = WINDOW_TYPE::hanning;
   constexpr auto hamming = WINDOW_TYPE::hamming;
   constexpr auto rectangular = WINDOW_TYPE::rectangular;
 
+  auto window_data = window->cast_data_and_get_pointer<Tcu>(ctx);
+
+  auto kernel = kernel_window<Tcu, rectangular>;
   if (window_type_t_ == hanning) {
-    auto kernel = kernel_window_func<Tcu, hanning>;
-    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, this->window_size_, this->fft_size_,
-                                   wf_ptr);
+    kernel = kernel_window<Tcu, hanning>;
   } else if (window_type_t_ == hamming) {
-    auto kernel = kernel_window_func<Tcu, hamming>;
-    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, this->window_size_, this->fft_size_,
-                                   wf_ptr);
+    kernel = kernel_window<Tcu, hamming>;
+  }
+  NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, this->window_size_, this->fft_size_,
+                                 window_data);
+}
+
+template <typename T>
+void ISTFTCuda<T>::calculate_inv_window(Context &ctx, Variable *inv_window) {
+  // Create window
+  calculate_window(ctx, &this->window_);
+
+  // Calculate inv_window
+  const int size = inv_window->size();
+  const auto window_data = this->window_.template get_data_pointer<Tcu>(ctx);
+  auto inv_window_data = inv_window->cast_data_and_get_pointer<Tcu>(ctx);
+  auto kernel = kernel_inv_window<Tcu>;
+  NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, size, this->fft_size_, this->stride_,
+                                 window_data, inv_window_data);
+
+  // Clear internal buffer
+  this->window_.data()->array()->clear();
+}
+
+template <typename T>
+void ISTFTCuda<T>::apply_inv_window_forward(Variable *x, Variable *y) {
+  // Create inv_window
+  calculate_inv_window(this->ctx_, &this->inv_window_);
+
+  // Apply inv_window
+  const int x_size = x->size();
+  const int inv_window_size = this->inv_window_.size();
+  const auto inv_window_data =
+      this->inv_window_.template get_data_pointer<Tcu>(this->ctx_);
+  const auto x_data = x->get_data_pointer<Tcu>(this->ctx_);
+  auto y_data = y->cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+  auto kernel = this->center_ ? kernel_apply_inv_window_forward<Tcu, true>
+                              : kernel_apply_inv_window_forward<Tcu, false>;
+  NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, x_size, inv_window_size, x_data,
+                                 y_data, inv_window_data, this->fft_size_);
+
+  // Clear internal buffer
+  this->inv_window_.data()->array()->clear();
+}
+
+template <typename T>
+void ISTFTCuda<T>::apply_inv_window_backward(Variable *x, Variable *y,
+                                             const bool accum) {
+  // Create inv_window
+  calculate_inv_window(this->ctx_, &this->inv_window_);
+
+  // Apply inv_window
+  const int x_size = x->size();
+  const int inv_window_size = this->inv_window_.size();
+  const auto inv_window_data =
+      this->inv_window_.template get_data_pointer<Tcu>(this->ctx_);
+  auto x_grad = x->cast_grad_and_get_pointer<Tcu>(this->ctx_, !accum);
+  const auto y_grad = y->get_grad_pointer<Tcu>(this->ctx_);
+  const int pad_size = this->fft_size_ / 2;
+
+  auto kernel = kernel_apply_inv_window_backward<Tcu, true /* center */,
+                                                 true /* accum */>;
+  if (this->center_) {
+    kernel = accum ? kernel_apply_inv_window_backward<Tcu, true, true>
+                   : kernel_apply_inv_window_backward<Tcu, true, false>;
   } else {
-    auto kernel = kernel_window_func<Tcu, rectangular>;
-    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, this->window_size_, this->fft_size_,
-                                   wf_ptr);
+    kernel = accum ? kernel_apply_inv_window_backward<Tcu, false, true>
+                   : kernel_apply_inv_window_backward<Tcu, false, false>;
+  }
+  NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, x_size, inv_window_size, pad_size,
+                                 x_grad, y_grad, inv_window_data);
+
+  // Clear internal buffer
+  this->inv_window_.data()->array()->clear();
+}
+
+template <typename T>
+void ISTFTCuda<T>::calculate_conv_weight(Variable &conv_cos,
+                                         Variable &conv_sin) {
+  if (this->as_stft_backward_) {
+    stft_cuda_->calculate_conv_weight(conv_cos, conv_sin);
+    return;
   }
 
-  // calculate inverse STFT filter coefficients
+  // Compute window
+  calculate_window(this->ctx_, &this->window_);
+
+  // Calculate IDFT (inverse descrete Fourier transform) coefficients and merge
+  // with window func.
   auto conv_cos_ptr = conv_cos.cast_data_and_get_pointer<Tcu>(this->ctx_);
   auto conv_sin_ptr = conv_sin.cast_data_and_get_pointer<Tcu>(this->ctx_);
-  const auto wf_data_ptr = window_func.get_data_pointer<Tcu>(this->ctx_);
+  const auto w_data_ptr =
+      this->window_.template get_data_pointer<Tcu>(this->ctx_);
 
   const int size = conv_cos.size();
   NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_conv_weight<Tcu>, this->fft_size_,
-                                 this->stride_, size, wf_data_ptr, conv_cos_ptr,
+                                 this->stride_, size, w_data_ptr, conv_cos_ptr,
                                  conv_sin_ptr);
+
+  // Clear internal buffer
+  this->window_.data()->array()->clear();
 }
 
 template <typename T>

--- a/src/nbla/cuda/function/generic/stft.cu
+++ b/src/nbla/cuda/function/generic/stft.cu
@@ -18,6 +18,8 @@
 #include <nbla/cuda/function/utils/stft.cuh>
 #include <nbla/variable.hpp>
 
+#include <nbla/cuda/function/istft.hpp>
+
 namespace nbla {
 
 template <typename T>
@@ -27,11 +29,22 @@ void STFTCuda<T>::setup_impl(const Variables &inputs,
   cuda_set_device(this->device_);
 
   this->window_type_t_ = string_to_window_type(this->window_type_);
+
+  if (this->as_istft_backward_) {
+    // For the use of some ISTFTCuda methods.
+    istft_cuda_ = make_shared<ISTFTCuda<T>>(
+        this->ctx_, this->window_size_, this->stride_, this->fft_size_,
+        this->window_type_, this->center_, this->pad_mode_,
+        false /* as_stft_backward */);
+    Variable dummy_y_r(outputs[0]->shape()), dummy_y_i(outputs[1]->shape()),
+        dummy_x;
+    istft_cuda_->setup({&dummy_y_r, &dummy_y_i}, {&dummy_x});
+  }
 }
 
 template <typename T>
 __global__ void kernel_conv_weight(const int fft_size, const int weight_size,
-                                   const T *window_func, T *conv_r, T *conv_i) {
+                                   const T *window, T *conv_r, T *conv_i) {
   NBLA_CUDA_KERNEL_LOOP(idx, weight_size) {
     const auto w_idx = idx / fft_size;
     const auto t_idx = idx - w_idx * fft_size; // idx % fft_size
@@ -40,44 +53,60 @@ __global__ void kernel_conv_weight(const int fft_size, const int weight_size,
     T mat_r = cospif(2.0f * w_idx * t_idx * r_fft_size);
     T mat_i = -sinpif(2.0f * w_idx * t_idx * r_fft_size);
 
-    conv_r[idx] = mat_r * window_func[t_idx];
-    conv_i[idx] = mat_i * window_func[t_idx];
+    conv_r[idx] = mat_r * window[t_idx];
+    conv_i[idx] = mat_i * window[t_idx];
   }
 }
 
 template <typename T>
 void STFTCuda<T>::calculate_conv_weight(Variable &conv_r, Variable &conv_i) {
-  // compute window func
-  Variable window_func({this->fft_size_});
-  auto wf_ptr = window_func.cast_data_and_get_pointer<Tcu>(this->ctx_);
+  if (this->as_istft_backward_) {
+    istft_cuda_->calculate_conv_weight(conv_r, conv_i);
+    return;
+  }
+
+  // Create window
+  auto w_ptr =
+      this->window_.template cast_data_and_get_pointer<Tcu>(this->ctx_);
 
   using WINDOW_TYPE = stft::WINDOW_TYPE;
   constexpr auto hanning = WINDOW_TYPE::hanning;
   constexpr auto hamming = WINDOW_TYPE::hamming;
   constexpr auto rectangular = WINDOW_TYPE::rectangular;
 
+  auto kernel = kernel_window<Tcu, rectangular>;
   if (window_type_t_ == hanning) {
-    auto kernel = kernel_window_func<Tcu, hanning>;
-    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, this->window_size_, this->fft_size_,
-                                   wf_ptr);
+    kernel = kernel_window<Tcu, hanning>;
   } else if (window_type_t_ == hamming) {
-    auto kernel = kernel_window_func<Tcu, hamming>;
-    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, this->window_size_, this->fft_size_,
-                                   wf_ptr);
-  } else {
-    auto kernel = kernel_window_func<Tcu, rectangular>;
-    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, this->window_size_, this->fft_size_,
-                                   wf_ptr);
+    kernel = kernel_window<Tcu, hamming>;
   }
+  NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, this->window_size_, this->fft_size_,
+                                 w_ptr);
 
-  // calculate STFT filter coefficients
+  // Calculate DFT (descrete Fourier transform) coefficients and merge with
+  // window func.
   auto conv_r_ptr = conv_r.cast_data_and_get_pointer<Tcu>(this->ctx_);
   auto conv_i_ptr = conv_i.cast_data_and_get_pointer<Tcu>(this->ctx_);
-  const auto wf_data_ptr = window_func.get_data_pointer<Tcu>(this->ctx_);
+  const auto w_data_ptr =
+      this->window_.template get_data_pointer<Tcu>(this->ctx_);
 
   const int size = conv_r.size();
   NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_conv_weight<Tcu>, this->fft_size_, size,
-                                 wf_data_ptr, conv_r_ptr, conv_i_ptr);
+                                 w_data_ptr, conv_r_ptr, conv_i_ptr);
+
+  // Clear internal buffer
+  this->window_.data()->array()->clear();
+}
+
+template <typename T>
+void STFTCuda<T>::apply_inv_window_forward(Variable *x, Variable *y) {
+  istft_cuda_->apply_inv_window_forward(x, y);
+}
+
+template <typename T>
+void STFTCuda<T>::apply_inv_window_backward(Variable *x, Variable *y,
+                                            const bool accum) {
+  istft_cuda_->apply_inv_window_backward(x, y, accum);
 }
 
 template <typename T>


### PR DESCRIPTION
[ISTFT](https://www.mathworks.com/help/signal/ref/istft.html) has the nonzero overlap-add (NOLA) constraint. Now we consider [NOLA constraint](https://gauss256.github.io/blog/cola.html).