### PR TITLE
remove flatc build from Dockerfile

### DIFF
--- a/docker/release/Dockerfile.cuda
+++ b/docker/release/Dockerfile.cuda
@@ -17,39 +17,6 @@
 ARG CU1_VER
 ARG CU2_VER
 ARG CUDNN_VER
-FROM ubuntu:18.04 as flatc
-
-ARG PIP_INS_OPTS
-ARG PYTHONWARNINGS
-ARG CURL_OPTS
-ARG WGET_OPTS
-ARG APT_OPTS
-
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN eval ${APT_OPTS} \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-       ca-certificates \
-       curl \
-       cmake \
-       make \
-       g++ \
-       git \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN umask 0 \
-    && mkdir -p /tmp/deps \
-    && cd /tmp/deps \
-    && git clone -b \
-       `curl --silent "https://api.github.com/repos/google/flatbuffers/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")'` \
-       https://github.com/google/flatbuffers.git \
-    && cd flatbuffers \
-    && cmake -G "Unix Makefiles" \
-    && make \
-    && make install \
-    && cd / \
-    && rm -rf /tmp/*
 
 FROM nvidia/cuda:${CU1_VER}.${CU2_VER}-cudnn${CUDNN_VER}-runtime-ubuntu18.04
 
@@ -96,8 +63,6 @@ RUN pip install ${PIP_INS_OPTS} opencv-python || true
 
 RUN pip install ${PIP_INS_OPTS} --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda${CU1_VER}0 \
     || echo "Skip DALI installation (CUDA=${CU1_VER}.${CU2_VER})"
-
-COPY --from=flatc /usr/local/bin/flatc /usr/local/bin/flatc
 
 ARG NNABLA_VER
 RUN pip install ${PIP_INS_OPTS} nnabla-ext-cuda${CU1_VER}${CU2_VER%.?}==${NNABLA_VER} nnabla_converter==${NNABLA_VER}

--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -17,40 +17,6 @@
 ARG CU1_VER
 ARG CU2_VER
 ARG CUDNN_VER
-FROM ubuntu:18.04 as flatc
-
-ARG PIP_INS_OPTS
-ARG PYTHONWARNINGS
-ARG CURL_OPTS
-ARG WGET_OPTS
-ARG APT_OPTS
-
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN eval ${APT_OPTS} \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-       ca-certificates \
-       curl \
-       cmake \
-       make \
-       g++ \
-       git \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN umask 0 \
-    && mkdir -p /tmp/deps \
-    && cd /tmp/deps \
-    && git clone -b \
-       `curl --silent "https://api.github.com/repos/google/flatbuffers/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")'` \
-       https://github.com/google/flatbuffers.git \
-    && cd flatbuffers \
-    && cmake -G "Unix Makefiles" \
-    && make \
-    && make install \
-    && cd / \
-    && rm -rf /tmp/*
 
 FROM ubuntu:18.04 as openmpi
 
@@ -144,8 +110,6 @@ RUN pip3 install ${PIP_INS_OPTS} --no-cache-dir --upgrade pip \
 COPY --from=openmpi /opt/openmpi /opt/openmpi
 ENV PATH /opt/openmpi/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/openmpi/lib:$LD_LIBRARY_PATH
-
-COPY --from=flatc /usr/local/bin/flatc /usr/local/bin/flatc
 
 # cuda compat driver support
 COPY cudalibcheck /usr/local/bin/cudalibcheck


### PR DESCRIPTION
As flatc is now included in the nnabla-converter wheel, so it's unnecessary to compile flatbuffer in the docker images for release anymore.