### PR TITLE
Support NVTX range events

### DIFF
--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -57,6 +57,7 @@ RUN eval ${YUM_OPTS} \
         libffi-devel \
         libsndfile \
         python-backports-lzma \
+        nsight-systems-2021.5.2 \
     && yum group install -y "Development Tools" \
     && yum clean all
 

--- a/include/nbla/cuda/nvtx.hpp
+++ b/include/nbla/cuda/nvtx.hpp
@@ -1,4 +1,5 @@
-// Copyright 2019,2020,2021 Sony Corporation.
+// Copyright 2021, 2022 Sony Corporation.
+// Copyright 2022 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,18 +17,17 @@
 #define __NBLA_NVTX_HPP__
 
 #include "nbla/cuda/defs.hpp"
-
 #include <string>
 
 namespace nbla {
 using std::string;
 
+int dl_nvtx_init(void);
+int dl_nvtx_finish(void);
+
 NBLA_CUDA_API void nvtx_mark_A(string msg);
-
 NBLA_CUDA_API void nvtx_range_push_A(string msg);
-
 NBLA_CUDA_API void nvtx_range_push_with_C(string msg);
-
 NBLA_CUDA_API void nvtx_range_pop();
 }
 

--- a/python/src/nnabla_ext/cuda/nvtx.pyx
+++ b/python/src/nnabla_ext/cuda/nvtx.pyx
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 from libcpp.string cimport string
+from libcpp cimport bool as cpp_bool
+from nnabla.function cimport Function
+from nnabla.function cimport CgFunctionPtr
+import nnabla.callback as callback
+
 
 cdef extern from "nbla/cuda/nvtx.hpp" namespace "nbla":
     void nvtx_mark_A(string) except +
@@ -32,3 +37,91 @@ def range_push(str msg, coloring=True):
 
 def range_pop():
     nvtx_range_pop()
+
+
+cdef class Range:
+    """Handle to range operation class for NVTX profiling
+
+    This class provide profiling of CUDA related function with nsys.
+    See Nsight Systems page for installation and user's guide.
+
+        https://docs.nvidia.com/nsight-systems/
+
+    To profile using nsys::
+
+        nsys profile -o <output_file> <command>
+
+    Args:
+        msg (string): A string representing the scope of this statement.
+        coloring (bool, optional, default=True): If this is True,
+            automatically assign colors to nvtx range box.
+            Default is True.
+        logging (bool, optional, default=False): If this is True,
+            profile each nnabla.function.
+            Please note that this will increase load.
+            It is recommended that only 1 logging is enabled
+            when using nested with-statements to avoid overload.
+
+    Simple example:
+
+    .. code-block:: python
+
+        import nnabla_ext.cuda.nvtx as nvtx
+
+        with nvtx.Range('training', logging=True):
+            for i in range(iteration):
+                with nvtx.Range('forward')
+                    loss.forward()
+                with nvtx.Range('backard'):
+                    loss.backward()
+                solver.update()
+    """
+    cdef string msg
+    cdef cpp_bool coloring
+    cdef cpp_bool logging
+
+    def __cinit__(self, string msg, cpp_bool coloring=True, cpp_bool logging=False):
+        self.msg = msg
+        self.coloring = coloring
+        self.logging = logging
+
+    def _func_pre_hook(self, func):
+        cdef CgFunctionPtr cg_func = (<Function>func).fun
+        name = cg_func.get().function().get().name()
+        range_push(name, self.coloring)
+
+    def _func_post_hook(self, func):
+        range_pop()
+
+    def enable(self):
+        """
+        Starts nnabla.function profiling.
+        If logging is already started, the operation will be ignored.
+        """
+        if not self.logging:
+            callback.set_function_pre_hook('nvtx_func_pre_hook', self._func_pre_hook)
+            callback.set_function_post_hook('nvtx_func_post_hook', self._func_post_hook)
+            self.logging = True
+
+    def disable(self):
+        """
+        Stop nnabla.function profiling.
+        If logging is not started, the operation will be ignored.
+        """
+        if self.logging:
+            callback.unset_function_pre_hook('nvtx_func_pre_hook')
+            callback.unset_function_post_hook('nvtx_func_post_hook')
+            self.logging = False
+
+    def __enter__(self):
+        range_push(self.msg, self.coloring)
+        if self.logging:
+            callback.set_function_pre_hook('nvtx_func_pre_hook', self._func_pre_hook)
+            callback.set_function_post_hook('nvtx_func_post_hook', self._func_post_hook)
+        return self
+
+    def __exit__(self, ex_type, ex_value, trace):
+        if self.logging:
+            callback.unset_function_pre_hook('nvtx_func_pre_hook')
+            callback.unset_function_post_hook('nvtx_func_post_hook')
+        range_pop()

--- a/python/test/cuda/nvtx/nvtx-check.py
+++ b/python/test/cuda/nvtx/nvtx-check.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nnabla_ext.cuda.nvtx as nvtx
+
+
+def main():
+    nvtx.range_push('nnabla-push-pop-test')
+    print('test for push and pop')
+    nvtx.range_pop()
+
+    with nvtx.Range('nnabla-range-test'):
+        print('test for Range')
+
+
+if __name__ == '__main__':
+    main()

--- a/python/test/cuda/nvtx/test_nvtx.py
+++ b/python/test/cuda/nvtx/test_nvtx.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2021 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+import platform
+import pytest
+from subprocess import check_call, call, CalledProcessError
+
+
+def command_exists(command):
+    return call(['which', command]) == 0
+
+
+def test_use_nvtx():
+    script = os.path.join(os.path.dirname(__file__), 'nvtx-check.py')
+    check_call(['python', script])
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason='Test on Linux only')
+def test_use_nsys():
+    outfile = 'nvtx-test'
+    script = os.path.join(os.path.dirname(__file__), 'nvtx-check.py')
+
+    if not command_exists('nsys'):
+        pytest.skip('nsys command does not exist.')
+
+    try:
+        check_call(['nsys', 'profile', '-o', outfile,
+                   '--export=text', '-f', 'true', 'python', script])
+    except CalledProcessError:
+        # maybe segfault occured, but it's ok if log is saved correctly.')
+        pass
+
+    with open(os.path.join(os.getcwd(), f'{outfile}.txt')) as f:
+        lines = f.readlines()
+
+    setup = [line for line in lines if 'nnabla-push-pop-test' in line]
+    forward = [line for line in lines if 'nnabla-range-test' in line]
+
+    assert len(setup) != 0
+    assert len(forward) != 0

--- a/src/nbla/cuda/init.cpp.tmpl
+++ b/src/nbla/cuda/init.cpp.tmpl
@@ -33,6 +33,7 @@
 #include <nbla/cuda/array/cuda_dlpack_array.hpp>
 #include <nbla/backend_registry.hpp>
 #include <nbla/cuda/communicator/dl_mpi.h>
+#include <nbla/cuda/nvtx.hpp>
 
 // Todo: avoid including cudnn.h in cuda package.
 #include <cudnn.h>
@@ -261,6 +262,10 @@ void init_cuda() {
     NBLA_REGISTER_COMMUNICATOR_IMPL(MultiProcessDataParallelCommunicator, MultiProcessDataParallelCommunicatorNcclh, "cuda:half");
   }
 #endif
+
+  // nvtx initialization
+  dl_nvtx_init();
+
   is_initialized = true;
 }
 


### PR DESCRIPTION
Enable nvtx message automatically if nsight-systems is installed.
`range_push()`, `range_pop()` and its with statements are supported as of now.

```python
import nnabla_ext.cuda.nvtx as nvtx

with nvtx.Range('training'):
    for epoch in range(epochs):
        ...
        with nvtx.Range('forward'):
            loss.forward()
        with nvtx.Range('backward'):
            loss.backward()
        solver.update()
```
