### PR TITLE
add watchdog timeout env so that can set timeout

### DIFF
--- a/include/nbla/cuda/communicator/watch_dog.hpp
+++ b/include/nbla/cuda/communicator/watch_dog.hpp
@@ -27,6 +27,7 @@ private:
   int state_;
   int exit_flag_;
   int timeout_ticks_;
+  int env_timeout_;
   std::mutex mutex_;
   std::condition_variable cv_;
   int bootup_flag_;

--- a/src/nbla/cuda/test/test_watch_dog.cpp
+++ b/src/nbla/cuda/test/test_watch_dog.cpp
@@ -82,6 +82,15 @@ TEST(WatchDogTest, TestDisableWithEnv) {
   setenv("NNABLA_MPI_WATCH_DOG_ENABLE", "1", 1);
 }
 
+TEST(WatchDogTest, TestEnvTimeout) {
+  setenv("NNABLA_MPI_WATCH_DOG_TIMEOUT", "3", 0);
+  Watchdog watch_dog(1);
+  {
+    Watchdog::WatchdogLock lck(watch_dog);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+  }
+}
+
 #if 0
 // These 2 cases are skipped.
 // This one is due to too long testing time.


### PR DESCRIPTION
This PR introduces watchdog timeout that can be set with environment variable "NNABLA_MPI_WATCH_DOG_TIMEOUT" in seconds.
