### PR TITLE
complete setup cfg in all condition

### DIFF
--- a/python/setup.cfg.in
+++ b/python/setup.cfg.in
@@ -13,3 +13,4 @@ cuda_target_file=$<TARGET_FILE:${NBLA_CUDA_LIBRARY_NAME}>
 
 cuda_toolkit_root_dir=${CUDA_TOOLKIT_ROOT_DIR}
 cudnn_include_dir=${CUDNN_INCLUDE_DIR}
+cutensor_include_dir=${cutensor_include_path}


### PR DESCRIPTION
In previous https://github.com/sony/nnabla-ext-cuda/pull/438 PR, the generation of setup.cfg does not include all the build condition, which is specified as building both cpp files and python wheel at the same time. This PR tends to fix this negligence.