### PR TITLE
update nvidia gpg key

### DIFF
--- a/docker/release/Dockerfile.cuda
+++ b/docker/release/Dockerfile.cuda
@@ -64,7 +64,6 @@ ARG APT_OPTS
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN eval ${APT_OPTS} \
-    && apt-key del 7fa2af80 \
     && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
     && apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docker/release/Dockerfile.cuda
+++ b/docker/release/Dockerfile.cuda
@@ -64,6 +64,8 @@ ARG APT_OPTS
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN eval ${APT_OPTS} \
+    && apt-key del 7fa2af80 \
+    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
     software-properties-common \

--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -99,7 +99,6 @@ ARG MPI
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN eval ${APT_OPTS} \
-    && apt-key del 7fa2af80 \
     && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
     && apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -99,6 +99,8 @@ ARG MPI
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN eval ${APT_OPTS} \
+    && apt-key del 7fa2af80 \
+    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
     software-properties-common \


### PR DESCRIPTION
nvidia GPG key was changed on Apr 2022, this causes apt update to fail, so add the new key in their docker image.

Ref: https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
