### PR TITLE
set windows all-in-one path automatically when import

### DIFF
--- a/build-tools/msvc/tools/env.bat
+++ b/build-tools/msvc/tools/env.bat
@@ -31,10 +31,8 @@ POPD
 
 CALL %nnabla_root%\build-tools\msvc\tools\env.bat %1 || GOTO :error
 
-SET NO_CUDA_PATH=
 IF [%TEST_NO_CUDA%] == [True] (
    ECHO Use test environment without cuda/cudnn for wheel with lib.
-   SET NO_CUDA_PATH=%VENV%\Lib\site-packages\nnabla_ext\cuda;
    GOTO :CUDA_CUDNN_SKIP
 )
 set CUDAVER=%2
@@ -94,7 +92,6 @@ IF NOT [%CUDNN_MAJOR%] == [%CUDNNVER%] (
 
 SET PATH=%CUDNN_PATH%\bin;%PATH%
 :CUDA_CUDNN_SKIP
-SET PATH=%NO_CUDA_PATH%%PATH%
 
 REM Ext CUDA folders
 SET nnabla_ext_cuda_root=%~dp0..\..\..

--- a/python/src/nnabla_ext/cuda/__init__.py
+++ b/python/src/nnabla_ext/cuda/__init__.py
@@ -36,6 +36,11 @@ import sys
 # From python3.8, PATH and the current working directory are no longer used to load DLL
 # User must use os.add_dll_directory() to add DLLs directory
 if sys.platform == 'win32':
+    path_env = os.environ.get('PATH').lower()
+    # Under Windows, CUDA libraries in alllib wheel need to be added to PATH
+    if 'cuda' not in path_env or 'cudnn' not in path_env:
+        alllib_cuda_path = os.path.dirname(os.path.realpath(__file__))
+        os.environ['PATH'] += os.pathsep + alllib_cuda_path
     if sys.version_info.minor >= 8:
         path_env = os.environ.get('PATH')
         if path_env is not None:


### PR DESCRIPTION
Currently, all-in-one wheel need to add the wheel installation path to PATH manually, which will cause inconvenience for user.
This PR sets it automatically when nnabla_ext.cuda is imported.

All in One wheels are available here: https://nnabla.org/install/#all-in-one_list
