### PR TITLE
Update gpg keys for centos based nvidia docker

### DIFF
--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -29,6 +29,8 @@ ENV LANG C
 ENV LANGUAGE C
 
 RUN eval ${YUM_OPTS} \
+    && curl ${CURL_OPTS} -L https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/D42D0685.pub -o D42D0685.pub \
+    && rpm --import D42D0685.pub \
     && yum install -y \
        epel-release \
        yum-utils \

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -66,6 +66,8 @@ ENV LANG C
 ENV LANGUAGE C
 
 RUN eval ${YUM_OPTS} \
+    && curl ${CURL_OPTS} -L https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/D42D0685.pub -o D42D0685.pub \
+    && rpm --import D42D0685.pub \
     && yum install -y \
        epel-release \
        yum-utils \

--- a/docker/development/Dockerfile.build-mpi-ppc64le
+++ b/docker/development/Dockerfile.build-mpi-ppc64le
@@ -66,6 +66,8 @@ ENV LANG C
 ENV LANGUAGE C
 
 RUN eval ${YUM_OPTS} \
+    && curl ${CURL_OPTS} -L https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/D42D0685.pub -o D42D0685.pub \
+    && rpm --import D42D0685.pub \
     && yum install -y \
        epel-release \
        yum-utils \

--- a/docker/development/Dockerfile.build-ppc64le
+++ b/docker/development/Dockerfile.build-ppc64le
@@ -29,6 +29,8 @@ ENV LANG C
 ENV LANGUAGE C
 
 RUN eval ${YUM_OPTS} \
+    && curl ${CURL_OPTS} -L https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/D42D0685.pub -o D42D0685.pub \
+    && rpm --import D42D0685.pub \
     && yum install -y \
        epel-release \
        yum-utils \


### PR DESCRIPTION
nvidia centos docker images need to update gpg keys, otherwise we got this error message:

```bash
The GPG keys listed for the "cuda" repository are already installed but they are not correct for this package.
Check that the correct key URLs are configured for this repository.
 Failing package is: nsight-systems-2021.1.3-2021.1.3.14_b695ea9-0.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA
```

Ref: https://developer.nvidia.com/blog/updating-the-cuda-linux-gpg-repository-key/