### PR TITLE
fix top_k problem for duplicated integer values

### DIFF
--- a/include/nbla/cuda/utils/top_k.cuh
+++ b/include/nbla/cuda/utils/top_k.cuh
@@ -161,8 +161,8 @@ __host__ void find_top_k_value(const T *data, const int size, MinMax<T> *minmax,
 
   for (int i = 0; i < CUDA_WARP_SIZE; i++) {
     // count values > min + 0.5 * (max - min)
-    bucket_count<UseAbsVal, Largest>
-        <<<blocks, threads>>>(data, size, K, i, minmax, bucket_data);
+    bucket_count<UseAbsVal, Largest><<<blocks, threads>>>(data, size, K, i,
+                                                          minmax, bucket_data);
     NBLA_CUDA_KERNEL_CHECK();
   }
 
@@ -247,8 +247,8 @@ __host__ void find_top_k_index(const T *data, const int size, Bucket<T> *bucket,
   auto threads = NBLA_CUDA_NUM_THREADS;
   auto blocks = NBLA_CUDA_GET_BLOCKS(size);
 
-  init_val_idx_list<T, UseAbsVal, Largest>
-      <<<blocks, threads>>>(data, size, bucket, sort_data, MAX_K, valid_k);
+  init_val_idx_list<T, UseAbsVal, Largest><<<blocks, threads>>>(
+      data, size, bucket, sort_data, MAX_K, valid_k);
   NBLA_CUDA_KERNEL_CHECK();
 
   // The memory layout of ValIdxBitonic is exactly the same as ValIdx.


### PR DESCRIPTION
top_k used a cuda-optimized algorithm, it does not need sort all data for top K values, instead, it use an algorithm to figure out the number of values that large a certain value, the number is expected to reach to K.

The following diagram shows this algorithm roughly:
![topk_algo](https://github.com/sony/nnabla-ext-cuda/assets/67675543/8efea1bc-ea40-4621-b123-d371e2b1dee4)

The original design was,
```
bitonic_sort<<<1, MAX_K>>>(actual_sort_data, K);
```
Only sort K data, not care previous step whether occurs above unconverged case.
In above unconverged case, the data need to be sorted should be more than K.
At that case, the data number need to be sorted might be larger than K, but it can obtain correct result, never occurs the error as bug report mentioned.

So, change this follows:
```
bitonic_sort<<<1, MAX_K>>>(actual_sort_data, valid_k);  
```
We sort the data for the actual data which are larger than pivot, not only for K data.