### PR TITLE
Options to scale gradients and to keep dtype in allreduce callback

### DIFF
--- a/build-tools/make/build.mk
+++ b/build-tools/make/build.mk
@@ -152,7 +152,6 @@ nnabla-ext-cuda-multi-gpu-test-local: nnabla-install nnabla-ext-cuda-install
 	cd $(BUILD_EXT_CUDA_DIRECTORY_WHEEL) \
 	&& PYTHONPATH=$(NNABLA_EXT_CUDA_DIRECTORY)/python/test:$(NNABLA_DIRECTORY)/python/test \
 		mpiexec -q -n 2 $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh \
-			-c NUL \
 			--test-communicator \
 			--communicator-gpus=0,1 \
 			$(NNABLA_DIRECTORY)/python/test/communicator

--- a/include/nbla/cuda/communicator/dl_nccl.h.tmpl
+++ b/include/nbla/cuda/communicator/dl_nccl.h.tmpl
@@ -57,7 +57,8 @@ typedef enum { ncclSum        = 0,
                ncclProd       = 1,
                ncclMax        = 2,
                ncclMin        = 3,
-               ncclNumOps     = 4 } ncclRedOp_t;
+	       ncclAvg        = 4,
+               ncclNumOps     = 5 } ncclRedOp_t;
 
 typedef enum { ncclInt8       = 0, ncclChar       = 0,
                ncclUint8      = 1,

--- a/src/nbla/cuda/communicator/multi_process_data_parallel_communicator.cu
+++ b/src/nbla/cuda/communicator/multi_process_data_parallel_communicator.cu
@@ -357,6 +357,17 @@ MultiProcessDataParallelCommunicatorNccl<
 }
 
 template <typename T> void MultiProcessDataParallelCommunicatorNccl<T>::init() {
+  // NCCL version check.
+  {
+    int nccl_ver;
+    NBLA_NCCL_CHECK(ncclGetVersion(&nccl_ver));
+    NBLA_CHECK(nccl_ver >= 21003, error_code::value,
+               "Incompatible NCCL version (%d.%d.%d). "
+               "MultiProcessDataParallelCommunicatorNccl is compatible with "
+               "NCCL v2.10.3 or later.",
+               nccl_ver / 10000, (nccl_ver % 10000) / 100, nccl_ver % 100);
+  }
+
   Watchdog::WatchdogLock lck(
       watch_dog_); // check if this function is finished within 10s.
   Communicator::init();


### PR DESCRIPTION
Counterpart of sony/nnabla#1150.
Add scale_grad and keep_dtype option to allreduce callback to perform it for narrowed arrays.

Additionally, reduce operations in all-reduce now use ncclAvg as ncclRedOp_t to perform reduction over devices and division by the number of devices at once (I didn't check if there is an improvement in the numerical stability by introducing it). With this change, the NCCL version will only work with 2.10.2 or later.