### PR TITLE
Add AssignCuda not to perform host-device copy

### DIFF
--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -567,6 +567,9 @@ IFFT:
 Prune:
   float: [float]
 #  half: [Half] # since segfault with Half
+Assign:
+  float: [float]
+  half: [Half]
 Gather:
   float: [float]
   half: [Half]

--- a/include/nbla/cuda/function/assign.hpp
+++ b/include/nbla/cuda/function/assign.hpp
@@ -1,0 +1,44 @@
+// Copyright 2018,2019,2020,2021 Sony Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_ASSIGN_HPP
+#define NBLA_CUDA_FUNCTION_ASSIGN_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/assign.hpp>
+
+namespace nbla {
+
+template <typename T> class AssignCuda : public Assign<T> {
+public:
+  typedef typename CudaType<T>::type Tcu;
+
+  explicit AssignCuda(const Context &ctx)
+      : Assign<T>(ctx), device_(std::stoi(ctx.device_id)) {}
+  virtual ~AssignCuda() {}
+  virtual string name() { return "AssignCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+};
+}
+#endif

--- a/src/nbla/cuda/function/generic/assign.cu
+++ b/src/nbla/cuda/function/generic/assign.cu
@@ -1,0 +1,44 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/assign.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+template <typename T>
+void AssignCuda<T>::setup_impl(const Variables &inputs,
+                               const Variables &outputs) {
+  Assign<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void AssignCuda<T>::forward_impl(const Variables &inputs,
+                                 const Variables &outputs) {
+  cuda_set_device(this->device_);
+  Assign<T>::forward_impl(inputs, outputs);
+}
+
+template <typename T>
+void AssignCuda<T>::backward_impl(const Variables &inputs,
+                                  const Variables &outputs,
+                                  const vector<bool> &propagate_down,
+                                  const vector<bool> &accum) {
+  cuda_set_device(this->device_);
+  Assign<T>::backward_impl(inputs, outputs, propagate_down, accum);
+}
+}


### PR DESCRIPTION
Previously, F.assign allows only CpuArray even though under cuda/cudnn context.
Therefore, it causes undesirable device-host copy and huge slowdowns.

To fix this, I added AssignCuda not to perform host-device memory copy.