### PR TITLE
Default disable watchdog and enable it with environment variable

### DIFF
--- a/src/nbla/cuda/test/test_watch_dog.cpp
+++ b/src/nbla/cuda/test/test_watch_dog.cpp
@@ -18,7 +18,9 @@
 #include <nbla/exception.hpp>
 #include <thread>
 
+#include <cstdlib>
 #include <stdio.h>
+#include <stdlib.h>
 
 namespace nbla {
 
@@ -67,6 +69,16 @@ TEST(WatchDogTest, TestLocalTimeoutSetting) {
     Watchdog::WatchdogLock lck(watch_dog, 4);
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
   }
+}
+
+TEST(WatchDogTest, TestDisableWithEnv) {
+  setenv("NNABLA_MPI_WATCH_DOG_ENABLE", "0", 0);
+  Watchdog watch_dog(3);
+  {
+    Watchdog::WatchdogLock lck(watch_dog, 1);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+  setenv("NNABLA_MPI_WATCH_DOG_ENABLE", "1", 1);
 }
 
 #if 0


### PR DESCRIPTION
Add an environment variable to allow disable watch dog for MPI all_reduce.