### PR TITLE
Better error message in CUDNN.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,15 @@ if(BUILD_CPP_LIB)
     include_directories(${NBLA_CUDA_INCLUDE_DIRS})
   
     file(GLOB NBLA_TEST_SOURCES src/nbla/cuda/test/test_*.cpp)
+    if(NOT WITH_NCCL)
+      file(GLOB NBLA_NCCL_TEST_SOURCES src/nbla/cuda/test/test_dl_mpi.cpp
+                                       src/nbla/cuda/test/test_watch_dog.cpp
+                                       src/nbla/cuda/test/test_multi_process_data_parallel_communicator.cpp)
+      foreach(d_file ${NBLA_NCCL_TEST_SOURCES})
+        list(REMOVE_ITEM NBLA_TEST_SOURCES ${d_file})
+      endforeach()
+    endif()
+    message(STATUS, ${NBLA_TEST_SOURCES})
     add_executable(clibtest ${NBLA_TEST_SOURCES})
     add_dependencies(clibtest ${NBLA_CUDA_LIBRARY_NAME})
     target_link_libraries(clibtest gtestd gtest_maind pthread)

--- a/include/nbla/cuda/common.hpp
+++ b/include/nbla/cuda/common.hpp
@@ -108,8 +108,14 @@ inline string cublas_status_to_string(cublasStatus_t status) {
   {                                                                            \
     cublasStatus_t status = condition;                                         \
     cudaGetLastError();                                                        \
-    NBLA_CHECK(status == CUBLAS_STATUS_SUCCESS, error_code::target_specific,   \
-               cublas_status_to_string(status));                               \
+    if (status != CUBLAS_STATUS_SUCCESS) {                                     \
+      NBLA_ERROR(                                                              \
+          error_code::target_specific,                                         \
+          string("CUBLAS_STATUS_") + cublas_status_to_string(status) +         \
+              string(                                                          \
+                  " occured in `" #condition                                   \
+                  "`. Please see CUBLAS API documentation for the cause."));   \
+    }                                                                          \
   }
 
 inline string cusolver_status_to_string(cusolverStatus_t status) {
@@ -155,8 +161,14 @@ inline string cusolver_status_to_string(cusolverStatus_t status) {
 #define NBLA_CUSOLVER_CHECK(condition)                                         \
   {                                                                            \
     cusolverStatus_t status = condition;                                       \
-    NBLA_CHECK(status == CUSOLVER_STATUS_SUCCESS, error_code::target_specific, \
-               cusolver_status_to_string(status));                             \
+    if (status != CUSOLVER_STATUS_SUCCESS) {                                   \
+      NBLA_ERROR(                                                              \
+          error_code::target_specific,                                         \
+          string("CUSOLVER_STATUS_") + cusolver_status_to_string(status) +     \
+              string(                                                          \
+                  " occured in `" #condition                                   \
+                  "`. Please see CUSOLVER API documentation for the cause.")); \
+    }                                                                          \
   }
 
 inline string curand_status_to_string(curandStatus_t status) {
@@ -186,8 +198,14 @@ inline string curand_status_to_string(curandStatus_t status) {
 #define NBLA_CURAND_CHECK(condition)                                           \
   {                                                                            \
     curandStatus_t status = condition;                                         \
-    NBLA_CHECK(status == CURAND_STATUS_SUCCESS, error_code::target_specific,   \
-               curand_status_to_string(status));                               \
+    if (status != CURAND_STATUS_SUCCESS) {                                     \
+      NBLA_ERROR(                                                              \
+          error_code::target_specific,                                         \
+          string("CUBLAS_STATUS_") + curand_status_to_string(status) +         \
+              string(                                                          \
+                  " occured in `" #condition                                   \
+                  "`. Please see CUSOLVER API documentation for the cause.")); \
+    }                                                                          \
   }
 
 /** Data type */

--- a/src/nbla/cuda/test/test_nbla_cuda_utils.cpp
+++ b/src/nbla/cuda/test/test_nbla_cuda_utils.cpp
@@ -1,0 +1,51 @@
+#include "gtest/gtest.h"
+#include <cudnn.h>
+#include <exception>
+#include <nbla/cuda/common.hpp>
+#include <nbla/cuda/cudnn/cudnn.hpp>
+
+namespace nbla {
+cudnnStatus_t FakeCudnnFunc(void) { return CUDNN_STATUS_ALLOC_FAILED; }
+
+cublasStatus_t FakeCublasFunc(void) { return CUBLAS_STATUS_ALLOC_FAILED; }
+
+cusolverStatus_t FakeCusolverFunc(void) { return CUSOLVER_STATUS_ALLOC_FAILED; }
+
+curandStatus_t FakeCurandFunc(void) { return CURAND_STATUS_ALLOCATION_FAILED; }
+
+TEST(NBLA_CUDNN_CHECK_Test, CheckCudnnFailed) {
+  try {
+    NBLA_CUDNN_CHECK(FakeCudnnFunc());
+    EXPECT_TRUE(false);
+  } catch (const std::exception &e) {
+    std::cout << "Caught exception \"" << e.what() << "\"\n";
+  }
+}
+
+TEST(NBLA_CUBLAS_CHECK_Test, CheckCublasFailed) {
+  try {
+    NBLA_CUBLAS_CHECK(FakeCublasFunc());
+    EXPECT_TRUE(false);
+  } catch (const std::exception &e) {
+    std::cout << "Caught exception \"" << e.what() << "\"\n";
+  }
+}
+
+TEST(NBLA_CUSOLVER_CHECK_Test, CheckCusolverFailed) {
+  try {
+    NBLA_CUSOLVER_CHECK(FakeCusolverFunc());
+    EXPECT_TRUE(false);
+  } catch (const std::exception &e) {
+    std::cout << "Caught exception \"" << e.what() << "\"\n";
+  }
+}
+
+TEST(NBLA_CURAND_CHECK_Test, CheckCurandFailed) {
+  try {
+    NBLA_CURAND_CHECK(FakeCurandFunc());
+    EXPECT_TRUE(false);
+  } catch (const std::exception &e) {
+    std::cout << "Caught exception \"" << e.what() << "\"\n";
+  }
+}
+}


### PR DESCRIPTION
Currently we give an error code from CUDNN API take from `cudnnStatus_t`. The error code doesn't tell what the cause actually is, which is not user-friendly. Something like:
```
RuntimeError: target_specific error in cudnn_set_tensor_nd_descriptor_force_dim
/home/gitlab-runner/builds/jmdP2aBr/1/nnabla/builders/all/nnabla-ext-cuda/src/nbla/cuda/cudnn/cudnn.cpp:40
Failed `status == CUDNN_STATUS_SUCCESS`: NOT_SUPPORTED
```

This PR proposes to show a full CUDNN error code and what API is called in the code to navigate users to the CUDNN API guide to identify the possible causes of the error.

The CUDNN API guide gives you the possible causes for each error code as follows (This is in case of [`cudnnSetTensorNdDescriptor`](https://docs.nvidia.com/deeplearning/cudnn/api/index.html#cudnnSetTensorNdDescriptor)).
> **CUDNN_STATUS_NOT_SUPPORTED**
> The parameter nbDims is outside the range [4, CUDNN_DIM_MAX], or the total size of the tensor descriptor exceeds the maximum limit of 2 Giga-elements.