### PR TITLE
pack zlib dll for windows alllib wheel

### DIFF
--- a/build-tools/msvc/build_cpplib.bat
+++ b/build-tools/msvc/build_cpplib.bat
@@ -25,11 +25,7 @@ IF NOT EXIST %nnabla_build_folder% (
    exit /b 255
 )
 
-SET third_party_folder=%nnabla_root%\third_party
 REM Build third party libraries.
-PUSHD .
-CALL %nnabla_root%\build-tools\msvc\tools\build_zlib.bat       || GOTO :error
-POPD
 CALL %~dp0tools\get_cutensor.bat %1 || GOTO :error
 
 REM Build CUDA extension library

--- a/build-tools/msvc/build_wheel.bat
+++ b/build-tools/msvc/build_wheel.bat
@@ -22,7 +22,6 @@ SETLOCAL
 REM Environment
 CALL %~dp0tools\env.bat %1 %2 %3 || GOTO :error
 
-SET third_party_folder=%nnabla_root%\third_party
 CALL %~dp0tools\get_cutensor.bat %2 || GOTO :error
 
 IF NOT EXIST %nnabla_build_folder% (

--- a/build-tools/msvc/tools/env.bat
+++ b/build-tools/msvc/tools/env.bat
@@ -40,6 +40,12 @@ set CUDNNVER=%3
 FOR /F "TOKENS=1 DELIMS=." %%A IN ("%CUDAVER%") DO SET CUDA_MAJOR=%%A
 FOR /F "TOKENS=2 DELIMS=." %%A IN ("%CUDAVER%") DO SET CUDA_MINOR=%%A
 
+REM Installing Zlib needed by cuDNN
+SET third_party_folder=%nnabla_root%\third_party
+PUSHD .
+CALL %nnabla_root%\build-tools\msvc\tools\build_zlib.bat || GOTO :error
+POPD
+
 REM CHECK CUDA installation
 
 SET NVIDIA_TOOLKIT_PATH=%ProgramFiles%\NVIDIA GPU Computing Toolkit

--- a/python/setup.py
+++ b/python/setup.py
@@ -286,6 +286,13 @@ def cuda_config(root_dir, cuda_lib, ext_opts, lib_dirs):
                             sys.exit(-1)
                 return libs
 
+            if 'zlib_dll' in os.environ:
+                zlib_lib_path = os.environ['zlib_dll']
+                print('Copying zlibwapi.dll')
+                shutil.copyfile(zlib_lib_path, join(
+                    path_cuda_pkg, 'zlibwapi.dll'))
+                package_data[cuda_pkg].append('zlibwapi.dll')
+
             for d in search_dependencies(cuda_lib_out):
                 print('LIB: {}'.format(d))
                 package_data[cuda_pkg].append(d)

--- a/third_party/LICENSES.md
+++ b/third_party/LICENSES.md
@@ -914,3 +914,30 @@ This supplement is an exhibit to the Agreement and is incorporated as an integra
 
 3. Licensing. If the distribution terms in this Agreement are not suitable for your organization, or for any questions regarding this Agreement, please contact NVIDIA at nvidia-compute-license-questions@nvidia.com
 ```
+
+## [zlib](https://www.zlib.net/zlib.html)
+
+`Neural Network Libraries CUDA extension` will use [zlib](https://www.zlib.net/zlib.html) for CUDA 11.6 or newer versions on Windows. nnabla_ext_cuda_alllib wheel for Windows will contain a copy of `zlibwapi.dll` as a part of the packed CUDA runtime environment.
+
+```
+Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+Jean-loup Gailly        Mark Adler
+jloup@gzip.org          madler@alumni.caltech.edu
+```


### PR DESCRIPTION
In Windows environment, zlib is now required for cuda11.6 and cudnn.
There is no problem if zlibwapi.dll is preinstalled, but alllib has to pack all libraries that nnabla needs because it's essential for cuda/cudnn runtime.