### PR TITLE
Speedup SortCuda with cub::DeviceSegmentedRadixSort

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ if(BUILD_CPP_LIB)
     ${PROJECT_SOURCE_DIR}/include
     ${NNABLA_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party/eigen-3.3.5
+    ${CMAKE_CURRENT_SOURCE_DIR}/third_party/cub-1.8.0
     ${NNABLA_DIR}/include/third_party/)
   include_directories(${NBLA_INCLUDE_DIRS};${PROJECT_BINARY_DIR})
   

--- a/include/nbla/cuda/function/sort.hpp
+++ b/include/nbla/cuda/function/sort.hpp
@@ -21,6 +21,15 @@
 namespace nbla {
 
 template <typename T> class SortCuda : public Sort<T> {
+protected:
+  // Members only for cub implementation
+  bool use_cub_;
+  bool need_transpose_;
+  size_t cub_temp_storage_bytes_;
+  int cub_num_items_, cub_num_segments_;
+  Shape_t transposed_shape_;
+  FunctionPtr transpose_converter_, transpose_deconverter_;
+
 public:
   typedef typename CudaType<T>::type Tcu;
 
@@ -36,6 +45,8 @@ public:
 
 protected:
   int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void thrust_sort(const Variables &inputs, const Variables &outputs);
   virtual void forward_impl(const Variables &inputs, const Variables &outputs);
   virtual void backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &propagate_down,

--- a/src/nbla/cuda/function/generic/sort.cu
+++ b/src/nbla/cuda/function/generic/sort.cu
@@ -27,6 +27,15 @@
 #include <thrust/async/sort.h>
 #endif
 
+#include <cub/cub.cuh>
+#include <nbla/function/transpose.hpp>
+
+// define cub::NumericTraits for nbla::HalfCuda to use cub functions.
+template <>
+struct cub::NumericTraits<nbla::HalfCuda>
+    : cub::BaseTraits<FLOATING_POINT, true, false, unsigned short,
+                      nbla::HalfCuda> {};
+
 namespace nbla {
 
 namespace sort_impl {
@@ -57,6 +66,19 @@ template <typename T> struct CompareLess {
 
 __global__ void make_sequence(const size_t size, size_t *dst) {
   NBLA_CUDA_KERNEL_LOOP(i, size) { dst[i] = static_cast<size_t>(i); }
+}
+
+__global__ void make_index(const int total_size, const int segment_size,
+                           int *dst) {
+  NBLA_CUDA_KERNEL_LOOP(i, total_size) {
+    dst[i] = static_cast<size_t>(i % segment_size);
+  }
+}
+
+__global__ void make_offsets(const int size, const int sort_size, int *dst) {
+  NBLA_CUDA_KERNEL_LOOP(i, size) {
+    dst[i] = static_cast<size_t>(i * sort_size);
+  }
 }
 
 __global__ void copy_index(const size_t size, const size_t stride,
@@ -91,8 +113,72 @@ __global__ void set_grad(const size_t size, const size_t stride, const T *src,
 } // namespace sort_impl
 
 template <typename T>
-void SortCuda<T>::forward_impl(const Variables &inputs,
-                               const Variables &outputs) {
+void SortCuda<T>::setup_impl(const Variables &inputs,
+                             const Variables &outputs) {
+  Sort<T>::setup_impl(inputs, outputs);
+  cuda_set_device(this->device_);
+
+  // Use cub sort for most cases. Slower thrust implementation is left for
+  // 64 bits indexing cases since cub does not support it.
+  use_cub_ = inputs[0]->size() < std::numeric_limits<int>::max();
+  if (use_cub_) {
+    // Cub needs contiguous memory layout for data to sort.
+    // Here, transpose functions are used for re-arranging memory layout before
+    // and after cub sort call.
+    need_transpose_ = this->inner_size != 1;
+    if (need_transpose_) {
+      // Create transpose axes.
+      // e.g.)
+      // input_ndim = 6, sort_axis = 3
+      // axis_for_converter:   [0, 1, 2, 4, 5, 3]
+      // axis_for_deconverter: [0, 1, 2, 5, 3, 4]
+      int ndim = inputs[0]->ndim();
+      std::vector<int> axis_for_converter, axis_for_deconverter;
+      for (int i = 0; i < this->axis; i++) {
+        axis_for_converter.push_back(i);
+        axis_for_deconverter.push_back(i);
+      }
+      axis_for_deconverter.push_back(ndim - 1);
+      for (int i = this->axis + 1; i < ndim; i++) {
+        axis_for_converter.push_back(i);
+        axis_for_deconverter.push_back(i - 1);
+      }
+      axis_for_converter.push_back(this->axis);
+
+      // Set up transpose functions.
+      Variable dummy_in(inputs[0]->shape()), dummy_mid, dummy_out;
+      transpose_converter_ = create_Transpose(this->ctx_, axis_for_converter);
+      transpose_deconverter_ =
+          create_Transpose(this->ctx_, axis_for_deconverter);
+      transpose_converter_->setup({&dummy_in}, {&dummy_mid});
+      transpose_deconverter_->setup({&dummy_mid}, {&dummy_out});
+      transposed_shape_ = dummy_mid.shape();
+    }
+
+    // Calculate size of temporal buffer needed for cub sort.
+    // When the first argument of SortPairs(Descending) is NULL, only size
+    // calculation of temporal buffer is performed.
+    cub_num_items_ = this->total_size;
+    cub_num_segments_ = cub_num_items_ / inputs[0]->shape()[this->axis];
+    if (this->reverse) {
+      cub::DeviceSegmentedRadixSort::SortPairsDescending<Tcu, int, int *>(
+          nullptr, cub_temp_storage_bytes_, nullptr, nullptr, nullptr, nullptr,
+          cub_num_items_, cub_num_segments_, nullptr, nullptr);
+    } else {
+      cub::DeviceSegmentedRadixSort::SortPairs<Tcu, int, int *>(
+          nullptr, cub_temp_storage_bytes_, nullptr, nullptr, nullptr, nullptr,
+          cub_num_items_, cub_num_segments_, nullptr, nullptr);
+    }
+
+    // Index buffer needs same size as input since cub sort algorithm handles
+    // input all at once.
+    this->temp_index.reshape(inputs[0]->shape(), true);
+  }
+}
+
+template <typename T>
+void SortCuda<T>::thrust_sort(const Variables &inputs,
+                              const Variables &outputs) {
 #if THRUST_VERSION < 100904 || !defined(THRUST_CPP11) ||                       \
     !defined(THRUST_MODERN_GCC)
   using thrust::sort;
@@ -101,7 +187,6 @@ void SortCuda<T>::forward_impl(const Variables &inputs,
 #endif
 
   using namespace sort_impl;
-  cuda_set_device(this->device_);
 
   const auto &ctx = this->ctx_;
   const auto &shape = inputs[0]->shape();
@@ -166,7 +251,84 @@ void SortCuda<T>::forward_impl(const Variables &inputs,
       outer_i_raw += this->outer_size;
     }
   }
+}
 
+template <typename T>
+void SortCuda<T>::forward_impl(const Variables &inputs,
+                               const Variables &outputs) {
+  using namespace sort_impl;
+  cuda_set_device(this->device_);
+  const auto &ctx = this->ctx_;
+
+  if (use_cub_) {
+
+    // Make input memory layout contiguous.
+    Variable transposed_input(transposed_shape_);
+    if (need_transpose_) {
+      transpose_converter_->forward({inputs[0]}, {&transposed_input});
+    }
+
+    // Temporary buffer for cub sort algorithm.
+    Variable temp_storage(
+        Shape_t{static_cast<Size_t>(cub_temp_storage_bytes_)});
+
+    // Make index sequence
+    int *temp_index_ptr =
+        this->temp_index.template cast_data_and_get_pointer<int>(ctx, true);
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(make_index, cub_num_items_,
+                                   cub_num_items_ / cub_num_segments_,
+                                   temp_index_ptr);
+
+    // Make segment offsets
+    Variable d_offsets(Shape_t{static_cast<Size_t>(cub_num_segments_ + 1)});
+    int *d_offsets_raw = d_offsets.cast_data_and_get_pointer<int>(ctx, true);
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(make_offsets, cub_num_segments_ + 1,
+                                   cub_num_items_ / cub_num_segments_,
+                                   d_offsets_raw);
+
+    // Device buffers
+    char *d_temp_storage = temp_storage.cast_data_and_get_pointer<char>(ctx);
+
+    Variable *v_data_in = need_transpose_ ? &transposed_input : inputs[0];
+    const auto *data_in = v_data_in->get_data_pointer<Tcu>(ctx);
+    Variable transposed_output(transposed_shape_);
+    // When `only_index == true`, `outputs[0]` is used as temporal dummy buffer
+    // for sort output.
+    Variable *v_data_out = need_transpose_ ? &transposed_output : outputs[0];
+    auto *data_out = v_data_out->cast_data_and_get_pointer<Tcu>(ctx, true);
+
+    Variable transposed_index(transposed_shape_);
+    Variable *v_index_out =
+        need_transpose_ ? &transposed_index : &this->sort_index;
+    int *sort_index_ptr =
+        v_index_out->template cast_data_and_get_pointer<int>(ctx, true);
+
+    // Call cub sort API
+    if (this->reverse) {
+      cub::DeviceSegmentedRadixSort::SortPairsDescending(
+          d_temp_storage, cub_temp_storage_bytes_, data_in, data_out,
+          temp_index_ptr, sort_index_ptr, cub_num_items_, cub_num_segments_,
+          d_offsets_raw, d_offsets_raw + 1);
+    } else {
+      cub::DeviceSegmentedRadixSort::SortPairs(
+          d_temp_storage, cub_temp_storage_bytes_, data_in, data_out,
+          temp_index_ptr, sort_index_ptr, cub_num_items_, cub_num_segments_,
+          d_offsets_raw, d_offsets_raw + 1);
+    }
+
+    // Restore memory layout.
+    if (need_transpose_) {
+      if (!this->only_index) {
+        transpose_deconverter_->forward({&transposed_output}, {outputs[0]});
+      }
+      transpose_deconverter_->forward({&transposed_index}, {&this->sort_index});
+    }
+  } else {
+    // Thrust sort implementation is used for 64 bits indexing cases.
+    thrust_sort(inputs, outputs);
+  }
+
+  // Copy sorted index to function output.
   if (this->with_index || this->only_index) {
     Variable *out_var = this->only_index ? outputs[0] : outputs[1];
     auto out_arr = out_var->data()->cast(get_dtype<size_t>(), ctx, true);

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -33,6 +33,10 @@ endfunction()
 
 download_and_extract_library(eigen-3.3.5 .zip https://gitlab.com/libeigen/eigen/-/archive/3.3.5/eigen-3.3.5.zip)
 download_and_extract_library(ompi-3.1.6 .zip https://github.com/open-mpi/ompi/archive/refs/tags/v3.1.6.zip)
+# cub is included for CUDA Toolkit >= 11.0.
+if(CUDA_VERSION VERSION_LESS "11.0")
+  download_and_extract_library(cub-1.8.0 .zip https://github.com/NVIDIA/cub/archive/refs/tags/1.8.0.zip)
+endif()
 
 # Generate dl_mpi.h from ompi.h.in
 execute_process(

--- a/third_party/LICENSES.md
+++ b/third_party/LICENSES.md
@@ -6,6 +6,7 @@
 * [LAPACK](#lapack)
 * [DLPack](#dlpack)
 * [PyTorch](#pytorch)
+* [CUB](#cub)
 
 
 ## [Eigen](eigen.tuxfamily.org/index.php)
@@ -731,4 +732,37 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
+```
+
+## [CUB](https://nvlabs.github.io/cub/)
+
+`Neural Network Libraries CUDA extension` may use [CUB](https://nvlabs.github.io/cub/) library for some functions.
+cub-1.8.0 is downloaded and extracted into `third_pary` directory during build with older CUDA Toolkit (<= 10.*).
+For newer CUDA Toolkit, we do not embedded them since CUB library is built in.
+
+```
+Copyright (c) 2010-2011, Duane Merrill.  All rights reserved.
+Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+   *  Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   *  Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+   *  Neither the name of the NVIDIA CORPORATION nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```


### PR DESCRIPTION
Reported that SortCuda perfomance is not good for some cases. In this PR, we replace sort library used in SortCuda from thrust to cub for most cases. For reported use case, about 25x optimization is achieved.