### PR TITLE
Fix SyncBatchnormalizationCuda in channel last mode

### DIFF
--- a/src/nbla/cuda/function/generic/sync_batch_normalization.cu
+++ b/src/nbla/cuda/function/generic/sync_batch_normalization.cu
@@ -108,6 +108,7 @@ void SyncBatchNormalizationCuda<T>::forward_impl_batch(
 
   // Calculate local mean and variance
   if (channel_last) {
+    v_semaphores_for_forward_.data()->zero();
     forward_collect_statistics_channels_last<Tc>(
         size0, size1, size2, x, &v_local_mean_, &v_local_invstd_,
         &v_staging_data_for_forward_, &v_semaphores_for_forward_, this->eps_,
@@ -199,6 +200,7 @@ void SyncBatchNormalizationCuda<T>::backward_impl_batch(
 
   // Reduce channels and calculate grad of beta and gamma to temporally buffers
   if (channel_last) {
+    v_semaphores_for_backward_.data()->zero();
     backward_reduce_channels_last<Tc>(
         size0, size1, size2, x, y, batch_mean, batch_var, &v_sum_dy_o_,
         &v_sum_dy_xmu_o_, &v_beta_grad_, &v_gamma_grad_,


### PR DESCRIPTION
Fixing a bug in outputs of SyncBN in channel last mode. The following code reproduces the bug showing very large running variance.
```python
# mpuirun -n 4 python debug.py

import numpy as np
import nnabla as nn
import nnabla.parametric_functions as PF
import nnabla.communicators as C
from nnabla.ext_utils import get_extension_context

extension_module = "cudnn"
ctx = get_extension_context(extension_module, type_config='float')
nn.set_default_context(ctx)

comm = C.MultiProcessCommunicator(ctx)
comm.init()

# channel_first = True
channel_first = False

shape = (64, 64, 112, 112) if channel_first else (64, 112, 112, 64)
axes = [1] if channel_first else [3]
x = nn.Variable(shape, need_grad=True)

np.random.seed(42)
x.d = np.random.randn(*shape).astype(np.float32)
y = PF.sync_batch_normalization(x, comm=comm, axes=axes)
for i in range(2):
    y.forward()

    bn_var = nn.get_parameters(grad_only=False)['bn/var'].data.data
    print(f"rank: {comm.rank}, itr: {i}, bn/var: amean: {np.mean(np.abs(bn_var))}, amax: {np.max(np.abs(bn_var))}")
```
