### PR TITLE
Update nvidia/cuda base image

### DIFF
--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -36,6 +36,7 @@ RUN eval ${APT_OPTS} \
        make \
        g++ \
        git \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN umask 0 \
@@ -104,7 +105,7 @@ RUN eval ${APT_OPTS} \
     && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    software-properties-common \
+       software-properties-common \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -115,8 +116,6 @@ RUN eval ${APT_OPTS} && apt-get update \
        bzip2 \
        ca-certificates \
        curl \
-       libglib2.0-0 \
-       libgl1-mesa-glx \
        python${PYTHON_VER} \
        python3-pip \
        python${PYTHON_VER}-distutils \
@@ -126,26 +125,27 @@ RUN eval ${APT_OPTS} && apt-get update \
        libdapl2 \
        libibmad5 \
        librdmacm1 \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VER} 0
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VER} 0
 
-RUN pip3 install ${PIP_INS_OPTS} --upgrade pip
-RUN pip install ${PIP_INS_OPTS} wheel setuptools
-RUN pip install ${PIP_INS_OPTS} opencv-python || true
 
-RUN pip install ${PIP_INS_OPTS} --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda${CU1_VER}${CU2_VER%.?} \
-    || echo "Skip DALI installation (CUDA=${CU1_VER}.${CU2_VER%.?})"
+ARG NNABLA_VER
+RUN pip3 install ${PIP_INS_OPTS} --no-cache-dir --upgrade pip \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir wheel setuptools \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir opencv-python || true \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda${CU1_VER}${CU2_VER%.?} \
+    || echo "Skip DALI installation (CUDA=${CU1_VER}.${CU2_VER%.?})" \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir nnabla-ext-cuda${CU1_VER}${CU2_VER%.?}==${NNABLA_VER} nnabla_converter==${NNABLA_VER} \
+    && rm -rf ~/.cache
 
 COPY --from=openmpi /opt/openmpi /opt/openmpi
 ENV PATH /opt/openmpi/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
 
 COPY --from=flatc /usr/local/bin/flatc /usr/local/bin/flatc
-
-ARG NNABLA_VER
-RUN pip install ${PIP_INS_OPTS} nnabla-ext-cuda${CU1_VER}${CU2_VER%.?}==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
 # cuda compat driver support
 COPY cudalibcheck /usr/local/bin/cudalibcheck


### PR DESCRIPTION
We used `nvidia/cuda:11.0-cudnn8-runtime-ubuntu18.04` as base, but this image has some issues and obsoleted.
So, we will migrate to use `nvidia/cuda:11.0.3-cudnn8-runtime-ubuntu18.04`.
`CU2_VER` has cuda minor version, and this PR changes this value handling from '0' to '0.3'.