### PR TITLE
use numpy 1.20.0 and later

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,7 +8,7 @@ PyYAML
 Cython
 boto3
 h5py<=3.1.0
-numpy
+numpy>=1.20.0
 protobuf
 six
 tqdm

--- a/python/setup.py
+++ b/python/setup.py
@@ -47,8 +47,6 @@ assert(__author__ is not None)
 assert(__email__ is not None)
 
 setup_requires = [
-    'numpy',
-    'Cython',  # Requires python-dev.
 ]
 
 whl_suffix = ''


### PR DESCRIPTION
This PR is same purpose as https://github.com/sony/nnabla/pull/1072.

nnabla-ext-cuda depends on nnabla, and nnabla depends on cython and numpy, so we remove the dependency on cython and numpy from nnabla-ext-cuda.