### PR TITLE
Use a singleton function for cudaGetDeviceProperties to avoid slowdown

### DIFF
--- a/include/nbla/cuda/common.hpp
+++ b/include/nbla/cuda/common.hpp
@@ -367,7 +367,9 @@ NBLA_CUDA_API vector<size_t> cuda_mem_get_info();
     Keep in mind that sometime using this function could lead to huge
     slowdowns in your implementation.
  */
-cudaDeviceProp cuda_get_current_device_properties();
+[[deprecated("Use SingletonManager::get<Cuda>()->get_device_properties() "
+             "instead.")]] cudaDeviceProp
+cuda_get_current_device_properties();
 
 int cuda_get_current_device_attribute(cudaDeviceAttr attr);
 }

--- a/include/nbla/cuda/cuda.hpp
+++ b/include/nbla/cuda/cuda.hpp
@@ -168,7 +168,7 @@ protected:
       tid_cuda_stream_t;
   unordered_map<int, unordered_map<int, tid_cuda_stream_t>> streams_;
 
-  shared_ptr<cudaDeviceProp> cuda_device_prop_;
+  vector<shared_ptr<cudaDeviceProp>> cuda_device_props_;
 
 private:
   friend SingletonManager;

--- a/src/nbla/cuda/cuda.cpp
+++ b/src/nbla/cuda/cuda.cpp
@@ -285,14 +285,16 @@ shared_ptr<cudaDeviceProp> Cuda::get_device_properties(int device) {
   if (device < 0) {
     device = cuda_get_device();
   }
-
-  if (cuda_device_prop_ != nullptr) {
-    return cuda_device_prop_;
+  if (device >= cuda_device_props_.size()) {
+    cuda_device_props_.resize(device + 1, nullptr);
   }
-
-  cuda_device_prop_ = make_shared<cudaDeviceProp>();
-  NBLA_CUDA_CHECK(cudaGetDeviceProperties(cuda_device_prop_.get(), device));
-  return cuda_device_prop_;
+  auto &cuda_device_prop = cuda_device_props_.at(device);
+  if (cuda_device_prop != nullptr) {
+    return cuda_device_prop;
+  }
+  cuda_device_prop = make_shared<cudaDeviceProp>();
+  NBLA_CUDA_CHECK(cudaGetDeviceProperties(cuda_device_prop.get(), device));
+  return cuda_device_prop;
 }
 
 NBLA_INSTANTIATE_SINGLETON(NBLA_CUDA_API, Cuda);

--- a/src/nbla/cuda/cudnn/function/generic/fused_batch_normalization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/fused_batch_normalization.cu
@@ -68,9 +68,8 @@ void FusedBatchNormalizationCudaCudnn<T>::setup_impl(const Variables &inputs,
   }
 #endif // _WIN32
   if (can_use_bn_ex) {
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, this->device_);
-    if ((prop.major == 5) && (prop.minor == 3)) {
+    auto prop = SingletonManager::get<Cuda>()->get_device_properties();
+    if ((prop->major == 5) && (prop->minor == 3)) {
       NBLA_LOG_WARN("FusedBatchNormalization is not supported by CuDNN on "
                     "compute archtitecture 5.3 - "
                     "fallback to composite implementation.")

--- a/src/nbla/cuda/function/generic/depthwise_convolution.cu
+++ b/src/nbla/cuda/function/generic/depthwise_convolution.cu
@@ -428,9 +428,8 @@ void DepthwiseConvolutionCuda<T>::setup_impl(const Variables &inputs,
   backprop_input_max_threads_per_block_ = attr2.maxThreadsPerBlock;
   backprop_weights_max_threads_per_block_ = attr3.maxThreadsPerBlock;
 
-  cudaDeviceProp prop;
-  cudaGetDeviceProperties(&prop, std::stoi(this->ctx_.device_id));
-  warp_size_ = prop.warpSize;
+  auto prop = SingletonManager::get<Cuda>()->get_device_properties();
+  warp_size_ = prop->warpSize;
 }
 
 template <typename T>

--- a/src/nbla/cuda/function/generic/depthwise_deconvolution.cu
+++ b/src/nbla/cuda/function/generic/depthwise_deconvolution.cu
@@ -445,9 +445,8 @@ void DepthwiseDeconvolutionCuda<T>::setup_impl(const Variables &inputs,
   backprop_input_max_threads_per_block_ = attr2.maxThreadsPerBlock;
   backprop_weights_max_threads_per_block_ = attr3.maxThreadsPerBlock;
 
-  cudaDeviceProp prop;
-  cudaGetDeviceProperties(&prop, std::stoi(this->ctx_.device_id));
-  warp_size_ = prop.warpSize;
+  auto prop = SingletonManager::get<Cuda>()->get_device_properties();
+  warp_size_ = prop->warpSize;
 }
 
 template <typename T>

--- a/src/nbla/cuda/function/generic/transpose.cu
+++ b/src/nbla/cuda/function/generic/transpose.cu
@@ -133,9 +133,8 @@ void TransposeCuda<T>::setup_impl(const Variables &inputs,
   // Setup for cuTENSOR
   //--------------------------------
   // cuTENSOR is available for CC >= 6.0
-  cudaDeviceProp prop;
-  NBLA_CUDA_CHECK(cudaGetDeviceProperties(&prop, this->device_));
-  cutensor_available_ = prop.major >= 6;
+  auto prop = SingletonManager::get<Cuda>()->get_device_properties();
+  cutensor_available_ = prop->major >= 6;
 
   if (cutensor_available_) {
     const auto ndim_original = inputs[0]->ndim();


### PR DESCRIPTION
`cudaGetDeviceProperties` is known to be slow unexpectedly in some cases. In this PR, I replaced all queries by `cudaGetDeviceProperties` with a function call in the singleton class `Cuda` which retains a cache of device properties. Also, I made `cuda_get_current_device_properties` deprecated.