### PR TITLE
Add narrow function for NdArray

### DIFF
--- a/include/nbla/cuda/array/cuda_array.hpp
+++ b/include/nbla/cuda/array/cuda_array.hpp
@@ -38,9 +38,9 @@ protected:
   int device_;
 
 public:
-  explicit CudaArray(const Size_t size, dtypes dtype, const Context &ctx);
   explicit CudaArray(const Size_t size, dtypes dtype, const Context &ctx,
-                     AllocatorMemory &&mem);
+                     const AllocatorMemoryPtr mem = nullptr,
+                     const Size_t offset = 0);
   virtual ~CudaArray();
   virtual void copy_from(const Array *src_array);
   virtual void zero();
@@ -67,7 +67,9 @@ public:
       @param dtype Data type.
       @param ctx Context specifies device ID.
    */
-  explicit CudaCachedArray(const Size_t size, dtypes dtype, const Context &ctx);
+  explicit CudaCachedArray(const Size_t size, dtypes dtype, const Context &ctx,
+                           const AllocatorMemoryPtr mem = nullptr,
+                           const Size_t offset = 0);
   virtual ~CudaCachedArray();
   static Context filter_context(const Context &ctx);
 };
@@ -84,7 +86,9 @@ public:
   @param ctx Context specifies device ID.
   */
   explicit CudaCachedUnifiedArray(const Size_t size, dtypes dtype,
-                                  const Context &ctx);
+                                  const Context &ctx,
+                                  const AllocatorMemoryPtr mem = nullptr,
+                                  const Size_t offset = 0);
   virtual ~CudaCachedUnifiedArray();
   static Context filter_context(const Context &ctx);
 };
@@ -101,7 +105,9 @@ public:
   @param ctx Context.
   */
   explicit CudaCachedHostArray(const Size_t size, dtypes dtype,
-                               const Context &ctx);
+                               const Context &ctx,
+                               const AllocatorMemoryPtr mem = nullptr,
+                               const Size_t offset = 0);
   virtual ~CudaCachedHostArray();
   static Context filter_context(const Context &ctx);
 };
@@ -119,7 +125,9 @@ public:
   @param ctx Context.
   */
   explicit CudaCachedVirtualArray(const Size_t size, dtypes dtype,
-                                  const Context &ctx);
+                                  const Context &ctx,
+                                  const AllocatorMemoryPtr mem = nullptr,
+                                  const Size_t offset = 0);
   virtual ~CudaCachedVirtualArray();
   static Context filter_context(const Context &ctx);
 

--- a/include/nbla/cuda/array/cuda_dlpack_array.hpp
+++ b/include/nbla/cuda/array/cuda_dlpack_array.hpp
@@ -30,7 +30,9 @@ protected:
   int device_;
 
 public:
-  explicit CudaDlpackArray(const Size_t size, dtypes dtype, const Context &ctx);
+  explicit CudaDlpackArray(const Size_t size, dtypes dtype, const Context &ctx,
+                           const AllocatorMemoryPtr mem = nullptr,
+                           const Size_t offset = 0);
   virtual ~CudaDlpackArray();
   virtual void copy_from(const Array *src_array);
   virtual void zero();

--- a/python/src/nnabla_ext/cuda/experimental/_dali_iterator.py
+++ b/python/src/nnabla_ext/cuda/experimental/_dali_iterator.py
@@ -39,7 +39,10 @@ def feed_ndarray(dali_tensor, arr, ctx, non_blocking=False):
          ", but NNabla Tensor has size {1}".format(dali_tensor.shape(), list(arr.size)))
     dtype = to_numpy_type(dali_tensor.dtype)
     # turn raw int to a c void pointer
-    c_type_pointer = ctypes.c_void_p(arr.data_ptr(dtype, ctx))
+    # NOTE : If data_ptr() is called with write_only=False, Array::zero() is executed.
+    # c void pointer obtained here is used by DALI, but it may be accessed at the same time by different
+    # cuda stream than CudaArray::zero(). To prevent this conflict, write_only must be True.
+    c_type_pointer = ctypes.c_void_p(arr.data_ptr(dtype, ctx, True))
     kw = {}
     if non_blocking:
         kw.update(dict(non_blocking=non_blocking))

--- a/src/nbla/cuda/array/cuda_dlpack_array.cpp
+++ b/src/nbla/cuda/array/cuda_dlpack_array.cpp
@@ -18,8 +18,10 @@
 namespace nbla {
 
 CudaDlpackArray::CudaDlpackArray(const Size_t size, dtypes dtype,
-                                 const Context &ctx)
-    : DlpackArray(size, dtype, ctx) {}
+                                 const Context &ctx,
+                                 const AllocatorMemoryPtr mem,
+                                 const Size_t offset)
+    : DlpackArray(size, dtype, ctx, mem, offset) {}
 
 CudaDlpackArray::~CudaDlpackArray() {}
 


### PR DESCRIPTION
This PR introduce `NdArray.narrow`.
`NdArray.narrow` returns a sub-array that is a narrowed version of a base array.
For more details, see the example below.

```python
x = nn.NdArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])

x1 = x.narrow(dim=0, start=0, length=4)
# x1 == nn.NdArray([0, 1, 2, 3])

x2 = x.narrow(0, 6, 4)
# x2 == nn.NdArray([6, 7, 8, 9])
```

nnabla: https://github.com/sony/nnabla/pull/1096