### PR TITLE
change protobuf3.19.4 to protobuf3.19.6

### DIFF
--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -157,7 +157,7 @@ RUN mkdir /tmp/deps \
     && rm -rf /tmp/*
 
 ############################################################ protobuf
-ARG PROTOVER=3.19.4
+ARG PROTOVER=3.19.6
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
     && curl ${CURL_OPTS} -L https://github.com/google/protobuf/archive/v${PROTOVER}.tar.gz -o protobuf-v${PROTOVER}.tar.gz \

--- a/docker/development/Dockerfile.build-mpi-ppc64le
+++ b/docker/development/Dockerfile.build-mpi-ppc64le
@@ -158,7 +158,7 @@ RUN mkdir /tmp/deps \
     && rm -rf /tmp/*
 
 ############################################################ protobuf
-ARG PROTOVER=3.19.4
+ARG PROTOVER=3.19.6
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
     && curl ${CURL_OPTS} -L https://github.com/google/protobuf/archive/v${PROTOVER}.tar.gz -o protobuf-v${PROTOVER}.tar.gz \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -6,11 +6,6 @@ PyYAML
 
 # Runtime
 Cython
-boto3
-h5py
-six
-tqdm
-
 autopep8
 
 # Test

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -8,8 +8,6 @@ PyYAML
 Cython
 boto3
 h5py
-numpy>=1.20.0
-protobuf<=3.20.1
 six
 tqdm
 


### PR DESCRIPTION
Google Colab environment was updated, and this caused conflicts in the installation of nnabla and nnabla-ext-cuda.
To overcome this, we update protobuf to the latest on the v3.19 line.

This is pair with https://github.com/sony/nnabla/pull/1172