### PR TITLE
Use get_current_device_attribute rather than properties

### DIFF
--- a/include/nbla/cuda/common.hpp
+++ b/include/nbla/cuda/common.hpp
@@ -285,6 +285,12 @@ int cuda_get_device();
 NBLA_CUDA_API vector<size_t> cuda_mem_get_info();
 
 /** Get device properties of current CUDA device.
+
+    Note that using `cuda_get_current_device_properties`
+    is extremely slower than `cuda_get_current_device_attribute`,
+    since some props require PCIe reads to query.
+    Keep in mind that sometime using this function could lead to huge
+    slowdowns in your implementation.
  */
 cudaDeviceProp cuda_get_current_device_properties();
 

--- a/src/nbla/cuda/common.cpp
+++ b/src/nbla/cuda/common.cpp
@@ -37,6 +37,13 @@ std::vector<size_t> cuda_mem_get_info() {
 }
 
 cudaDeviceProp cuda_get_current_device_properties() {
+  /** Note:
+      Using `cuda_get_current_device_properties` is extremely slower than
+      `cuda_get_current_device_attribute`,
+      since some props require PCIe reads to query.
+      Keep in mind that sometime using this function could lead to huge
+      slowdowns in your implementation.
+  */
   cudaDeviceProp prop;
   int device = cuda_get_device(); // Note: Assuming device is properly set.
   NBLA_CUDA_CHECK(cudaGetDeviceProperties(&prop, device));

--- a/src/nbla/cuda/utils/reduce.cu
+++ b/src/nbla/cuda/utils/reduce.cu
@@ -170,9 +170,14 @@ void ReduceSetup::operator()(const Shape_t &shape_input,
   }
 
   // Collect the information about the device
-  const auto device_prop = cuda_get_current_device_properties();
+  // Note that using `cuda_get_current_device_properties` is extremely slower,
+  // since some props require PCIe reads to query.
+  auto max_threads_per_multi_procesor = cuda_get_current_device_attribute(
+      cudaDeviceAttr::cudaDevAttrMaxThreadsPerMultiProcessor);
+  auto multi_processor_count = cuda_get_current_device_attribute(
+      cudaDeviceAttr::cudaDevAttrMultiProcessorCount);
   const auto min_blocks_per_sm =
-      device_prop.maxThreadsPerMultiProcessor / NBLA_CUDA_REDUCE_NUM_THREADS;
-  min_blocks = min_blocks_per_sm * device_prop.multiProcessorCount;
+      max_threads_per_multi_procesor / NBLA_CUDA_REDUCE_NUM_THREADS;
+  min_blocks = min_blocks_per_sm * multi_processor_count;
 }
 }


### PR DESCRIPTION
In the previous implementation, cudaGetDeviceProperties was used to get attributes to compute min_blocks for reduction.
solver.clip_grad_by_norm calls sumCuda.setup() every time which calles cudaGetDeviceProperties and it leads to huge bottleneck especially for the case with a lot of parameters, since cudaGetDeviceProperties require PCIe reads for some prop.

Change reduce.cu to use cudaDeviceGetAttributes to fix this bottleneck.