### PR TITLE
Remove unnecessary flatbuffer build

### DIFF
--- a/docker/release/Dockerfile.cuda
+++ b/docker/release/Dockerfile.cuda
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG CU1_VER
-ARG CU2_VER
-ARG CUDNN_VER
 
 FROM nvidia/cuda:${CU1_VER}.${CU2_VER}-cudnn${CUDNN_VER}-runtime-ubuntu18.04
 

--- a/docker/release/Dockerfile.cuda
+++ b/docker/release/Dockerfile.cuda
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Flatbuffer compiler
 ARG CU1_VER
 ARG CU2_VER
 ARG CUDNN_VER

--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG CU1_VER
-ARG CU2_VER
-ARG CUDNN_VER
 
 FROM ubuntu:18.04 as openmpi
 

--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Flatbuffer compiler
 ARG CU1_VER
 ARG CU2_VER
 ARG CUDNN_VER


### PR DESCRIPTION
flatbuffer is now included in nnabla-converter wheel.
But, flatbuffer related contents are remained in some dockerfiles, so this PR remove these unnecessary directives.
