### PR TITLE
Fix FFT/iFFT cufftXtMakePlanMany usage

### DIFF
--- a/include/nbla/cuda/function/fft.hpp
+++ b/include/nbla/cuda/function/fft.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018,2019,2020,2021 Sony Corporation.
+// Copyright 2018,2019,2020,2021,2022,2023 Sony Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/nbla/cuda/function/fft.hpp
+++ b/include/nbla/cuda/function/fft.hpp
@@ -15,8 +15,6 @@
 #ifndef NBLA_CUDA_FUNCTION_FFT_HPP
 #define NBLA_CUDA_FUNCTION_FFT_HPP
 
-#include <cufft.h>
-#include <cufftXt.h>
 #include <nbla/cuda/cuda.hpp>
 #include <nbla/cuda/function/utils/fft.hpp>
 #include <nbla/function/fft.hpp>
@@ -30,10 +28,7 @@ public:
 
   explicit FFTCuda(const Context &ctx, int signal_ndim, bool normalized)
       : FFT<T>(ctx, signal_ndim, normalized), signal_size_(1),
-        device_(std::stoi(ctx.device_id)) {
-    cuda_set_device(this->device_);
-    NBLA_CUFFT_CHECK(cufftCreate(&plan_forward_));
-    NBLA_CUFFT_CHECK(cufftCreate(&plan_backward_));
+        device_(std::stoi(ctx.device_id)), plan_forward_(0), plan_backward_(0) {
   }
   virtual ~FFTCuda();
   virtual string name() { return "FFTCuda"; }

--- a/include/nbla/cuda/function/ifft.hpp
+++ b/include/nbla/cuda/function/ifft.hpp
@@ -1,4 +1,4 @@
-// Copyright 2018,2019,2020,2021 Sony Corporation.
+// Copyright 2018,2019,2020,2021,2022,2023 Sony Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/nbla/cuda/function/ifft.hpp
+++ b/include/nbla/cuda/function/ifft.hpp
@@ -15,8 +15,6 @@
 #ifndef NBLA_CUDA_FUNCTION_IFFT_HPP
 #define NBLA_CUDA_FUNCTION_IFFT_HPP
 
-#include <cufft.h>
-#include <cufftXt.h>
 #include <nbla/cuda/cuda.hpp>
 #include <nbla/cuda/function/utils/fft.hpp>
 #include <nbla/function/ifft.hpp>
@@ -29,9 +27,7 @@ public:
 
   explicit IFFTCuda(const Context &ctx, int signal_ndim, bool normalized)
       : IFFT<T>(ctx, signal_ndim, normalized), signal_size_(1),
-        device_(std::stoi(ctx.device_id)) {
-    NBLA_CUFFT_CHECK(cufftCreate(&plan_forward_));
-    NBLA_CUFFT_CHECK(cufftCreate(&plan_backward_));
+        device_(std::stoi(ctx.device_id)), plan_forward_(0), plan_backward_(0) {
   }
   virtual ~IFFTCuda();
   virtual string name() { return "IFFTCuda"; }

--- a/include/nbla/cuda/function/utils/fft.cuh
+++ b/include/nbla/cuda/function/utils/fft.cuh
@@ -285,6 +285,9 @@ void exec_cufft(const Context ctx, const Tcu *input_ptr, Tcu *output_ptr,
   // execution_type: execution type
   cudaDataType_t execution_type = get_cufft_dtype<Tcu>(true);
 
+  // Create plan
+  NBLA_CUFFT_CHECK(cufftCreate(&plan));
+
   // Make plan
   NBLA_CUFFT_CHECK(
       cufftSetAutoAllocation(plan, false)); // use nnabla's memory allocation
@@ -299,6 +302,9 @@ void exec_cufft(const Context ctx, const Tcu *input_ptr, Tcu *output_ptr,
   // Execute FFT
   NBLA_CUFFT_CHECK(
       cufftXtExec(plan, (void *)input_ptr, (void *)output_ptr, direction));
+
+  // Destroy plan
+  NBLA_CUFFT_CHECK(cufftDestroy(plan));
 }
 }
 #endif

--- a/include/nbla/cuda/function/utils/fft.cuh
+++ b/include/nbla/cuda/function/utils/fft.cuh
@@ -1,4 +1,4 @@
-// Copyright 2018,2019,2020,2021 Sony Corporation.
+// Copyright 2018,2019,2020,2021,2022,2023 Sony Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/nbla/cuda/function/generic/fft.cu
+++ b/src/nbla/cuda/function/generic/fft.cu
@@ -1,4 +1,4 @@
-// Copyright 2018,2019,2020,2021 Sony Corporation.
+// Copyright 2018,2019,2020,2021,2022,2023 Sony Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/nbla/cuda/function/generic/fft.cu
+++ b/src/nbla/cuda/function/generic/fft.cu
@@ -21,10 +21,7 @@
 
 namespace nbla {
 
-template <typename T> FFTCuda<T>::~FFTCuda() {
-  NBLA_CUFFT_CHECK(cufftDestroy(plan_forward_));
-  NBLA_CUFFT_CHECK(cufftDestroy(plan_backward_));
-}
+template <typename T> FFTCuda<T>::~FFTCuda() {}
 
 template <typename T>
 void FFTCuda<T>::setup_impl(const Variables &inputs, const Variables &outputs) {

--- a/src/nbla/cuda/function/generic/ifft.cu
+++ b/src/nbla/cuda/function/generic/ifft.cu
@@ -1,4 +1,4 @@
-// Copyright 2018,2019,2020,2021 Sony Corporation.
+// Copyright 2018,2019,2020,2021,2022,2023 Sony Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/nbla/cuda/function/generic/ifft.cu
+++ b/src/nbla/cuda/function/generic/ifft.cu
@@ -21,10 +21,7 @@
 
 namespace nbla {
 
-template <typename T> IFFTCuda<T>::~IFFTCuda() {
-  NBLA_CUFFT_CHECK(cufftDestroy(plan_forward_));
-  NBLA_CUFFT_CHECK(cufftDestroy(plan_backward_));
-}
+template <typename T> IFFTCuda<T>::~IFFTCuda() {}
 
 template <typename T>
 void IFFTCuda<T>::setup_impl(const Variables &inputs,


### PR DESCRIPTION
This is the PR to solve this issue: https://github.com/sony/nnabla-ext-cuda/issues/413

Start from [CUDA 11.1](https://docs.nvidia.com/cuda/archive/11.1.0/cufft/index.html#function-cufftmakeplanmany), `cufftMakePlanMany(...)` can only be used once for a given handle.
```
This call can only be used once for a given handle. It will fail and return CUFFT_INVALID_PLAN if the plan is locked,
i.e. the handle was previously used with a different cufftPlan or cufftMakePlan call.
```

[CUDA<=11.0](https://docs.nvidia.com/cuda/archive/11.0/cufft/index.html#function-cufftmakeplanmany) doesn't mention the above in its doc.

As in nnabla impl, we call `cufftXtMakePlanMany(...)` instead of `cufftMakePlanMany(...)`, its doc doesn't mention the usage change in CUDA>=11.1, but apparently it should apply the same usage as `cufftMakePlanMany(...)`. This is why we found our FFT/iFFT test case failed on Windows. The same issue may exist in Linux, but we didn't observe it, just say CUDA impl behaves slightly different on various platforms. All platforms should follow its documentation, though this change is for both Windows and Linux.

After this modification, we found new issue..
The FFT/iFFT test on windows+cuda11.6 environment took longer time, we will continue to struggle on this issue.