### PR TITLE
CUDA11.6 Support

### DIFF
--- a/include/nbla/cuda/defs.hpp
+++ b/include/nbla/cuda/defs.hpp
@@ -33,7 +33,9 @@
     defined(nnabla_cuda_110_8_EXPORTS) ||                                      \
     defined(nnabla_cuda_110_8_dbg_EXPORTS) ||                                  \
     defined(nnabla_cuda_114_8_EXPORTS) ||                                      \
-    defined(nnabla_cuda_114_8_dbg_EXPORTS)
+    defined(nnabla_cuda_114_8_dbg_EXPORTS) ||                                  \
+    defined(nnabla_cuda_116_8_EXPORTS) ||                                      \
+    defined(nnabla_cuda_116_8_dbg_EXPORTS)
 #define NBLA_CUDA_API __declspec(dllexport)
 #else
 #define NBLA_CUDA_API __declspec(dllimport)

--- a/src/nbla/cuda/function/generic/sort.cu
+++ b/src/nbla/cuda/function/generic/sort.cu
@@ -160,14 +160,16 @@ void SortCuda<T>::setup_impl(const Variables &inputs,
     // calculation of temporal buffer is performed.
     cub_num_items_ = this->total_size;
     cub_num_segments_ = cub_num_items_ / inputs[0]->shape()[this->axis];
+
+    int ofst = 0;
     if (this->reverse) {
       cub::DeviceSegmentedRadixSort::SortPairsDescending<Tcu, int, int *>(
           nullptr, cub_temp_storage_bytes_, nullptr, nullptr, nullptr, nullptr,
-          cub_num_items_, cub_num_segments_, nullptr, nullptr);
+          cub_num_items_, cub_num_segments_, &ofst, &ofst);
     } else {
       cub::DeviceSegmentedRadixSort::SortPairs<Tcu, int, int *>(
           nullptr, cub_temp_storage_bytes_, nullptr, nullptr, nullptr, nullptr,
-          cub_num_items_, cub_num_segments_, nullptr, nullptr);
+          cub_num_items_, cub_num_segments_, &ofst, &ofst);
     }
 
     // Index buffer needs same size as input since cub sort algorithm handles


### PR DESCRIPTION
This PR extend the range of supported cuda.
Note: cuda11.6 will support users which currently use cuda11.4.

Related to https://github.com/sony/nnabla/pull/1164
