### PR TITLE
Use vs2019 default path

### DIFF
--- a/build-tools/msvc/build_cpplib.bat
+++ b/build-tools/msvc/build_cpplib.bat
@@ -56,7 +56,7 @@ REM We can only use msbuild instead cmake here!
 msbuild ALL_BUILD.vcxproj /p:Configuration=%build_type% /verbosity:minimal /maxcpucount || GOTO :error
 REM cmake --build . --config %build_type% || GOTO :error
 SET OLD_PATH=%PATH%
-SET PATH="%ProgramFiles%\Cmake\bin";%PATH%
+SET PATH="C:\Program Files "("x86")"\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin";%PATH%
 cpack -G ZIP -C %build_type%
 SET PATH=%OLD_PATH%
 GOTO :end


### PR DESCRIPTION
Currently, vs2019 directory had to be a directory that did not contain special characters.
This PR enables to use the default vs2019 path.
