### PR TITLE
Fix: Slow Softmax backward when H and W are 1

### DIFF
--- a/include/nbla/cuda/cudnn/cudnn.hpp
+++ b/include/nbla/cuda/cudnn/cudnn.hpp
@@ -291,6 +291,7 @@ class CudnnSoftmax {
   CudnnTensorDescriptor input_desc_;
   CudnnTensorDescriptor output_desc_;
   cudnnSoftmaxAlgorithm_t algo_;
+  cudnnSoftmaxMode_t mode_;
   int device_;
 
 public:

--- a/src/nbla/cuda/cudnn/cudnn.cpp
+++ b/src/nbla/cuda/cudnn/cudnn.cpp
@@ -669,7 +669,7 @@ void CudnnPooling::backward(const void *alpha, const void *y, const void *dy,
 CudnnSoftmax::CudnnSoftmax(const Shape_t &inshape, int axis,
                            cudnnSoftmaxAlgorithm_t algo, cudnnDataType_t dtype,
                            int device)
-    : algo_(algo), device_(device) {
+    : algo_(algo), mode_(CUDNN_SOFTMAX_MODE_CHANNEL), device_(device) {
   const size_t size = std::accumulate(inshape.cbegin(), inshape.cend(),
                                       (size_t)1, std::multiplies<size_t>());
   const size_t size_axis = ndi::inner_size(inshape, axis);
@@ -681,6 +681,9 @@ CudnnSoftmax::CudnnSoftmax(const Shape_t &inshape, int axis,
   const int stride_h = W * stride_w;
   const int stride_c = H * stride_h;
   const int stride_n = C * stride_c;
+  if (stride_c == 1) {
+    mode_ = CUDNN_SOFTMAX_MODE_INSTANCE;
+  }
   NBLA_CUDNN_CHECK(cudnnSetTensor4dDescriptorEx(input_desc_.desc, dtype, N, C,
                                                 H, W, stride_n, stride_c,
                                                 stride_h, stride_w));
@@ -696,16 +699,16 @@ CudnnSoftmax::Ptr CudnnSoftmax::create(const Shape_t &inshape, int axis,
 void CudnnSoftmax::forward(const void *alpha, const void *x, const void *beta,
                            void *y) const {
   auto handle = SingletonManager::get<CudnnHandleManager>()->handle(device_);
-  NBLA_CUDNN_CHECK(
-      cudnnSoftmaxForward(handle, algo_, CUDNN_SOFTMAX_MODE_CHANNEL, alpha,
-                          input_desc_.desc, x, beta, output_desc_.desc, y));
+  NBLA_CUDNN_CHECK(cudnnSoftmaxForward(handle, algo_, mode_, alpha,
+                                       input_desc_.desc, x, beta,
+                                       output_desc_.desc, y));
 }
 void CudnnSoftmax::backward(const void *alpha, const void *y, const void *dy,
                             const void *beta, void *dx) const {
   auto handle = SingletonManager::get<CudnnHandleManager>()->handle(device_);
-  NBLA_CUDNN_CHECK(cudnnSoftmaxBackward(
-      handle, algo_, CUDNN_SOFTMAX_MODE_CHANNEL, alpha, output_desc_.desc, y,
-      output_desc_.desc, dy, beta, input_desc_.desc, dx));
+  NBLA_CUDNN_CHECK(cudnnSoftmaxBackward(handle, algo_, mode_, alpha,
+                                        output_desc_.desc, y, output_desc_.desc,
+                                        dy, beta, input_desc_.desc, dx));
 }
 
 //////////////////////////////


### PR DESCRIPTION
Reported that softmax backward was very slow when reduction is performed in an innermost axis. I just made a change such that it uses CUDNN_SOFTMAX_MODE_INSTANCE when H and W are 1, and confirmed that it considerably improved the performance in the setting reported in the slack as well as some settings with H x W=1.

### Benchmarks
Measured in `SoftmaxCudaCudnn<float>` on GTX 1080 with a benchmark script added in sony/nnabla#1052.

| inspecs            | axis | v1.27 forward \[ms\] | v1.27 backward \[ms\] | Fixed forward \[ms\] | Fixed backward \[ms\] | Speedup F | Speedup B |
| ------------------ | ---- | -------------------- | --------------------- | -------------------- | --------------------- | --------- | --------- |
| (64, 80, 224, 224) | 1    | 22.36                | 26.96                 | 22.40                | 26.98                 | 1.00      | 1.00      |
| (64, 224, 224, 80) | 3    | 73.80                | 4810.75               | 49.62                | 40.52                 | **1.49**      | **118.73**    |
| (64, 20, 224, 224) | 1    | 5.27                 | 6.46                  | 5.27                 | 6.46                  | 1.00      | 1.00      |
| (64, 224, 224, 20) | 3    | 70.73                | 4737.35               | 46.71                | 37.17                 | **1.51**      | **127.45**    |
| (1, 1000)          | 1    | 0.01                 | 0.01                  | 0.01                 | 0.01                  | 1.00      | 1.00      |
| (64, 1000)         | 1    | 0.02                 | 0.15                  | 0.01                 | 0.01                  | **2.00**      | **15.00**     |
| (768, 50, 50)      | 2    | 0.92                 | 57.94                 | 0.68                 | 0.53                  | **1.35**      | **109.32**    |
