### PR TITLE
Update protobuf to 3.19.4

### DIFF
--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -95,7 +95,7 @@ RUN mkdir /tmp/deps \
     && rm -rf /tmp/*
 
 ############################################################ protobuf
-ARG PROTOVER=3.10.1
+ARG PROTOVER=3.19.4
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
     && curl ${CURL_OPTS} -L https://github.com/google/protobuf/archive/v${PROTOVER}.tar.gz -o protobuf-v${PROTOVER}.tar.gz \

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -146,7 +146,7 @@ RUN mkdir /tmp/deps \
     && rm -rf /tmp/*
 
 ############################################################ protobuf
-ARG PROTOVER=3.10.1
+ARG PROTOVER=3.19.4
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
     && curl ${CURL_OPTS} -L https://github.com/google/protobuf/archive/v${PROTOVER}.tar.gz -o protobuf-v${PROTOVER}.tar.gz \

--- a/docker/development/Dockerfile.build-mpi-ppc64le
+++ b/docker/development/Dockerfile.build-mpi-ppc64le
@@ -145,7 +145,7 @@ RUN mkdir /tmp/deps \
     && rm -rf /tmp/*
 
 ############################################################ protobuf
-ARG PROTOVER=3.10.1
+ARG PROTOVER=3.19.4
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
     && curl ${CURL_OPTS} -L https://github.com/google/protobuf/archive/v${PROTOVER}.tar.gz -o protobuf-v${PROTOVER}.tar.gz \

--- a/docker/development/Dockerfile.build-ppc64le
+++ b/docker/development/Dockerfile.build-ppc64le
@@ -94,7 +94,7 @@ RUN mkdir /tmp/deps \
     && rm -rf /tmp/*
 
 ############################################################ protobuf
-ARG PROTOVER=3.10.1
+ARG PROTOVER=3.19.4
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
     && curl ${CURL_OPTS} -L https://github.com/google/protobuf/archive/v${PROTOVER}.tar.gz -o protobuf-v${PROTOVER}.tar.gz \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,7 +9,7 @@ Cython
 boto3
 h5py<=3.1.0
 numpy>=1.20.0
-protobuf
+protobuf<=3.20.1
 six
 tqdm
 


### PR DESCRIPTION
protobuf was updated, so the following error appears now.

```text
TypeError: Descriptors cannot not be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
```

* Update protobuf to 3.19.4