### PR TITLE
Add ca-certificates to Dockerfiles

### DIFF
--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -73,6 +73,7 @@ RUN eval ${YUM_OPTS} \
        epel-release \
        yum-utils \
     && yum install -y \
+        ca-certificates \
         curl \
         freetype-devel \
         git \

--- a/docker/development/Dockerfile.build-mpi-ppc64le
+++ b/docker/development/Dockerfile.build-mpi-ppc64le
@@ -73,6 +73,7 @@ RUN eval ${YUM_OPTS} \
        epel-release \
        yum-utils \
     && yum install -y \
+        ca-certificates \
         curl \
         freetype-devel \
         git \

--- a/docker/development/Dockerfile.cuda-cudnn-lib-in-wheel-test
+++ b/docker/development/Dockerfile.cuda-cudnn-lib-in-wheel-test
@@ -66,6 +66,7 @@ RUN eval ${YUM_OPTS} \
        epel-release \
        yum-utils \
     && yum install -y \
+        ca-certificates \
         curl \
         freetype-devel \
         git \

--- a/docker/release/Dockerfile.cuda
+++ b/docker/release/Dockerfile.cuda
@@ -32,17 +32,15 @@ ARG APT_OPTS
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN eval ${APT_OPTS} \
-    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
+    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/ppc64el/3bf863cc.pub \
     && apt-get update \
-    && apt-get install -y --no-install-recommends \
-    software-properties-common \
+    && apt-get install -y software-properties-common \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update
 
-RUN add-apt-repository ppa:deadsnakes/ppa
-
-RUN eval ${APT_OPTS} && apt-get update \
-    && apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
        bzip2 \
        ca-certificates \
        curl \
@@ -51,6 +49,7 @@ RUN eval ${APT_OPTS} && apt-get update \
        python${PYTHON_VER} \
        python3-pip \
        python${PYTHON_VER}-distutils \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VER} 0

--- a/docker/release/Dockerfile.cuda
+++ b/docker/release/Dockerfile.cuda
@@ -32,15 +32,14 @@ ARG APT_OPTS
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN eval ${APT_OPTS} \
-    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/ppc64el/3bf863cc.pub \
+    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
     && apt-get update \
     && apt-get install -y software-properties-common \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
     && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update
-
-RUN apt-get install -y --no-install-recommends \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
        bzip2 \
        ca-certificates \
        curl \

--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -66,17 +66,15 @@ ARG APT_OPTS
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN eval ${APT_OPTS} \
-    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
+    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/ppc64el/3bf863cc.pub \
     && apt-get update \
-    && apt-get install -y --no-install-recommends \
-       software-properties-common \
+    && apt-get install -y software-properties-common \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update
 
-RUN add-apt-repository ppa:deadsnakes/ppa
-
-RUN eval ${APT_OPTS} && apt-get update \
-    && apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
        bzip2 \
        ca-certificates \
        curl \

--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -66,15 +66,14 @@ ARG APT_OPTS
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN eval ${APT_OPTS} \
-    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/ppc64el/3bf863cc.pub \
+    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
     && apt-get update \
     && apt-get install -y software-properties-common \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
     && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update
-
-RUN apt-get install -y --no-install-recommends \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
        bzip2 \
        ca-certificates \
        curl \

--- a/docker/runtime/Dockerfile.runtime
+++ b/docker/runtime/Dockerfile.runtime
@@ -31,14 +31,14 @@ RUN eval ${APT_OPTS} && apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt-get update
-
-RUN apt-get install -y --no-install-recommends \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
        bzip2 \
        ca-certificates \
        wget \
        curl \
        python${PYVERNAME} \
+    && apt-get install -y --no-install-recommends \
        python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/runtime/Dockerfile.runtime
+++ b/docker/runtime/Dockerfile.runtime
@@ -26,28 +26,25 @@ ARG PYTHON_VERSION_MAJOR
 ARG PYTHON_VERSION_MINOR
 ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
-RUN eval ${APT_OPTS} && apt-get update
-RUN apt install -y software-properties-common
-RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update
+RUN eval ${APT_OPTS} && apt-get update \
+    && apt-get install -y software-properties-common \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update
 
 RUN apt-get install -y --no-install-recommends \
-        bzip2 \
-        ca-certificates \
-        wget \
-        curl \
-        python${PYVERNAME} \
+       bzip2 \
+       ca-certificates \
+       wget \
+       curl \
+       python${PYVERNAME} \
+       python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-
 ARG CUDA_VERSION_MAJOR
 ARG CUDA_VERSION_MINOR
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-       python${PYVERNAME}-distutils || echo "skip install python-distutils" \
-    && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "${PYVERNAME}" = "3.6" ]; then curl ${CURL_OPTS} https://bootstrap.pypa.io/pip/${PYVERNAME}/get-pip.py -o get-pip.py; else \
     curl ${CURL_OPTS} https://bootstrap.pypa.io/get-pip.py -o get-pip.py; fi \

--- a/docker/runtime/Dockerfile.runtime-mpi
+++ b/docker/runtime/Dockerfile.runtime-mpi
@@ -71,21 +71,21 @@ ARG PYTHON_VERSION_MINOR
 ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
 RUN eval ${APT_OPTS} \
-    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/ppc64el/3bf863cc.pub \
+    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
     && apt-get update \
     && apt-get install -y software-properties-common \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
     && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update
-
-RUN apt-get install -y --no-install-recommends \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
        bzip2 \
        ca-certificates \
        openssh-client \
        wget \
        curl \
        python${PYVERNAME} \
+    && apt-get install -y --no-install-recommends \
        python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/runtime/Dockerfile.runtime-mpi
+++ b/docker/runtime/Dockerfile.runtime-mpi
@@ -71,28 +71,23 @@ ARG PYTHON_VERSION_MINOR
 ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
 RUN eval ${APT_OPTS} \
-    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub \
+    && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/ppc64el/3bf863cc.pub \
+    && apt-get update \
+    && apt-get install -y software-properties-common \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+    && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update
-RUN apt install -y software-properties-common
-RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update
 
-RUN cd /tmp \
-	&& apt-get update \
-        && apt-get install -y \
-               bzip2 \
-               ca-certificates \
-               openssh-client \
-               wget \
-               curl \
-               python${PYVERNAME} \
-        && rm -rf /var/lib/apt/lists/* \
-        && cd / \
-        && rm -rf /tmp/*
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
+       bzip2 \
+       ca-certificates \
+       openssh-client \
+       wget \
+       curl \
+       python${PYVERNAME} \
        python${PYVERNAME}-distutils || echo "skip install python-distutils" \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "${PYVERNAME}" = "3.6" ]; then curl ${CURL_OPTS} https://bootstrap.pypa.io/pip/${PYVERNAME}/get-pip.py -o get-pip.py; else \

--- a/docker/runtime/Dockerfile.runtime-ppc64le
+++ b/docker/runtime/Dockerfile.runtime-ppc64le
@@ -26,31 +26,29 @@ ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
 RUN eval ${APT_OPTS} \
     && apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/ppc64el/3bf863cc.pub \
-    && apt-get update
-RUN apt install -y software-properties-common
-RUN add-apt-repository ppa:deadsnakes/ppa
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-        cmake \
-        g++ \
-        gfortran \
-        git \
-        libfreetype6-dev \
-        libhdf5-dev \
-        libjpeg-dev \
-        liblapack-dev \
-        libopenmpi-dev \
-        lsb-release \
-        make \
-        pkg-config \
-        wget \
-        curl \
-        python${PYVERNAME} \
+    && apt-get update \
+    && apt-get install -y software-properties-common \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
+       cmake \
+       g++ \
+       gfortran \
+       git \
+       libfreetype6-dev \
+       libhdf5-dev \
+       libjpeg-dev \
+       liblapack-dev \
+       libopenmpi-dev \
+       lsb-release \
+       make \
+       pkg-config \
+       wget \
+       curl \
+       python${PYVERNAME} \
        python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/runtime/Dockerfile.runtime-ppc64le
+++ b/docker/runtime/Dockerfile.runtime-ppc64le
@@ -29,11 +29,10 @@ RUN eval ${APT_OPTS} \
     && apt-get update \
     && apt-get install -y software-properties-common \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
     && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update
-
-RUN apt-get install -y --no-install-recommends \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
        cmake \
        g++ \
        gfortran \
@@ -49,6 +48,7 @@ RUN apt-get install -y --no-install-recommends \
        wget \
        curl \
        python${PYVERNAME} \
+    && apt-get install -y --no-install-recommends \
        python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
to avoid certificate expiration issue in patchelf:

```
 ---> 3c3d8132b0a6
Step 18/29 : RUN mkdir /tmp/deps     && cd /tmp/deps     && wget ${WGET_OPTS} http://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2     && tar xfa patchelf-0.9.tar.bz2     && cd patchelf-0.9     && ./configure     && make     && make install     && cd /     && rm -rf /tmp/*
 ---> Running in d5c47e8f003f
--2022-10-19 01:35:12--  http://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2
Resolving nixos.org (nixos.org)... ****, ...
Connecting to nixos.org (nixos.org)|***|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2 [following]
--2022-10-19 01:35:12--  https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2
Connecting to nixos.org (nixos.org)|***|:443... connected.
ERROR: cannot verify nixos.org's certificate, issued by '/C=US/O=Let\'s Encrypt/CN=R3':
  Issued certificate has expired.
To connect to nixos.org insecurely, use `--no-check-certificate'.
```