### PR TITLE
Faster LayerNormCuda::setup_impl (GN and IN as well) by removing unnecessary function creation

### DIFF
--- a/src/nbla/cuda/cudnn/function/generic/instance_normalization.cu
+++ b/src/nbla/cuda/cudnn/function/generic/instance_normalization.cu
@@ -33,7 +33,7 @@ void InstanceNormalizationCudaCudnn<T>::setup_impl(const Variables &inputs,
              "fallen back into InstanceNormalizationCuda since cuDNN "
              "BatchNormalization does not exist in this cuDNN version.")
 #endif
-  InstanceNormalizationCuda<T>::setup_impl(inputs, outputs);
+  InstanceNormalizationCuda<T>::setup_shapes(inputs, outputs);
   cuda_set_device(this->device_);
 
   if (outputs.size() == 3) {

--- a/src/nbla/cuda/function/generic/group_normalization.cu
+++ b/src/nbla/cuda/function/generic/group_normalization.cu
@@ -29,7 +29,7 @@ namespace nbla {
 template <typename T>
 void GroupNormalizationCuda<T>::setup_impl(const Variables &inputs,
                                            const Variables &outputs) {
-  GroupNormalization<T>::setup_impl(inputs, outputs);
+  GroupNormalization<T>::setup_shapes(inputs, outputs);
   cuda_set_device(this->device_);
 
   const auto x = inputs[0];

--- a/src/nbla/cuda/function/generic/instance_normalization.cu
+++ b/src/nbla/cuda/function/generic/instance_normalization.cu
@@ -30,7 +30,7 @@ namespace nbla {
 template <typename T>
 void InstanceNormalizationCuda<T>::setup_impl(const Variables &inputs,
                                               const Variables &outputs) {
-  InstanceNormalization<T>::setup_impl(inputs, outputs);
+  InstanceNormalization<T>::setup_shapes(inputs, outputs);
   cuda_set_device(this->device_);
 
   const auto x = inputs[0];

--- a/src/nbla/cuda/function/generic/layer_normalization.cu
+++ b/src/nbla/cuda/function/generic/layer_normalization.cu
@@ -29,7 +29,7 @@ namespace nbla {
 template <typename T>
 void LayerNormalizationCuda<T>::setup_impl(const Variables &inputs,
                                            const Variables &outputs) {
-  LayerNormalization<T>::setup_impl(inputs, outputs);
+  LayerNormalization<T>::setup_shapes(inputs, outputs);
   cuda_set_device(this->device_);
 
   const auto x = inputs[0];


### PR DESCRIPTION
Counterpart of sony/nnabla#1115.
