### PR TITLE
remove duplicate ext-cuda test

### DIFF
--- a/build-tools/make/build.mk
+++ b/build-tools/make/build.mk
@@ -180,9 +180,6 @@ nnabla-ext-cuda-multi-gpu-test-local: nnabla-install nnabla-ext-cuda-install
 			--test-communicator \
 			--communicator-gpus=0,1 \
 			$(NNABLA_DIRECTORY)/python/test/communicator
-	cd $(BUILD_EXT_CUDA_DIRECTORY_WHEEL) \
-	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh ${PYTEST_OPTS} $(NNABLA_DIRECTORY)/python/test \
-	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh ${PYTEST_OPTS} $(NNABLA_EXT_CUDA_DIRECTORY)/python/test
 
 .PHONY: update-gpu-list
 update-gpu-list:


### PR DESCRIPTION
In current nnabla-ext-cuda tests, the test content for nnabla-ext-cuda-test-local is also included in nnabla-ext-cuda-multi-gpu-test-local, which seems to be duplicate and unnecessary as these tests are still executed on one single GPU even if there're multiple GPUs available.