### PR TITLE
fix segmentation fault issue on docker container

### DIFF
--- a/docker/release/Dockerfile.cuda
+++ b/docker/release/Dockerfile.cuda
@@ -101,7 +101,7 @@ RUN eval ${APT_OPTS} \
        liblzma-dev \
     && pip install ${PIP_INS_OPTS} --no-cache-dir --upgrade pip \
     && pip install ${PIP_INS_OPTS} --no-cache-dir wheel setuptools \
-    && pip install ${PIP_INS_OPTS} --no-cache-dir opencv-python || true \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir opencv-python-headless || true \
     && pip install ${PIP_INS_OPTS} --no-cache-dir --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda${CU1_VER}0 \
         || echo "Skip DALI installation (CUDA=${CU1_VER}.${CU2_VER})" \
     && pip install ${PIP_INS_OPTS} --no-cache-dir nnabla-ext-cuda${CU1_VER}${CU2_VER%.?}==${NNABLA_VER} nnabla_converter==${NNABLA_VER}

--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -142,7 +142,7 @@ RUN eval ${APT_OPTS} \
        liblzma-dev \
     && pip install ${PIP_INS_OPTS} --no-cache-dir --upgrade pip \
     && pip install ${PIP_INS_OPTS} --no-cache-dir wheel setuptools \
-    && pip install ${PIP_INS_OPTS} --no-cache-dir opencv-python || true \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir opencv-python-headless || true \
     && (pip install ${PIP_INS_OPTS} --no-cache-dir --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda${CU1_VER}0 \
        || echo "Skip DALI installation (CUDA=${CU1_VER}.${CU2_VER})") \
     && pip install ${PIP_INS_OPTS} --no-cache-dir nnabla-ext-cuda${CU1_VER}${CU2_VER%.?}==${NNABLA_VER} nnabla_converter==${NNABLA_VER}


### PR DESCRIPTION
This is revisit of https://github.com/sony/nnabla-ext-cuda/pull/443 because this commit was removed unexpedictly.

We have tried to run nnabla-example's slegan with single GPU, but it cannot be work with v1.31.0 container.
But, nnabla v1.26.0 container can work correctly.

This is caused by lacking of libraries, so we decided to use opencv-python-headless instead of opencv-python.
