### PR TITLE
Set to use openib by default

### DIFF
--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -84,7 +84,8 @@ RUN cd tmp/openmpi/openmpi-${MPI} \
         F77=gfortran \
         FC=gfortran \
     && make -j8 \
-    && make install
+    && make install \
+    && echo btl_openib_allow_ib = 1 >> /opt/openmpi/etc/openmpi-mca-params.conf
 
 FROM nvidia/cuda:${CU1_VER}.${CU2_VER}-cudnn${CUDNN_VER}-runtime-ubuntu18.04
 


### PR DESCRIPTION
From v1.30.0, we will support cuda11.4 with mpi v4.x.x.
But, UCX will be used by default from openmpi v4.0.x, so this PR change the default to use openib.
User can use ucx by optionally adding `--mca btl_openib_allow_ib 0` on mpirun command.