### PR TITLE
Fix: copy function was missing in MaxPoolingCudnn

### DIFF
--- a/include/nbla/cuda/cudnn/function/max_pooling.hpp
+++ b/include/nbla/cuda/cudnn/function/max_pooling.hpp
@@ -43,6 +43,16 @@ public:
       return CUDNN_POOLING_MAX_DETERMINISTIC;
     return CUDNN_POOLING_MAX;
   }
+  // NOTE: With an unknown reason, creating this class derived from
+  // `BasePoolingCudaCudnn<MaxPooling<T>>` gave a compile error. So I decided to
+  // derive it from BasePooling class which seems to succeed, but the problem is
+  // that it doesn't implement `copy()` function. I copy & paste the copy
+  // function found in the MaxPooling class although it's ugly.
+  shared_ptr<Function> copy() const override {
+    return create_MaxPooling(this->ctx_, this->kernel_, this->stride_,
+                             this->ignore_border_, this->pad_,
+                             this->channel_last_);
+  }
 };
 }
 #endif


### PR DESCRIPTION
As described in the title, the copy function was not properly implemented in MaxPoolingCudnn. This caused segfault.