### PR TITLE
Feature/20210608 cholesky decomposition

### DIFF
--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -376,6 +376,9 @@ Sort:
 Reshape:
   float: [float]
   half: [Half]
+BatchCholesky:
+  float: [float]
+#  half: [Half]
 BatchInv:
   float: [float]
 #  half: [Half]

--- a/include/nbla/cuda/common.hpp
+++ b/include/nbla/cuda/common.hpp
@@ -1,5 +1,5 @@
 // Copyright 2017,2018,2019,2020,2021 Sony Corporation.
-// Copyright 2021 Sony Group Corporation.
+// Copyright 2021,2022 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/nbla/cuda/common.hpp
+++ b/include/nbla/cuda/common.hpp
@@ -22,6 +22,7 @@
 #include <cuda.h>
 #include <cuda_runtime.h>
 #include <curand.h>
+#include <cusolverDn.h>
 #if CUDA_VERSION >= 8000
 #include <library_types.h>
 #endif
@@ -109,6 +110,53 @@ inline string cublas_status_to_string(cublasStatus_t status) {
     cudaGetLastError();                                                        \
     NBLA_CHECK(status == CUBLAS_STATUS_SUCCESS, error_code::target_specific,   \
                cublas_status_to_string(status));                               \
+  }
+
+inline string cusolver_status_to_string(cusolverStatus_t status) {
+#define CASE_CUSOLVER_STATUS(NAME)                                             \
+  case CUSOLVER_STATUS_##NAME:                                                 \
+    return #NAME;
+
+  switch (status) {
+    CASE_CUSOLVER_STATUS(SUCCESS);
+    CASE_CUSOLVER_STATUS(NOT_INITIALIZED);
+    CASE_CUSOLVER_STATUS(ALLOC_FAILED);
+    CASE_CUSOLVER_STATUS(INVALID_VALUE);
+    CASE_CUSOLVER_STATUS(ARCH_MISMATCH);
+    CASE_CUSOLVER_STATUS(MAPPING_ERROR);
+    CASE_CUSOLVER_STATUS(EXECUTION_FAILED);
+    CASE_CUSOLVER_STATUS(INTERNAL_ERROR);
+    CASE_CUSOLVER_STATUS(MATRIX_TYPE_NOT_SUPPORTED);
+    CASE_CUSOLVER_STATUS(NOT_SUPPORTED);
+    CASE_CUSOLVER_STATUS(ZERO_PIVOT);
+    CASE_CUSOLVER_STATUS(INVALID_LICENSE);
+#if CUDA_VERSION >= 10020
+    CASE_CUSOLVER_STATUS(IRS_PARAMS_NOT_INITIALIZED);
+    CASE_CUSOLVER_STATUS(IRS_PARAMS_INVALID);
+    CASE_CUSOLVER_STATUS(IRS_INTERNAL_ERROR);
+    CASE_CUSOLVER_STATUS(IRS_NOT_SUPPORTED);
+    CASE_CUSOLVER_STATUS(IRS_OUT_OF_RANGE);
+    CASE_CUSOLVER_STATUS(IRS_NRHS_NOT_SUPPORTED_FOR_REFINE_GMRES);
+    CASE_CUSOLVER_STATUS(IRS_INFOS_NOT_INITIALIZED);
+#endif
+#if CUDA_VERSION >= 11000
+    CASE_CUSOLVER_STATUS(IRS_PARAMS_INVALID_PREC);
+    CASE_CUSOLVER_STATUS(IRS_PARAMS_INVALID_REFINE);
+    CASE_CUSOLVER_STATUS(IRS_PARAMS_INVALID_MAXITER);
+    CASE_CUSOLVER_STATUS(IRS_INFOS_NOT_DESTROYED);
+    CASE_CUSOLVER_STATUS(IRS_MATRIX_SINGULAR);
+    CASE_CUSOLVER_STATUS(INVALID_WORKSPACE);
+#endif
+  }
+  return "UNKNOWN";
+#undef CASE_CUSOLVER_STATUS
+}
+
+#define NBLA_CUSOLVER_CHECK(condition)                                         \
+  {                                                                            \
+    cusolverStatus_t status = condition;                                       \
+    NBLA_CHECK(status == CUSOLVER_STATUS_SUCCESS, error_code::target_specific, \
+               cusolver_status_to_string(status));                             \
   }
 
 inline string curand_status_to_string(curandStatus_t status) {

--- a/include/nbla/cuda/cuda.hpp
+++ b/include/nbla/cuda/cuda.hpp
@@ -53,6 +53,9 @@ public:
   /** Get cuBLAS handle of a specified device */
   cublasHandle_t cublas_handle(int device = -1);
 
+  /** Get cuSOLVER Dn handle of a specified device */
+  cusolverDnHandle_t cusolverdn_handle(int device = -1);
+
   /** Get or create cuda event */
   std::shared_ptr<cudaEvent_t> cuda_event(unsigned int flags, int device = -1);
 
@@ -133,11 +136,14 @@ public:
 
 protected:
   std::mutex mtx_cublas_;
+  std::mutex mtx_cusolverdn_;
   std::mutex mtx_curand_;
   std::mutex mtx_stream_;
   typedef unordered_map<std::thread::id, cublasHandle_t> tid_cublas_handle_t;
   unordered_map<int, tid_cublas_handle_t>
       cublas_handles_; ///< cuBLAS handles for each device.
+  unordered_map<int, cusolverDnHandle_t>
+      cusolverdn_handles_; ///< cuSOLVER Dn handles for each device.
   unordered_map<int, curandGenerator_t> curand_generators_;
   unordered_map<int, unordered_map<unsigned int, vector<cudaEvent_t>>>
       cuda_unused_events_;

--- a/include/nbla/cuda/cuda.hpp
+++ b/include/nbla/cuda/cuda.hpp
@@ -1,5 +1,5 @@
 // Copyright 2017,2018,2019,2020,2021 Sony Corporation.
-// Copyright 2021 Sony Group Corporation.
+// Copyright 2021,2022 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/nbla/cuda/cusolver.hpp
+++ b/include/nbla/cuda/cusolver.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Sony Group Corporation.
+// Copyright 2022 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/nbla/cuda/cusolver.hpp
+++ b/include/nbla/cuda/cusolver.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright 2021 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef __NBLA_CUSOLVER_HPP__
-#define __NBLA_CUSOLVER_HPP__
+#ifndef NBLA_CUSOLVER_HPP
+#define NBLA_CUSOLVER_HPP
 
 #include <cusolverDn.h>
 

--- a/include/nbla/cuda/cusolver.hpp
+++ b/include/nbla/cuda/cusolver.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __NBLA_CUSOLVER_HPP__
+#define __NBLA_CUSOLVER_HPP__
+
+#include <cusolverDn.h>
+
+namespace nbla {
+template <typename T>
+void cusolverdn_potrf_batched(cusolverDnHandle_t handle, int n, T **x, int lda,
+                              int *info, int batchSize);
+}
+#endif

--- a/include/nbla/cuda/function/batch_cholesky.hpp
+++ b/include/nbla/cuda/function/batch_cholesky.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright 2021 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/nbla/cuda/function/batch_cholesky.hpp
+++ b/include/nbla/cuda/function/batch_cholesky.hpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Sony Group Corporation.
+// Copyright 2022 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/nbla/cuda/function/batch_cholesky.hpp
+++ b/include/nbla/cuda/function/batch_cholesky.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CUDA_FUNCTION_BATCH_CHOLESKY_HPP
+#define NBLA_CUDA_FUNCTION_BATCH_CHOLESKY_HPP
+
+#include <nbla/cuda/cuda.hpp>
+#include <nbla/function/batch_cholesky.hpp>
+
+namespace nbla {
+
+template <typename T> class BatchCholeskyCuda : public BatchCholesky<T> {
+public:
+  typedef typename CudaType<T>::type Tcu;
+
+  explicit BatchCholeskyCuda(const Context &ctx, bool upper)
+      : BatchCholesky<T>(ctx, upper), device_(std::stoi(ctx.device_id)) {}
+  virtual ~BatchCholeskyCuda() {}
+  virtual string name() { return "BatchCholeskyCuda"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cuda>()->array_classes();
+  }
+
+protected:
+  int device_;
+  virtual void setup_impl(const Variables &inputs, const Variables &outputs);
+  virtual void forward_impl(const Variables &inputs, const Variables &outputs);
+  virtual void backward_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &propagate_down,
+                             const vector<bool> &accum);
+  virtual void phi(Variable &x);
+};
+}
+#endif

--- a/include/nbla/cuda/math.hpp
+++ b/include/nbla/cuda/math.hpp
@@ -1,5 +1,5 @@
 // Copyright 2017,2018,2019,2020,2021 Sony Corporation.
-// Copyright 2021 Sony Group Corporation.
+// Copyright 2021,2022 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/nbla/cuda/math.hpp
+++ b/include/nbla/cuda/math.hpp
@@ -19,6 +19,7 @@
 #include <nbla/common.hpp>
 #include <nbla/cuda/cublas.hpp>
 #include <nbla/cuda/cuda.hpp>
+#include <nbla/cuda/cusolver.hpp>
 
 namespace nbla {
 
@@ -184,6 +185,15 @@ static Size_t next_pow2_floor(Size_t n) {
   return n - (n >> 1);
   // Same as
   // return static_cast<T>(std::pow(2, std::floor(std::log2(n))));
+}
+
+template <typename T>
+void cuda_potrf_batched(int device, int n, T **x, int *info, int batchSize) {
+  _TD();
+  cusolverDnHandle_t handle =
+      SingletonManager::get<Cuda>()->cusolverdn_handle(device);
+  cusolverdn_potrf_batched<Tc>(handle, n, reinterpret_cast<Tc **>(x), n, info,
+                               batchSize);
 }
 }
 #endif

--- a/src/nbla/cuda/CMakeLists.txt
+++ b/src/nbla/cuda/CMakeLists.txt
@@ -22,6 +22,7 @@ message("Version: " ${CUDA_VERSION})
 message("Library: " ${CUDA_CUDA_LIBRARY})
 message("Runtime: " ${CUDA_CUDART_LIBRARY})
 message("CUBLAS: " ${CUDA_CUBLAS_LIBRARIES})
+message("CUSOLVER: " ${CUDA_cusolver_LIBRARY})
 message("CURAND: " ${CUDA_curand_LIBRARY})
 message("CUFFT: " ${CUDA_CUFFT_LIBRARIES})
 set(NBLA_CUDA_INCLUDE_DIRS ${CUDA_INCLUDE_DIRS})
@@ -29,6 +30,7 @@ list(APPEND NBLA_CUDA_LINKER_LIBS
   ${CUDA_CUDA_LIBRARY}
   ${CUDA_CUDART_LIBRARY}
   ${CUDA_CUBLAS_LIBRARIES}
+  ${CUDA_cusolver_LIBRARY}
   ${CUDA_curand_LIBRARY}
   ${CUDA_CUFFT_LIBRARIES}
   )

--- a/src/nbla/cuda/cuda.cpp
+++ b/src/nbla/cuda/cuda.cpp
@@ -1,5 +1,5 @@
 // Copyright 2017,2018,2019,2020,2021 Sony Corporation.
-// Copyright 2021 Sony Group Corporation.
+// Copyright 2021,2022 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/nbla/cuda/cusolver.cpp
+++ b/src/nbla/cuda/cusolver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright 2021 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/nbla/cuda/cusolver.cpp
+++ b/src/nbla/cuda/cusolver.cpp
@@ -1,4 +1,4 @@
-// Copyright 2021 Sony Group Corporation.
+// Copyright 2022 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/nbla/cuda/cusolver.cpp
+++ b/src/nbla/cuda/cusolver.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/cusolver.hpp>
+
+namespace nbla {
+// ----------------------------------------------------------------------
+// potrf batched
+// ----------------------------------------------------------------------
+template <>
+void cusolverdn_potrf_batched(cusolverDnHandle_t handle, int n, double **x,
+                              int lda, int *info, int batchSize) {
+  NBLA_CUSOLVER_CHECK(cusolverDnDpotrfBatched(handle, CUBLAS_FILL_MODE_UPPER, n,
+                                              x, lda, info, batchSize));
+}
+template <>
+void cusolverdn_potrf_batched(cusolverDnHandle_t handle, int n, float **x,
+                              int lda, int *info, int batchSize) {
+  NBLA_CUSOLVER_CHECK(cusolverDnSpotrfBatched(handle, CUBLAS_FILL_MODE_UPPER, n,
+                                              x, lda, info, batchSize));
+}
+}

--- a/src/nbla/cuda/function/generic/batch_cholesky.cu
+++ b/src/nbla/cuda/function/generic/batch_cholesky.cu
@@ -1,4 +1,4 @@
-// Copyright 2021 Sony Group Corporation.
+// Copyright 2022 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,8 @@
 // Sets head pointers of matrices in mini-batch.
 template <typename T>
 __global__ void kernel_set_batch_pointers(int batchSize, int n, const T **ptr,
-                                          const T *head) {
+                                          const T *head)
+{
   NBLA_CUDA_KERNEL_LOOP(idx, batchSize) { ptr[idx] = head + idx * n * n; }
 }
 
@@ -34,105 +35,128 @@ __global__ void kernel_set_batch_pointers(int batchSize, int n, const T **ptr,
   NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_set_batch_pointers, BATCH, this->dim_, \
                                  (const T **)dev_list_##NAME, (const T *)PTR)
 
-namespace nbla {
+namespace nbla
+{
 
-namespace batch_cholesky {
-template <typename T, bool upper>
-__global__ void construct_triangular_matrix(int batchSize, int n, const T *lu,
-                                            T *y) {
-  NBLA_CUDA_KERNEL_LOOP(idx, batchSize * n * n) {
-    int matrixSize = (n * n);
-    int batchNum = idx / matrixSize;
-    int idxInMatrix = idx - batchNum * matrixSize;
-    int row = idxInMatrix / n;
-    int col = idxInMatrix % n;
+  namespace batch_cholesky
+  {
+    template <typename T, bool upper>
+    __global__ void construct_triangular_matrix(int batchSize, int n, const T *lu,
+                                                T *y)
+    {
+      NBLA_CUDA_KERNEL_LOOP(idx, batchSize * n * n)
+      {
+        int matrixSize = (n * n);
+        int batchNum = idx / matrixSize;
+        int idxInMatrix = idx - batchNum * matrixSize;
+        int row = idxInMatrix / n;
+        int col = idxInMatrix % n;
 
-    if (row < col) {
-      // upper part
-      y[idx] = upper ? lu[idx] : (T)0.0;
-    } else if (col < row) {
-      // lower part
-      y[idx] = upper ? (T)0.0 : lu[batchNum * matrixSize + col * n + row];
-    } else {
-      // diagonal part
-      y[idx] = lu[idx];
+        if (row < col)
+        {
+          // upper part
+          y[idx] = upper ? lu[idx] : (T)0.0;
+        }
+        else if (col < row)
+        {
+          // lower part
+          y[idx] = upper ? (T)0.0 : lu[batchNum * matrixSize + col * n + row];
+        }
+        else
+        {
+          // diagonal part
+          y[idx] = lu[idx];
+        }
+      }
+    }
+
+    template <typename T>
+    __global__ void apply_phi(int batchSize, int n, T *y)
+    {
+      NBLA_CUDA_KERNEL_LOOP(idx, batchSize * n * n)
+      {
+        int matrixSize = (n * n);
+        int batchNum = idx / matrixSize;
+        int idxInMatrix = idx - batchNum * matrixSize;
+        int row = idxInMatrix / n;
+        int col = idxInMatrix % n;
+
+        if (row == col)
+        {
+          y[idx] = y[idx] * 0.5;
+        }
+        else if (row < col)
+        {
+          y[idx] = 0.0;
+        }
+      }
     }
   }
-}
 
-template <typename T> __global__ void apply_phi(int batchSize, int n, T *y) {
-  NBLA_CUDA_KERNEL_LOOP(idx, batchSize * n * n) {
-    int matrixSize = (n * n);
-    int batchNum = idx / matrixSize;
-    int idxInMatrix = idx - batchNum * matrixSize;
-    int row = idxInMatrix / n;
-    int col = idxInMatrix % n;
+  template <typename T>
+  void BatchCholeskyCuda<T>::setup_impl(const Variables &inputs,
+                                        const Variables &outputs)
+  {
+    BatchCholesky<T>::setup_impl(inputs, outputs);
 
-    if (row == col) {
-      y[idx] = y[idx] * 0.5;
-    } else if (row < col) {
-      y[idx] = 0.0;
+    cuda_set_device(this->device_);
+  }
+
+  template <typename T>
+  void BatchCholeskyCuda<T>::forward_impl(const Variables &inputs,
+                                          const Variables &outputs)
+  {
+    cuda_set_device(this->device_);
+
+    NdArray info_ndarr(Shape_t{this->batch_size_});
+    shared_ptr<Array> info =
+        info_ndarr.cast_sp(dtypes::INT, this->ctx_, true /*write only*/);
+    info->zero();
+
+    NdArray lu(Shape_t{inputs[0]->size()});
+    ArrayPtr lu_arr = lu.cast_sp(get_dtype<Tcu>(), this->ctx_, true);
+    lu_arr->copy_from(
+        inputs[0]->data()->cast(get_dtype<Tcu>(), this->ctx_, false));
+    Tcu *lu_ptr = lu_arr->pointer<Tcu>();
+
+    NBLA_GET_BATCH_POINTERS(lu_ptr, lu, this->batch_size_, ); // dev_list_lu
+
+    // cholesky decomposition
+    // NOTE: cusolver always return upper triangular part of the matrix
+    cuda_potrf_batched<Tcu>(this->device_, this->dim_, dev_list_lu,
+                            info->pointer<int>(), this->batch_size_);
+    Tcu *y_ptr = outputs[0]->cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+    if (this->upper_)
+    {
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+          (batch_cholesky::construct_triangular_matrix<Tcu, true>),
+          this->batch_size_, this->dim_, lu_ptr, y_ptr);
+    }
+    else
+    {
+      NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+          (batch_cholesky::construct_triangular_matrix<Tcu, false>),
+          this->batch_size_, this->dim_, lu_ptr, y_ptr);
     }
   }
-}
-}
 
-template <typename T>
-void BatchCholeskyCuda<T>::setup_impl(const Variables &inputs,
-                                      const Variables &outputs) {
-  BatchCholesky<T>::setup_impl(inputs, outputs);
-
-  cuda_set_device(this->device_);
-}
-
-template <typename T>
-void BatchCholeskyCuda<T>::forward_impl(const Variables &inputs,
-                                        const Variables &outputs) {
-  cuda_set_device(this->device_);
-
-  NdArray info_ndarr(Shape_t{this->batch_size_});
-  shared_ptr<Array> info =
-      info_ndarr.cast_sp(dtypes::INT, this->ctx_, true /*write only*/);
-  info->zero();
-
-  NdArray lu(Shape_t{inputs[0]->size()});
-  ArrayPtr lu_arr = lu.cast_sp(get_dtype<Tcu>(), this->ctx_, true);
-  lu_arr->copy_from(
-      inputs[0]->data()->cast(get_dtype<Tcu>(), this->ctx_, false));
-  Tcu *lu_ptr = lu_arr->pointer<Tcu>();
-
-  NBLA_GET_BATCH_POINTERS(lu_ptr, lu, this->batch_size_, ); // dev_list_lu
-
-  // cholesky decomposition
-  // NOTE: cusolver always return upper triangular part of the matrix
-  cuda_potrf_batched<Tcu>(this->device_, this->dim_, dev_list_lu,
-                          info->pointer<int>(), this->batch_size_);
-  Tcu *y_ptr = outputs[0]->cast_data_and_get_pointer<Tcu>(this->ctx_, true);
-  if (this->upper_) {
-    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
-        (batch_cholesky::construct_triangular_matrix<Tcu, true>),
-        this->batch_size_, this->dim_, lu_ptr, y_ptr);
-  } else {
-    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
-        (batch_cholesky::construct_triangular_matrix<Tcu, false>),
-        this->batch_size_, this->dim_, lu_ptr, y_ptr);
+  template <typename T>
+  void BatchCholeskyCuda<T>::backward_impl(const Variables &inputs,
+                                           const Variables &outputs,
+                                           const vector<bool> &propagate_down,
+                                           const vector<bool> &accum)
+  {
+    cuda_set_device(this->device_);
+    BatchCholesky<T>::backward_impl(inputs, outputs, propagate_down, accum);
   }
-}
 
-template <typename T>
-void BatchCholeskyCuda<T>::backward_impl(const Variables &inputs,
-                                         const Variables &outputs,
-                                         const vector<bool> &propagate_down,
-                                         const vector<bool> &accum) {
-  cuda_set_device(this->device_);
-  BatchCholesky<T>::backward_impl(inputs, outputs, propagate_down, accum);
-}
+  template <typename T>
+  void BatchCholeskyCuda<T>::phi(Variable &x)
+  {
+    cuda_set_device(this->device_);
+    Tcu *y = x.cast_data_and_get_pointer<Tcu>(this->ctx_, true);
 
-template <typename T> void BatchCholeskyCuda<T>::phi(Variable &x) {
-  cuda_set_device(this->device_);
-  Tcu *y = x.cast_data_and_get_pointer<Tcu>(this->ctx_, true);
-
-  NBLA_CUDA_LAUNCH_KERNEL_SIMPLE((batch_cholesky::apply_phi<Tcu>),
-                                 this->batch_size_, this->dim_, y);
-}
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE((batch_cholesky::apply_phi<Tcu>),
+                                   this->batch_size_, this->dim_, y);
+  }
 }

--- a/src/nbla/cuda/function/generic/batch_cholesky.cu
+++ b/src/nbla/cuda/function/generic/batch_cholesky.cu
@@ -1,0 +1,137 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/cuda/array/cuda_array.hpp>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/function/batch_cholesky.hpp>
+#include <nbla/cuda/math.hpp>
+#include <nbla/variable.hpp>
+
+// Sets head pointers of matrices in mini-batch.
+template <typename T>
+__global__ void kernel_set_batch_pointers(int batchSize, int n, const T **ptr,
+                                          const T *head) {
+  NBLA_CUDA_KERNEL_LOOP(idx, batchSize) { ptr[idx] = head + idx * n * n; }
+}
+
+// A macro that creates an array of pointers of matrices.
+#define NBLA_GET_BATCH_POINTERS(PTR, NAME, BATCH, CONST)                       \
+  CudaCachedArray list_##PTR(sizeof(Tcu *) * BATCH, dtypes::BYTE, this->ctx_); \
+  CONST Tcu **dev_list_##NAME =                                                \
+      reinterpret_cast<CONST Tcu **>(list_##PTR.pointer<void>());              \
+  NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(kernel_set_batch_pointers, BATCH, this->dim_, \
+                                 (const T **)dev_list_##NAME, (const T *)PTR)
+
+namespace nbla {
+
+namespace batch_cholesky {
+template <typename T, bool upper>
+__global__ void construct_triangular_matrix(int batchSize, int n, const T *lu,
+                                            T *y) {
+  NBLA_CUDA_KERNEL_LOOP(idx, batchSize * n * n) {
+    int matrixSize = (n * n);
+    int batchNum = idx / matrixSize;
+    int idxInMatrix = idx - batchNum * matrixSize;
+    int row = idxInMatrix / n;
+    int col = idxInMatrix % n;
+
+    if (row < col) {
+      // upper part
+      y[idx] = upper ? lu[idx] : (T)0.0;
+    } else if (col < row) {
+      // lower part
+      y[idx] = upper ? (T)0.0 : lu[batchNum * matrixSize + col * n + row];
+    } else {
+      // diagonal part
+      y[idx] = lu[idx];
+    }
+  }
+}
+
+template <typename T> __global__ void apply_phi(int batchSize, int n, T *y) {
+  NBLA_CUDA_KERNEL_LOOP(idx, batchSize * n * n) {
+    int matrixSize = (n * n);
+    int batchNum = idx / matrixSize;
+    int idxInMatrix = idx - batchNum * matrixSize;
+    int row = idxInMatrix / n;
+    int col = idxInMatrix % n;
+
+    if (row == col) {
+      y[idx] = y[idx] * 0.5;
+    } else if (row < col) {
+      y[idx] = 0.0;
+    }
+  }
+}
+}
+
+template <typename T>
+void BatchCholeskyCuda<T>::setup_impl(const Variables &inputs,
+                                      const Variables &outputs) {
+  BatchCholesky<T>::setup_impl(inputs, outputs);
+
+  cuda_set_device(this->device_);
+}
+
+template <typename T>
+void BatchCholeskyCuda<T>::forward_impl(const Variables &inputs,
+                                        const Variables &outputs) {
+  cuda_set_device(this->device_);
+
+  shared_ptr<CudaCachedArray> info =
+      make_shared<CudaCachedArray>(this->batch_size_, dtypes::INT, this->ctx_);
+  info->zero();
+
+  NdArray lu(Shape_t{inputs[0]->size()});
+  ArrayPtr lu_arr = lu.cast_sp(get_dtype<Tcu>(), this->ctx_, true);
+  lu_arr->copy_from(
+      inputs[0]->data()->cast(get_dtype<Tcu>(), this->ctx_, false));
+  Tcu *lu_ptr = lu_arr->pointer<Tcu>();
+
+  NBLA_GET_BATCH_POINTERS(lu_ptr, lu, this->batch_size_, ); // dev_list_lu
+
+  // cholesky decomposition
+  // NOTE: cusolver always return upper triangular part of matrix
+  cuda_potrf_batched<Tcu>(this->device_, this->dim_, dev_list_lu,
+                          info->pointer<int>(), this->batch_size_);
+  Tcu *y_ptr = outputs[0]->cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+  if (this->upper_) {
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+        (batch_cholesky::construct_triangular_matrix<Tcu, true>),
+        this->batch_size_, this->dim_, lu_ptr, y_ptr);
+  } else {
+    NBLA_CUDA_LAUNCH_KERNEL_SIMPLE(
+        (batch_cholesky::construct_triangular_matrix<Tcu, false>),
+        this->batch_size_, this->dim_, lu_ptr, y_ptr);
+  }
+}
+
+template <typename T>
+void BatchCholeskyCuda<T>::backward_impl(const Variables &inputs,
+                                         const Variables &outputs,
+                                         const vector<bool> &propagate_down,
+                                         const vector<bool> &accum) {
+  cuda_set_device(this->device_);
+  BatchCholesky<T>::backward_impl(inputs, outputs, propagate_down, accum);
+}
+
+template <typename T> void BatchCholeskyCuda<T>::phi(Variable &x) {
+  cuda_set_device(this->device_);
+  Tcu *y = x.cast_data_and_get_pointer<Tcu>(this->ctx_, true);
+
+  NBLA_CUDA_LAUNCH_KERNEL_SIMPLE((batch_cholesky::apply_phi<Tcu>),
+                                 this->batch_size_, this->dim_, y);
+}
+}


### PR DESCRIPTION
Adding batch-wise cholesky decomposition function.
The backward of this function returns symmetric matrix for convenience. 
(Even though cholesky decomposition requires only the upper/lower part of the matrix.)
See [also this pytorch's issue](https://github.com/pytorch/pytorch/issues/18825).

For implementation details see [this paper](https://arxiv.org/abs/1602.07527).

NOTE: cuda version of cholesky decomposition is implemented using cusolver.
Therefore, this PR also adds changes to link cusolver library to the nnabla-ext-cuda package.