### PR TITLE
Support broadcast in instance norm kernel to improve performance

### DIFF
--- a/include/nbla/cuda/function/instance_normalization.hpp
+++ b/include/nbla/cuda/function/instance_normalization.hpp
@@ -41,7 +41,7 @@ protected:
   int device_;
   Variable mean_, var_;
   float inv_reduce_size_;
-  Size_t reduce_size_, outer_size_;
+  Size_t reduce_size_, outer_size_, channel_size_;
 
   // Internal buffers for backward
   Variable sum_dy_, sum_dyx_;
@@ -62,6 +62,14 @@ protected:
   void backward_channel_first(const Variables &inputs, const Variables &outputs,
                               const vector<bool> &propagate_down,
                               const vector<bool> &accum);
+  void backward_channel_first_dx(const Variables &inputs,
+                                 const Variables &outputs,
+                                 const vector<bool> &propagate_down,
+                                 const vector<bool> &accum);
+  void backward_channel_first_dbeta_dgamma(const Variables &inputs,
+                                           const Variables &outputs,
+                                           const vector<bool> &propagate_down,
+                                           const vector<bool> &accum);
 };
 }
 #endif

--- a/src/nbla/cuda/function/generic/instance_normalization.cu
+++ b/src/nbla/cuda/function/generic/instance_normalization.cu
@@ -21,6 +21,7 @@
 #include <nbla/cuda/function/kernel/instance_normalization.cuh>
 #include <nbla/cuda/function/kernel/normalization.cuh>
 #include <nbla/cuda/utils/reduce_ops/instance_normalization.cuh>
+#include <nbla/cuda/utils/reduce_ops/sum.cuh>
 #include <nbla/cuda/utils/reduce_ops/welford.cuh>
 
 namespace nbla {
@@ -31,24 +32,18 @@ void InstanceNormalizationCuda<T>::setup_impl(const Variables &inputs,
   InstanceNormalization<T>::setup_impl(inputs, outputs);
   cuda_set_device(this->device_);
 
-  // Broadcasting scale and bias is not supported in CUDA backend.
-  if (this->need_beta_broadcast_ || this->need_gamma_broadcast_) {
-    this->fall_back_func_ = make_shared<InstanceNormalization<T>>(
-        this->ctx_, this->channel_axis_, this->batch_axis_, this->eps_,
-        this->no_scale_, this->no_bias_);
-    this->fall_back_func_->setup(inputs, outputs);
-    return;
-  }
+  const auto x = inputs[0];
+  const auto x_shape = x->shape();
+  channel_size_ = x_shape[this->channel_axis_];
 
   // Setup input and output adaptor for channel-last memory format
-  need_adaptor_ = ChannelFirstAdaptor::need_adaptor(
-      inputs[0]->shape(), this->batch_axis_, this->channel_axis_);
+  need_adaptor_ = ChannelFirstAdaptor::need_adaptor(x_shape, this->batch_axis_,
+                                                    this->channel_axis_);
 
   if (need_adaptor_) {
     adaptor_ = std::make_shared<ChannelFirstAdaptor>();
-    adaptor_->setup(inputs[0], &pre_adaptor_, &post_adaptor_, outputs[0],
-                    inputs[0]->shape(), this->batch_axis_, this->channel_axis_,
-                    this->ctx_);
+    adaptor_->setup(x, &pre_adaptor_, &post_adaptor_, outputs[0], x_shape,
+                    this->batch_axis_, this->channel_axis_, this->ctx_);
 
     reduce_size_ = pre_adaptor_.size(this->batch_axis_.size() + 1);
     inv_reduce_size_ = 1.0f / reduce_size_;
@@ -64,14 +59,14 @@ void InstanceNormalizationCuda<T>::setup_impl(const Variables &inputs,
   //----------------
 
   // Batch stats
-  mean_.reshape({outer_size_}, true);
-  var_.reshape({outer_size_}, true);
+  mean_.reshape(Shape_t{outer_size_}, true);
+  var_.reshape(Shape_t{outer_size_}, true);
 
   // Internal buffers for backward calculation
-  sum_dy_.reshape({outer_size_}, true);
-  sum_dyx_.reshape({outer_size_}, true);
-  factor_a_.reshape({outer_size_}, true);
-  factor_b_.reshape({outer_size_}, true);
+  sum_dy_.reshape(Shape_t{outer_size_}, true);
+  sum_dyx_.reshape(Shape_t{outer_size_}, true);
+  factor_a_.reshape(Shape_t{outer_size_}, true);
+  factor_b_.reshape(Shape_t{outer_size_}, true);
 }
 
 template <typename T>
@@ -158,8 +153,22 @@ void InstanceNormalizationCuda<T>::forward_channel_first(
     grid.z = 1;
     const auto block = NBLA_CUDA_IN_NUM_THREADS;
 
-    instance_norm_forward_normalization<<<grid, block>>>(
-        outer_size_, reduce_size_, x, mean, var, beta, gamma, y, this->eps_);
+    auto kernel =
+        instance_norm_forward_normalization<Tc, Size_t, false /* bc_beta */,
+                                            false /* bc_gamma */>;
+    if (this->need_beta_broadcast_) {
+      kernel =
+          this->need_gamma_broadcast_
+              ? instance_norm_forward_normalization<Tc, Size_t, true, true>
+              : instance_norm_forward_normalization<Tc, Size_t, true, false>;
+    } else {
+      kernel =
+          this->need_gamma_broadcast_
+              ? instance_norm_forward_normalization<Tc, Size_t, false, true>
+              : instance_norm_forward_normalization<Tc, Size_t, false, false>;
+    }
+    kernel<<<grid, block>>>(outer_size_, channel_size_, reduce_size_, x, mean,
+                            var, beta, gamma, y, this->eps_);
     NBLA_CUDA_KERNEL_CHECK();
   }
 }
@@ -205,15 +214,8 @@ template <typename T>
 void InstanceNormalizationCuda<T>::backward_channel_first(
     const Variables &inputs, const Variables &outputs,
     const vector<bool> &propagate_down, const vector<bool> &accum) {
-  Variable *v_mean = &mean_;
-  Variable *v_var = &var_;
-  // Output mean and var when output_stats == true.
-  if (outputs.size() == 3) {
-    v_mean = outputs[1];
-    v_var = outputs[2];
-  }
-
   // Calculate sum of dy and sum of dy * x.
+  // These values are used in dx and dbeta/dgamma calculation.
   {
     const Tc *x = inputs[0]->get_data_pointer<Tc>(this->ctx_);
     const Tc *dy = outputs[0]->get_grad_pointer<Tc>(this->ctx_);
@@ -234,8 +236,36 @@ void InstanceNormalizationCuda<T>::backward_channel_first(
     NBLA_CUDA_KERNEL_CHECK();
   }
 
-  // Calculate a and b such that `dx = gamma / sqrt(var) * dy + a * x + b`.
+  // Calculate dx
   if (propagate_down[0]) {
+    backward_channel_first_dx(inputs, outputs, propagate_down, accum);
+  }
+
+  // Calculate dbeta and dgamma.
+  if ((inputs.size() > 1 && propagate_down[1]) ||
+      (inputs.size() > 2 && propagate_down[2])) {
+    backward_channel_first_dbeta_dgamma(inputs, outputs, propagate_down, accum);
+  }
+
+  // Clear internal buffer
+  sum_dy_.data()->array()->clear();
+  sum_dyx_.data()->array()->clear();
+}
+
+template <typename T>
+void InstanceNormalizationCuda<T>::backward_channel_first_dx(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  Variable *v_mean = &mean_;
+  Variable *v_var = &var_;
+  // Output mean and var when output_stats == true.
+  if (outputs.size() == 3) {
+    v_mean = outputs[1];
+    v_var = outputs[2];
+  }
+
+  // Calculate a and b such that `dx = gamma / sqrt(var) * dy + a * x + b`.
+  {
     const auto gamma_idx = this->no_bias_ ? 1 : 2;
     const Tc *gamma = this->no_scale_
                           ? nullptr
@@ -258,14 +288,17 @@ void InstanceNormalizationCuda<T>::backward_channel_first(
                                    outer_size_, NBLA_CUDA_IN_NUM_THREADS)));
     const auto block = NBLA_CUDA_IN_NUM_THREADS;
 
-    instance_norm_backward_dx_factor<<<grid, block>>>(
-        outer_size_, inv_reduce_size_, gamma, mean, var, dmean, dvar, sum_dy,
-        sum_dyx, factor_a, factor_b, this->eps_);
+    auto kernel = this->need_gamma_broadcast_
+                      ? instance_norm_backward_dx_factor<Tc, Size_t, true>
+                      : instance_norm_backward_dx_factor<Tc, Size_t, false>;
+    kernel<<<grid, block>>>(outer_size_, channel_size_, inv_reduce_size_, gamma,
+                            mean, var, dmean, dvar, sum_dy, sum_dyx, factor_a,
+                            factor_b, this->eps_);
     NBLA_CUDA_KERNEL_CHECK();
   }
 
   // Calculate dx.
-  if (propagate_down[0]) {
+  {
     const auto gamma_idx = this->no_bias_ ? 1 : 2;
 
     const Tc *x = inputs[0]->get_data_pointer<Tc>(this->ctx_);
@@ -288,66 +321,144 @@ void InstanceNormalizationCuda<T>::backward_channel_first(
     grid.z = 1;
     const auto block = NBLA_CUDA_IN_NUM_THREADS;
 
-    auto kernel = accum[0] ? instance_norm_backward_dx<true, Tc, Size_t>
-                           : instance_norm_backward_dx<false, Tc, Size_t>;
-    kernel<<<grid, block>>>(outer_size_, reduce_size_, x, gamma, dy, var,
-                            factor_a, factor_b, dx, this->eps_);
+    auto kernel = instance_norm_backward_dx<Tc, Size_t, false /* bc_gamma */,
+                                            false /* accum */>;
+    if (this->need_gamma_broadcast_) {
+      kernel = accum[0] ? instance_norm_backward_dx<Tc, Size_t, true, true>
+                        : instance_norm_backward_dx<Tc, Size_t, true, false>;
+    } else {
+      kernel = accum[0] ? instance_norm_backward_dx<Tc, Size_t, false, true>
+                        : instance_norm_backward_dx<Tc, Size_t, false, false>;
+    }
+    kernel<<<grid, block>>>(outer_size_, channel_size_, reduce_size_, x, gamma,
+                            dy, var, factor_a, factor_b, dx, this->eps_);
     NBLA_CUDA_KERNEL_CHECK();
 
     // Clear internal buffer
     factor_a_.data()->array()->clear();
     factor_b_.data()->array()->clear();
   }
+}
 
-  // Calculate dbeta and dgamma.
-  if ((inputs.size() > 1 && propagate_down[1]) ||
-      (inputs.size() > 2 && propagate_down[2])) {
-    const auto beta_idx = 1;
-    const auto gamma_idx = this->no_bias_ ? 1 : 2;
-
-    const Tc *x = inputs[0]->get_data_pointer<Tc>(this->ctx_);
-    const Tc *gamma = this->no_scale_
-                          ? nullptr
-                          : inputs[gamma_idx]->get_data_pointer<Tc>(this->ctx_);
-    const Tc *dy = outputs[0]->get_grad_pointer<Tc>(this->ctx_);
-    const Tc *sum_dy = sum_dy_.get_data_pointer<Tc>(this->ctx_);
-    const Tc *sum_dyx = sum_dyx_.get_data_pointer<Tc>(this->ctx_);
-    const Tc *mean = v_mean->get_data_pointer<Tc>(this->ctx_);
-    const Tc *var = v_var->get_data_pointer<Tc>(this->ctx_);
-    Tc *dbeta = !this->no_bias_ && propagate_down[beta_idx]
-                    ? inputs[beta_idx]->cast_grad_and_get_pointer<Tc>(
-                          this->ctx_, !accum[beta_idx])
-                    : nullptr;
-    Tc *dgamma = !this->no_scale_ && propagate_down[gamma_idx]
-                     ? inputs[gamma_idx]->cast_grad_and_get_pointer<Tc>(
-                           this->ctx_, !accum[gamma_idx])
-                     : nullptr;
-
-    const auto grid = std::min(static_cast<Size_t>(NBLA_CUDA_IN_MAX_BLOCKS),
-                               static_cast<Size_t>(NBLA_CEIL_SIZE_T_DIV(
-                                   outer_size_, NBLA_CUDA_IN_NUM_THREADS)));
-    const auto block = NBLA_CUDA_IN_NUM_THREADS;
-
-    // Select kernels by accum combination.
-    auto kernel = instance_norm_backward_dbeta_dgamma<true, true, Tc, Size_t>;
-    if (!this->no_bias_ && accum[beta_idx]) {
-      kernel =
-          !this->no_scale_ && accum[gamma_idx]
-              ? instance_norm_backward_dbeta_dgamma<true, true, Tc, Size_t>
-              : instance_norm_backward_dbeta_dgamma<true, false, Tc, Size_t>;
-    } else {
-      kernel =
-          !this->no_scale_ && accum[gamma_idx]
-              ? instance_norm_backward_dbeta_dgamma<false, true, Tc, Size_t>
-              : instance_norm_backward_dbeta_dgamma<false, false, Tc, Size_t>;
-    }
-    kernel<<<grid, block>>>(outer_size_, reduce_size_, x, gamma, dy, sum_dy,
-                            sum_dyx, mean, var, dbeta, dgamma, this->eps_);
-    NBLA_CUDA_KERNEL_CHECK();
+template <typename T>
+void InstanceNormalizationCuda<T>::backward_channel_first_dbeta_dgamma(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  Variable *v_mean = &mean_;
+  Variable *v_var = &var_;
+  // Output mean and var when output_stats == true.
+  if (outputs.size() == 3) {
+    v_mean = outputs[1];
+    v_var = outputs[2];
   }
 
-  // Clear internal buffer
-  sum_dy_.data()->array()->clear();
-  sum_dyx_.data()->array()->clear();
+  // Calculate dbeta and dgamma.
+  Variable dbeta_buf(Shape_t{outer_size_});
+  Variable dgamma_buf(Shape_t{outer_size_});
+
+  const auto beta_idx = 1;
+  const auto gamma_idx = this->no_bias_ ? 1 : 2;
+
+  const bool pd_beta = !this->no_bias_ && propagate_down[beta_idx];
+  const bool pd_gamma = !this->no_scale_ && propagate_down[gamma_idx];
+  const bool accum_beta = !this->no_bias_ && accum[beta_idx];
+  const bool accum_gamma = !this->no_scale_ && accum[gamma_idx];
+  const bool bc_beta = this->need_beta_broadcast_;
+  const bool bc_gamma = this->need_gamma_broadcast_;
+
+  const Tc *x = inputs[0]->get_data_pointer<Tc>(this->ctx_);
+  const Tc *gamma = this->no_scale_
+                        ? nullptr
+                        : inputs[gamma_idx]->get_data_pointer<Tc>(this->ctx_);
+  const Tc *dy = outputs[0]->get_grad_pointer<Tc>(this->ctx_);
+  const Tc *sum_dy = sum_dy_.get_data_pointer<Tc>(this->ctx_);
+  const Tc *sum_dyx = sum_dyx_.get_data_pointer<Tc>(this->ctx_);
+  const Tc *mean = v_mean->get_data_pointer<Tc>(this->ctx_);
+  const Tc *var = v_var->get_data_pointer<Tc>(this->ctx_);
+
+  // Support function to get pointer of affine parameter grad.
+  auto cast_affine_param_grad = [&](Variable &buffer, const int inputs_idx,
+                                    const bool propagate_down, const bool accum,
+                                    const bool need_broadcast) {
+    if (!propagate_down) {
+      return (Tc *)nullptr;
+    }
+
+    if (need_broadcast) {
+      return buffer.cast_grad_and_get_pointer<Tc>(this->ctx_, true);
+    }
+
+    return inputs[inputs_idx]->cast_grad_and_get_pointer<Tc>(this->ctx_,
+                                                             !accum);
+  };
+
+  Tc *dbeta =
+      cast_affine_param_grad(dbeta_buf, beta_idx, pd_beta, accum_beta, bc_beta);
+  Tc *dgamma = cast_affine_param_grad(dgamma_buf, gamma_idx, pd_gamma,
+                                      accum_gamma, bc_gamma);
+
+  const auto grid = std::min(static_cast<Size_t>(NBLA_CUDA_IN_MAX_BLOCKS),
+                             static_cast<Size_t>(NBLA_CEIL_SIZE_T_DIV(
+                                 outer_size_, NBLA_CUDA_IN_NUM_THREADS)));
+  const auto block = NBLA_CUDA_IN_NUM_THREADS;
+
+  // Select kernels by accum combination.
+  // If broadcast is needed, accumulation is not done here but done after
+  // broadcast backward.
+  auto kernel =
+      instance_norm_backward_dbeta_dgamma<false /* accum_beta */,
+                                          false /* accum_gamma */, Tc, Size_t>;
+  if (accum_beta && !bc_beta) {
+    kernel = accum_gamma && !bc_gamma
+                 ? instance_norm_backward_dbeta_dgamma<true, true, Tc, Size_t>
+                 : instance_norm_backward_dbeta_dgamma<true, false, Tc, Size_t>;
+  } else {
+    kernel =
+        accum_gamma && !bc_gamma
+            ? instance_norm_backward_dbeta_dgamma<false, true, Tc, Size_t>
+            : instance_norm_backward_dbeta_dgamma<false, false, Tc, Size_t>;
+  }
+  kernel<<<grid, block>>>(outer_size_, reduce_size_, x, gamma, dy, sum_dy,
+                          sum_dyx, mean, var, dbeta, dgamma, this->eps_);
+  NBLA_CUDA_KERNEL_CHECK();
+
+  // Support function for affine param broadcast backward.
+  auto affine_param_broadcast_backward = [&](
+      Tc *d_affine_param_ptr, const int param_idx, const bool accum) {
+    // Reduction as broadcast backward
+    ReduceSetup reduce_setup;
+    reduce_setup(Shape_t{outer_size_ / channel_size_, channel_size_},
+                 Shape_t{0});
+
+    // d_beta or d_gamma
+    auto *d_affine_param_out_ptr =
+        inputs[param_idx]->cast_grad_and_get_pointer<Tc>(this->ctx_, !accum);
+
+    if (accum) {
+      // Temporary buffer for reduction
+      Variable reduce_buf(Shape_t{channel_size_});
+      auto *reduce_buf_ptr =
+          reduce_buf.cast_grad_and_get_pointer<Tc>(this->ctx_, true);
+      device_sum(this->ctx_, d_affine_param_ptr, reduce_buf_ptr, reduce_setup);
+
+      // Gradient accumulation
+      auto kernel =
+          accum ? instance_norm_backward_accum_affine_param<Tc, Size_t, true>
+                : instance_norm_backward_accum_affine_param<Tc, Size_t, false>;
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel, channel_size_, reduce_buf_ptr,
+                                     d_affine_param_out_ptr);
+    } else {
+      device_sum(this->ctx_, d_affine_param_ptr, d_affine_param_out_ptr,
+                 reduce_setup);
+    }
+  };
+
+  if (pd_beta && bc_beta) {
+    affine_param_broadcast_backward(dbeta, beta_idx, accum_beta);
+  }
+
+  if (pd_gamma && bc_gamma) {
+    affine_param_broadcast_backward(dgamma, gamma_idx, accum_gamma);
+  }
 }
 }

--- a/src/nbla/cuda/function/generic/layer_normalization.cu
+++ b/src/nbla/cuda/function/generic/layer_normalization.cu
@@ -50,7 +50,7 @@ void LayerNormalizationCuda<T>::setup_impl(const Variables &inputs,
   }
 
   batch_size_ = 1;
-  for (auto b : this->batch_axis_) {
+  for (const auto b : this->batch_axis_) {
     batch_size_ *= x_shape[b];
   }
 
@@ -62,14 +62,14 @@ void LayerNormalizationCuda<T>::setup_impl(const Variables &inputs,
   //----------------
 
   // Batch stats
-  mean_.reshape({batch_size_}, true);
-  var_.reshape({batch_size_}, true);
+  mean_.reshape(Shape_t{batch_size_}, true);
+  var_.reshape(Shape_t{batch_size_}, true);
 
   // Internal buffers for backward calculation
-  sum_dygamma_.reshape({batch_size_}, true);
-  sum_dyxgamma_.reshape({batch_size_}, true);
-  factor_a_.reshape({batch_size_}, true);
-  factor_b_.reshape({batch_size_}, true);
+  sum_dygamma_.reshape(Shape_t{batch_size_}, true);
+  sum_dyxgamma_.reshape(Shape_t{batch_size_}, true);
+  factor_a_.reshape(Shape_t{batch_size_}, true);
+  factor_b_.reshape(Shape_t{batch_size_}, true);
 }
 
 template <typename T>


### PR DESCRIPTION
Fix unexpected falling back to the slower implementation of instance normalization (IN) caused by scale/bias broadcasting. Scale/Bias broadcasting means gamma/beta (function inputs) broadcasting for the batch axis (e.g. (1, C, 1, 1) -> (B, C, 1, 1)). This feature is only for IN and PF.instance_normalization creates gamma/beta with shape = (1, C, 1, 1).

corresponding PR for nnabla: https://github.com/sony/nnabla/pull/1000