### PR TITLE
Fix to run tests for CUDA functions and solvers

### DIFF
--- a/build-tools/make/build.mk
+++ b/build-tools/make/build.mk
@@ -143,9 +143,8 @@ nnabla-ext-cuda-test:
 .PHONY: nnabla-ext-cuda-test-local
 nnabla-ext-cuda-test-local: nnabla-install nnabla-ext-cuda-install
 	cd $(BUILD_EXT_CUDA_DIRECTORY_WHEEL) \
-	&& PYTHONPATH=$(NNABLA_EXT_CUDA_DIRECTORY)/python/test \
-	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh ${PYTEST_OPTS} $(NNABLA_DIRECTORY)/python/test \
-	&& $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh ${PYTEST_OPTS} $(NNABLA_EXT_CUDA_DIRECTORY)/python/test
+	&& PYTHONPATH=$(NNABLA_EXT_CUDA_DIRECTORY)/python/test $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh ${PYTEST_OPTS} $(NNABLA_DIRECTORY)/python/test \
+	&& PYTHONPATH=$(NNABLA_EXT_CUDA_DIRECTORY)/python/test $(NNABLA_DIRECTORY)/build-tools/make/pytest.sh ${PYTEST_OPTS} $(NNABLA_EXT_CUDA_DIRECTORY)/python/test
 
 .PHONY: nnabla-ext-cuda-multi-gpu-test-local
 nnabla-ext-cuda-multi-gpu-test-local: nnabla-install nnabla-ext-cuda-install


### PR DESCRIPTION
It turned out that, due to incorrect way of specification of environment variables, most of CUDA functions and solvers haven't been tested. I fixed it with very minor modification in makefile.