### PR TITLE
Cover hpcx environment for CI

### DIFF
--- a/build-tools/make/build-with-docker.mk
+++ b/build-tools/make/build-with-docker.mk
@@ -165,14 +165,17 @@ docker_image_nnabla_ext_cuda:
 ########################################################################################################################
 # Docker image installed with wheel included cuda/cudnn libraries
 
+DOCKERFILE_PATH_LIB_IN_WHEEL=$(NNABLA_EXT_CUDA_DIRECTORY)/docker/development/Dockerfile.cuda-cudnn-lib-in-wheel-test
+DOCKER_IMAGE_ID_NNABLA_EXT_CUDA_LIB_IN_WHEEL = $(shell md5sum $(DOCKERFILE_PATH_LIB_IN_WHEEL) | cut -d \  -f 1)
+
 .PHONY: docker_image_cuda_cudnn_lib_in_wheel
 docker_image_cuda_cudnn_lib_in_wheel:
 	cd $(NNABLA_EXT_CUDA_DIRECTORY) \
 	&& docker build $(DOCKER_BUILD_ARGS) \
 		--build-arg CUDA_VERSION_MAJOR=$(CUDA_VERSION_MAJOR) \
 		--build-arg PYTHON_VER=3.$(PYTHON_VERSION_MINOR) \
-		--build-arg MPI=$(OMPI_VERSION) \
-		-f docker/development/Dockerfile.cuda-cudnn-lib-in-wheel-test . -t nnabla-ext-cuda-whl:py3$(PYTHON_VERSION_MINOR)-cuda$(CUDA_VERSION_MAJOR)$(CUDA_VERSION_MINOR)-$(CUDNN_VERSION)-mpi$(OMPI_VERSION)
+		--build-arg MPIVER=$(OMPI_VERSION) \
+		-f $(DOCKERFILE_PATH_LIB_IN_WHEEL) . -t nnabla-ext-cuda-lib-in-whl-py3$(PYTHON_VERSION_MINOR)-cuda$(CUDA_SUFFIX)-mpi$(OMPI_VERSION):$(DOCKER_IMAGE_ID_NNABLA_EXT_CUDA_LIB_IN_WHEEL)
 
 ########################################################################################################################
 # Test with wheel included cuda/cudnn libraries
@@ -180,10 +183,10 @@ docker_image_cuda_cudnn_lib_in_wheel:
 bwd-nnabla-ext-cuda-cudnn-lib-in-wheel-test: docker_image_cuda_cudnn_lib_in_wheel
 	cd $(NNABLA_EXT_CUDA_DIRECTORY) \
 	&& docker run --gpus=all $(DOCKER_RUN_OPTS) \
-		nnabla-ext-cuda-whl:py3$(PYTHON_VERSION_MINOR)-cuda$(CUDA_VERSION_MAJOR)$(CUDA_VERSION_MINOR)-$(CUDNN_VERSION)-mpi$(OMPI_VERSION) make -f  build-tools/make/build.mk nnabla-ext-cuda-test-local
+		nnabla-ext-cuda-lib-in-whl-py3$(PYTHON_VERSION_MINOR)-cuda$(CUDA_SUFFIX)-mpi$(OMPI_VERSION):$(DOCKER_IMAGE_ID_NNABLA_EXT_CUDA_LIB_IN_WHEEL) make -f  build-tools/make/build.mk nnabla-ext-cuda-test-local
 
 .PHONY: bwd-nnabla-ext-cuda-cudnn-lib-in-wheel-multi-gpu-test
 bwd-nnabla-ext-cuda-cudnn-lib-in-wheel-multi-gpu-test: docker_image_cuda_cudnn_lib_in_wheel
 	cd $(NNABLA_EXT_CUDA_DIRECTORY) \
 	&& docker run --gpus=all $(DOCKER_RUN_OPTS) \
-		nnabla-ext-cuda-whl:py3$(PYTHON_VERSION_MINOR)-cuda$(CUDA_VERSION_MAJOR)$(CUDA_VERSION_MINOR)-$(CUDNN_VERSION)-mpi$(OMPI_VERSION) make -f  build-tools/make/build.mk nnabla-ext-cuda-multi-gpu-test-local
+		nnabla-ext-cuda-lib-in-whl-py3$(PYTHON_VERSION_MINOR)-cuda$(CUDA_SUFFIX)-mpi$(OMPI_VERSION):$(DOCKER_IMAGE_ID_NNABLA_EXT_CUDA_LIB_IN_WHEEL) make -f  build-tools/make/build.mk nnabla-ext-cuda-multi-gpu-test-local

--- a/build-tools/make/build-with-docker.mk
+++ b/build-tools/make/build-with-docker.mk
@@ -29,6 +29,7 @@ DOCKER_RUN_OPTS += -e CMAKE_OPTS=$(CMAKE_OPTS)
 DOCKER_RUN_OPTS += -e INCLUDE_CUDA_CUDNN_LIB_IN_WHL=$(INCLUDE_CUDA_CUDNN_LIB_IN_WHL)
 
 include $(NNABLA_EXT_CUDA_DIRECTORY)/build-tools/make/options.mk
+include $(NNABLA_EXT_CUDA_DIRECTORY)/build-tools/make/hpcx_url.mk
 ifndef NNABLA_BUILD_INCLUDED
   include $(NNABLA_DIRECTORY)/build-tools/make/build.mk
 endif
@@ -58,9 +59,9 @@ docker_image_build_cuda:
 		--build-arg CUDA_VERSION_MAJOR=$(CUDA_VERSION_MAJOR) \
 		--build-arg CUDA_VERSION_MINOR=$(CUDA_VERSION_MINOR) \
 		--build-arg CUDNN_VERSION=$(CUDNN_VERSION) \
-		--build-arg ARCH_SUFFIX=$(ARCH_SUFFIX) \
 		--build-arg PYTHON_VERSION_MAJOR=$(PYTHON_VERSION_MAJOR) \
 		--build-arg PYTHON_VERSION_MINOR=$(PYTHON_VERSION_MINOR) \
+		--build-arg HPCX_URL_centos=$(HPCX_URL_centos_$(OMPI_VERSION)) \
 		-t $(DOCKER_IMAGE_BUILD_NNABLA_EXT_CUDA) \
 		-f docker/development/Dockerfile.build-mpi$(ARCH_SUFFIX) \
 		.
@@ -72,11 +73,11 @@ docker_image_build_cuda_test:
 		--build-arg CUDA_VERSION_MAJOR=$(CUDA_VERSION_MAJOR) \
 		--build-arg CUDA_VERSION_MINOR=$(CUDA_VERSION_MINOR) \
 		--build-arg CUDNN_VERSION=$(CUDNN_VERSION) \
-		--build-arg ARCH_SUFFIX=$(ARCH_SUFFIX) \
 		--build-arg MPIVER=$(OMPI_VERSION) \
 		--build-arg PYTHON_VERSION_MAJOR=$(PYTHON_VERSION_MAJOR) \
 		--build-arg PYTHON_VERSION_MINOR=$(PYTHON_VERSION_MINOR) \
 		--build-arg BUILD_WITH_CUTENSOR=False \
+		--build-arg HPCX_URL_centos=$(HPCX_URL_centos_$(OMPI_VERSION)) \
 		-t $(DOCKER_IMAGE_TEST_NNABLA_EXT_CUDA) \
 		-f docker/development/Dockerfile.build-mpi$(ARCH_SUFFIX) \
 		.
@@ -175,6 +176,7 @@ docker_image_cuda_cudnn_lib_in_wheel:
 		--build-arg CUDA_VERSION_MAJOR=$(CUDA_VERSION_MAJOR) \
 		--build-arg PYTHON_VER=3.$(PYTHON_VERSION_MINOR) \
 		--build-arg MPIVER=$(OMPI_VERSION) \
+		--build-arg HPCX_URL_centos=$(HPCX_URL_centos_$(OMPI_VERSION)) \
 		-f $(DOCKERFILE_PATH_LIB_IN_WHEEL) . -t nnabla-ext-cuda-lib-in-whl-py3$(PYTHON_VERSION_MINOR)-cuda$(CUDA_SUFFIX)-mpi$(OMPI_VERSION):$(DOCKER_IMAGE_ID_NNABLA_EXT_CUDA_LIB_IN_WHEEL)
 
 ########################################################################################################################

--- a/build-tools/make/hpcx_url.mk
+++ b/build-tools/make/hpcx_url.mk
@@ -1,0 +1,22 @@
+# Copyright 2023 Sony Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+########################################################################################################################
+# Suppress most of make message.
+.SILENT:
+
+# Map specific openmpi version to HPCX download url
+
+export HPCX_URL_ubuntu_4.1.5='http://www.mellanox.com/downloads/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl2.12-x86_64.tbz'
+export HPCX_URL_centos_4.1.5='https://content.mellanox.com/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat7-cuda11-gdrcopy2-nccl2.12-x86_64.tbz'

--- a/docker/development/.entrypoint-hpcx.sh
+++ b/docker/development/.entrypoint-hpcx.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2023 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -d "/opt/mpi/hpcx-v2.12" ]; then
+    curdir=$PWD
+    cd /opt/mpi/hpcx-v2.12
+    . ./hpcx-init.sh
+    hpcx_load
+    cd $curdir
+    unset curdir
+fi
+
+if [ $# -eq 0 ]; then
+    exec "/bin/bash"
+else
+    exec "$@"
+fi

--- a/docker/development/.entrypoint-hpcx.sh
+++ b/docker/development/.entrypoint-hpcx.sh
@@ -14,12 +14,8 @@
 # limitations under the License.
 
 if [ -d "/opt/mpi/hpcx" ]; then
-    curdir=$PWD
-    cd /opt/mpi/hpcx
-    . ./hpcx-init.sh
+    . /opt/mpi/hpcx/hpcx-init.sh
     hpcx_load
-    cd $curdir
-    unset curdir
 fi
 
 if [ $# -eq 0 ]; then

--- a/docker/development/.entrypoint-hpcx.sh
+++ b/docker/development/.entrypoint-hpcx.sh
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -d "/opt/mpi/hpcx-v2.12" ]; then
+if [ -d "/opt/mpi/hpcx" ]; then
     curdir=$PWD
-    cd /opt/mpi/hpcx-v2.12
+    cd /opt/mpi/hpcx
     . ./hpcx-init.sh
     hpcx_load
     cd $curdir

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -33,6 +33,7 @@ ARG CURL_OPTS
 ARG WGET_OPTS
 ARG YUM_OPTS
 ARG MPIVER=3.1.6
+ARG HPCX_URL_centos
 
 ENV LC_ALL C
 ENV LANG C
@@ -63,7 +64,7 @@ COPY docker/release/hpcx-ompi-etc.patch /tmp/hpcx-ompi-etc.patch
 RUN if [ $(echo "${MPIVER}" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }') -gt 30106 ]; then \
         mkdir /root/openmpi-hpcx \
         && cd /root/openmpi-hpcx \
-        && curl ${CURL_OPTS} -LO https://content.mellanox.com/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat7-cuda11-gdrcopy2-nccl2.12-x86_64.tbz \
+        && curl ${CURL_OPTS} -LO ${HPCX_URL_centos} \
         && tar -xvf hpcx*.tbz \
         && rm -f hpcx*.tbz \
         && mv hpcx* hpcx \

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -66,8 +66,8 @@ RUN if [ $(echo "${MPIVER}" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }') -
         && curl ${CURL_OPTS} -LO https://content.mellanox.com/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat7-cuda11-gdrcopy2-nccl2.12-x86_64.tbz \
         && tar -xvf hpcx*.tbz \
         && rm -f hpcx*.tbz \
-        && mv hpcx* hpcx-v2.12 \
-        && cd hpcx-v2.12 \
+        && mv hpcx* hpcx \
+        && cd hpcx \
         && ./utils/hpcx_rebuild.sh --ompi-extra-config --enable-openib-rdmacm-ibaddr \
         && cp -ap ./hpcx-rebuild/lib/libmca_common_verbs.* ./ompi/lib/ \
         && cp -ap ./hpcx-rebuild/lib/openmpi/mca_btl_openib.* ./ompi/lib/openmpi/ \
@@ -246,7 +246,7 @@ RUN mkdir /tmp/deps \
 ############################################################ Copy OpenMPI
 COPY --from=openmpi /root/openmpi-* /root
 RUN if [ -e /root/openmpi-*.rpm ]; then rpm -i /root/openmpi-*.rpm; fi
-RUN if [ -d /root/hpcx-v2.12 ]; then mkdir /opt/mpi; mv /root/hpcx-v2.12 /opt/mpi/hpcx-v2.12; fi
+RUN if [ -d /root/hpcx ]; then mkdir /opt/mpi; mv /root/hpcx /opt/mpi/hpcx; fi
 
 ARG PYTHON_VERSION_MAJOR=3
 ARG PYTHON_VERSION_MINOR=8

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -246,7 +246,7 @@ RUN mkdir /tmp/deps \
 ############################################################ Copy OpenMPI
 COPY --from=openmpi /root/openmpi-* /root
 RUN if [ -e /root/openmpi-*.rpm ]; then rpm -i /root/openmpi-*.rpm; fi
-RUN if [ -d /root/openmpi-hpcx ]; then mv /root/openmpi-hpcx /opt/mpi; fi
+RUN if [ -d /root/hpcx-v2.12 ]; then mkdir /opt/mpi; mv /root/hpcx-v2.12 /opt/mpi/hpcx-v2.12; fi
 
 ARG PYTHON_VERSION_MAJOR=3
 ARG PYTHON_VERSION_MINOR=8

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -32,6 +32,7 @@ ARG PYTHONWARNINGS
 ARG CURL_OPTS
 ARG WGET_OPTS
 ARG YUM_OPTS
+ARG MPIVER=3.1.6
 
 ENV LC_ALL C
 ENV LANG C
@@ -44,14 +45,46 @@ RUN eval ${YUM_OPTS} \
     && yum install -y \
         curl \
         rpm-build \
+    && if [ $(echo "${MPIVER}" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }') -gt 30106 ]; then \
+        yum install -y libibverbs \
+        librdmacm \
+        rdma-core-devel \
+        numactl-libs \
+        numactl-devel \
+        binutils-devel \
+        patch; \
+    fi \
     && yum group install -y "Development Tools" \
     && yum clean all
 
-ARG MPIVER=3.1.6
-RUN mkdir /root/rpmbuild
-RUN cd /root/rpmbuild; curl ${CURL_OPTS} https://download.open-mpi.org/release/open-mpi/v${MPIVER%.*}/openmpi-${MPIVER}-1.src.rpm -o openmpi-${MPIVER}-1.src.rpm
-RUN cd /root/rpmbuild; rpmbuild --rebuild openmpi-${MPIVER}-1.src.rpm
-RUN mv /root/rpmbuild/RPMS/x86_64/openmpi-${MPIVER}-1.*.rpm /root
+COPY docker/release/hpcx-init.patch /tmp/hpcx-init.patch
+COPY docker/release/hpcx-ompi-etc.patch /tmp/hpcx-ompi-etc.patch
+
+RUN if [ $(echo "${MPIVER}" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }') -gt 30106 ]; then \
+        mkdir /root/openmpi-hpcx \
+        && cd /root/openmpi-hpcx \
+        && curl ${CURL_OPTS} -LO https://content.mellanox.com/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat7-cuda11-gdrcopy2-nccl2.12-x86_64.tbz \
+        && tar -xvf hpcx*.tbz \
+        && rm -f hpcx*.tbz \
+        && mv hpcx* hpcx-v2.12 \
+        && cd hpcx-v2.12 \
+        && ./utils/hpcx_rebuild.sh --ompi-extra-config --enable-openib-rdmacm-ibaddr \
+        && cp -ap ./hpcx-rebuild/lib/libmca_common_verbs.* ./ompi/lib/ \
+        && cp -ap ./hpcx-rebuild/lib/openmpi/mca_btl_openib.* ./ompi/lib/openmpi/ \
+        && cp -ap ./hpcx-rebuild/share/openmpi/*verbs* ./ompi/share/openmpi/ \
+        && cp -ap ./hpcx-rebuild/share/openmpi/*openib* ./ompi/share/openmpi/ \
+        && rm -rf ./sources/openmpi-gitclone ./hpcx_rebuild ./hpcx_rebuild.sh \
+        && patch -p1 < /tmp/hpcx-init.patch \
+        && patch -p1 < /tmp/hpcx-ompi-etc.patch \
+        && chmod og+w ./ompi/etc/* \
+        && cd ..; \
+    else \
+        mkdir /root/rpmbuild \
+        && cd /root/rpmbuild \
+        && curl ${CURL_OPTS} https://download.open-mpi.org/release/open-mpi/v${MPIVER%.*}/openmpi-${MPIVER}-1.src.rpm -o openmpi-${MPIVER}-1.src.rpm \
+        && rpmbuild --rebuild openmpi-${MPIVER}-1.src.rpm \
+        && mv /root/rpmbuild/RPMS/x86_64/openmpi-${MPIVER}-1.*.rpm /root; \
+    fi
 
 FROM nvidia/cuda:${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR}-cudnn${CUDNN_VERSION}-devel-centos7
 
@@ -107,6 +140,7 @@ RUN eval ${YUM_OPTS} \
         sqlite \
         sqlite-devel \
         tk-devel \
+        numactl-libs \
     && if [ "${BUILD_WITH_CUTENSOR}" == "True" ]; then yum install -y libcutensor-devel; fi \
     && yum group install -y "Development Tools" \
     && yum clean all
@@ -210,8 +244,9 @@ RUN mkdir /tmp/deps \
     && rm -rf /tmp/*
 
 ############################################################ Copy OpenMPI
-COPY --from=openmpi /root/openmpi-*.rpm /root
-RUN rpm -i /root/openmpi-*.rpm
+COPY --from=openmpi /root/openmpi-* /root
+RUN if [ -e /root/openmpi-*.rpm ]; then rpm -i /root/openmpi-*.rpm; fi
+RUN if [ -d /root/openmpi-hpcx ]; then mv /root/openmpi-hpcx /opt/mpi; fi
 
 ARG PYTHON_VERSION_MAJOR=3
 ARG PYTHON_VERSION_MINOR=8
@@ -250,3 +285,9 @@ ENV CXX /usr/local/bin/g++
 ####################################################
 RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
 RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
+
+# Entrypoint
+COPY docker/development/.entrypoint-hpcx.sh /opt/.entrypoint.sh
+RUN chmod +x /opt/.entrypoint.sh
+
+ENTRYPOINT ["/bin/bash", "-c", "/opt/.entrypoint.sh \"${@}\"", "--"]

--- a/docker/development/Dockerfile.cuda-cudnn-lib-in-wheel-test
+++ b/docker/development/Dockerfile.cuda-cudnn-lib-in-wheel-test
@@ -27,6 +27,7 @@ ARG CURL_OPTS
 ARG WGET_OPTS
 ARG YUM_OPTS
 ARG MPIVER=3.1.6
+ARG HPCX_URL_centos
 
 ENV LC_ALL C
 ENV LANG C
@@ -57,7 +58,7 @@ COPY docker/release/hpcx-ompi-etc.patch /tmp/hpcx-ompi-etc.patch
 RUN if [ $(echo "${MPIVER}" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }') -gt 30106 ]; then \
         mkdir /root/openmpi-hpcx \
         && cd /root/openmpi-hpcx \
-        && curl ${CURL_OPTS} -LO https://content.mellanox.com/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat7-cuda11-gdrcopy2-nccl2.12-x86_64.tbz \
+        && curl ${CURL_OPTS} -LO ${HPCX_URL_centos} \
         && tar -xvf hpcx*.tbz \
         && rm -f hpcx*.tbz \
         && mv hpcx* hpcx \

--- a/docker/development/Dockerfile.cuda-cudnn-lib-in-wheel-test
+++ b/docker/development/Dockerfile.cuda-cudnn-lib-in-wheel-test
@@ -60,8 +60,8 @@ RUN if [ $(echo "${MPIVER}" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }') -
         && curl ${CURL_OPTS} -LO https://content.mellanox.com/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat7-cuda11-gdrcopy2-nccl2.12-x86_64.tbz \
         && tar -xvf hpcx*.tbz \
         && rm -f hpcx*.tbz \
-        && mv hpcx* hpcx-v2.12 \
-        && cd hpcx-v2.12 \
+        && mv hpcx* hpcx \
+        && cd hpcx \
         && ./utils/hpcx_rebuild.sh --ompi-extra-config --enable-openib-rdmacm-ibaddr \
         && cp -ap ./hpcx-rebuild/lib/libmca_common_verbs.* ./ompi/lib/ \
         && cp -ap ./hpcx-rebuild/lib/openmpi/mca_btl_openib.* ./ompi/lib/openmpi/ \
@@ -171,7 +171,7 @@ RUN mkdir /tmp/deps \
 ############################################################ Copy OpenMPI
 COPY --from=openmpi /root/openmpi-* /root
 RUN if [ -e /root/openmpi-*.rpm ]; then rpm -i /root/openmpi-*.rpm; fi
-RUN if [ -d /root/hpcx-v2.12 ]; then mkdir /opt/mpi; mv /root/hpcx-v2.12 /opt/mpi/hpcx-v2.12; fi
+RUN if [ -d /root/hpcx ]; then mkdir /opt/mpi; mv /root/hpcx /opt/mpi/hpcx; fi
 
 ############################################################ build python from source
 ARG PYTHON_VER

--- a/docker/development/Dockerfile.cuda-cudnn-lib-in-wheel-test
+++ b/docker/development/Dockerfile.cuda-cudnn-lib-in-wheel-test
@@ -171,7 +171,7 @@ RUN mkdir /tmp/deps \
 ############################################################ Copy OpenMPI
 COPY --from=openmpi /root/openmpi-* /root
 RUN if [ -e /root/openmpi-*.rpm ]; then rpm -i /root/openmpi-*.rpm; fi
-RUN if [ -d /root/openmpi-hpcx ]; then mv /root/openmpi-hpcx /opt/mpi; fi
+RUN if [ -d /root/hpcx-v2.12 ]; then mkdir /opt/mpi; mv /root/hpcx-v2.12 /opt/mpi/hpcx-v2.12; fi
 
 ############################################################ build python from source
 ARG PYTHON_VER

--- a/docker/development/Dockerfile.cuda-cudnn-lib-in-wheel-test
+++ b/docker/development/Dockerfile.cuda-cudnn-lib-in-wheel-test
@@ -39,13 +39,46 @@ RUN eval ${YUM_OPTS} \
     && yum install -y \
         curl \
         rpm-build \
+    && if [ $(echo "${MPIVER}" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }') -gt 30106 ]; then \
+        yum install -y libibverbs \
+        librdmacm \
+        rdma-core-devel \
+        numactl-libs \
+        numactl-devel \
+        binutils-devel \
+        patch; \
+    fi \
     && yum group install -y "Development Tools" \
     && yum clean all
 
-RUN mkdir /root/rpmbuild
-RUN cd /root/rpmbuild; curl ${CURL_OPTS} https://download.open-mpi.org/release/open-mpi/v${MPIVER%.*}/openmpi-${MPIVER}-1.src.rpm -o openmpi-${MPIVER}-1.src.rpm
-RUN cd /root/rpmbuild; rpmbuild --rebuild openmpi-${MPIVER}-1.src.rpm
-RUN mv /root/rpmbuild/RPMS/x86_64/openmpi-${MPIVER}-1.*.rpm /root
+COPY docker/release/hpcx-init.patch /tmp/hpcx-init.patch
+COPY docker/release/hpcx-ompi-etc.patch /tmp/hpcx-ompi-etc.patch
+
+RUN if [ $(echo "${MPIVER}" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }') -gt 30106 ]; then \
+        mkdir /root/openmpi-hpcx \
+        && cd /root/openmpi-hpcx \
+        && curl ${CURL_OPTS} -LO https://content.mellanox.com/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat7-cuda11-gdrcopy2-nccl2.12-x86_64.tbz \
+        && tar -xvf hpcx*.tbz \
+        && rm -f hpcx*.tbz \
+        && mv hpcx* hpcx-v2.12 \
+        && cd hpcx-v2.12 \
+        && ./utils/hpcx_rebuild.sh --ompi-extra-config --enable-openib-rdmacm-ibaddr \
+        && cp -ap ./hpcx-rebuild/lib/libmca_common_verbs.* ./ompi/lib/ \
+        && cp -ap ./hpcx-rebuild/lib/openmpi/mca_btl_openib.* ./ompi/lib/openmpi/ \
+        && cp -ap ./hpcx-rebuild/share/openmpi/*verbs* ./ompi/share/openmpi/ \
+        && cp -ap ./hpcx-rebuild/share/openmpi/*openib* ./ompi/share/openmpi/ \
+        && rm -rf ./sources/openmpi-gitclone ./hpcx_rebuild ./hpcx_rebuild.sh \
+        && patch -p1 < /tmp/hpcx-init.patch \
+        && patch -p1 < /tmp/hpcx-ompi-etc.patch \
+        && chmod og+w ./ompi/etc/* \
+        && cd ..; \
+    else \
+        mkdir /root/rpmbuild \
+        && cd /root/rpmbuild \
+        && curl ${CURL_OPTS} https://download.open-mpi.org/release/open-mpi/v${MPIVER%.*}/openmpi-${MPIVER}-1.src.rpm -o openmpi-${MPIVER}-1.src.rpm \
+        && rpmbuild --rebuild openmpi-${MPIVER}-1.src.rpm \
+        && mv /root/rpmbuild/RPMS/x86_64/openmpi-${MPIVER}-1.*.rpm /root; \
+    fi
 
 FROM centos:7
 
@@ -100,6 +133,7 @@ RUN eval ${YUM_OPTS} \
         sqlite \
         sqlite-devel \
         tk-devel \
+        numactl-libs \
     && yum group install -y "Development Tools" \
     && yum clean all
 
@@ -135,8 +169,9 @@ RUN mkdir /tmp/deps \
     && rm -rf /tmp/*
 
 ############################################################ Copy OpenMPI
-COPY --from=openmpi /root/openmpi-*.rpm /root
-RUN rpm -i /root/openmpi-*.rpm
+COPY --from=openmpi /root/openmpi-* /root
+RUN if [ -e /root/openmpi-*.rpm ]; then rpm -i /root/openmpi-*.rpm; fi
+RUN if [ -d /root/openmpi-hpcx ]; then mv /root/openmpi-hpcx /opt/mpi; fi
 
 ############################################################ build python from source
 ARG PYTHON_VER
@@ -173,5 +208,9 @@ ENV CXX /usr/local/bin/g++
 RUN echo NCCL_SHM_DISABLE=1 >> /etc/nccl.conf
 RUN echo NCCL_P2P_LEVEL=SYS >> /etc/nccl.conf
 
-WORKDIR /home
-CMD [ "/bin/bash" ]
+
+# Entrypoint
+COPY docker/development/.entrypoint-hpcx.sh /opt/.entrypoint.sh
+RUN chmod +x /opt/.entrypoint.sh
+
+ENTRYPOINT ["/bin/bash", "-c", "/opt/.entrypoint.sh \"${@}\"", "--"]

--- a/docker/release/.entrypoint-cuda-mpi.sh
+++ b/docker/release/.entrypoint-cuda-mpi.sh
@@ -17,12 +17,8 @@
 source /etc/shinit_v2
 
 if [ -d "/opt/mpi/hpcx" ]; then
-    curdir=$PWD
-    cd /opt/mpi/hpcx
-    . ./hpcx-init.sh
+    . /opt/mpi/hpcx/hpcx-init.sh
     hpcx_load
-    cd $curdir
-    unset curdir
 else
     export PATH=/opt/mpi/bin:$PATH
     export LD_LIBRARY_PATH=/opt/mpi/lib:$LD_LIBRARY_PATH

--- a/docker/release/.entrypoint-cuda-mpi.sh
+++ b/docker/release/.entrypoint-cuda-mpi.sh
@@ -16,9 +16,9 @@
 
 source /etc/shinit_v2
 
-if [ -d "/opt/mpi/hpcx-v2.12" ]; then
+if [ -d "/opt/mpi/hpcx" ]; then
     curdir=$PWD
-    cd /opt/mpi/hpcx-v2.12
+    cd /opt/mpi/hpcx
     . ./hpcx-init.sh
     hpcx_load
     cd $curdir

--- a/docker/release/20-nvidia-cuda-compat.sh
+++ b/docker/release/20-nvidia-cuda-compat.sh
@@ -16,12 +16,8 @@
 test -f /etc/shinit_v2 && . /etc/shinit_v2
 
 if [ -d "/opt/mpi/hpcx" ]; then
-    curdir=$PWD
-    cd /opt/mpi/hpcx
-    . ./hpcx-init.sh
+    . /opt/mpi/hpcx/hpcx-init.sh
     hpcx_load
-    cd $curdir
-    unset curdir
 else
     export PATH=/opt/mpi/bin:$PATH
     export LD_LIBRARY_PATH=/opt/mpi/lib:$LD_LIBRARY_PATH

--- a/docker/release/20-nvidia-cuda-compat.sh
+++ b/docker/release/20-nvidia-cuda-compat.sh
@@ -15,9 +15,9 @@
 
 test -f /etc/shinit_v2 && . /etc/shinit_v2
 
-if [ -d "/opt/mpi/hpcx-v2.12" ]; then
+if [ -d "/opt/mpi/hpcx" ]; then
     curdir=$PWD
-    cd /opt/mpi/hpcx-v2.12
+    cd /opt/mpi/hpcx
     . ./hpcx-init.sh
     hpcx_load
     cd $curdir

--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -25,7 +25,6 @@ ARG CURL_OPTS
 ARG WGET_OPTS
 ARG APT_OPTS
 ARG MPI
-ARG MPI_OPTS
 
 RUN eval ${APT_OPTS} \
     && apt-get update \
@@ -50,8 +49,8 @@ RUN if [ $(echo "${MPI}" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }') -gt 
         && curl ${CURL_OPTS} -LO http://www.mellanox.com/downloads/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-ubuntu18.04-cuda11-gdrcopy2-nccl2.12-x86_64.tbz \
         && tar -xvf hpcx*.tbz \
         && rm -f hpcx*.tbz \
-        && mv hpcx* hpcx-v2.12 \
-        && cd hpcx-v2.12 \
+        && mv hpcx* hpcx \
+        && cd hpcx \
         && ./utils/hpcx_rebuild.sh --ompi-extra-config --enable-openib-rdmacm-ibaddr \
         && cp -ap ./hpcx-rebuild/lib/libmca_common_verbs.* ./ompi/lib/ \
         && cp -ap ./hpcx-rebuild/lib/openmpi/mca_btl_openib.* ./ompi/lib/openmpi/ \
@@ -68,7 +67,7 @@ RUN if [ $(echo "${MPI}" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }') -gt 
         && tar Cxvf /tmp/openmpi /tmp/openmpi/openmpi-${MPI}.tar.bz2 \
         && cd tmp/openmpi/openmpi-${MPI} \
         && ./configure \
-            --prefix=/opt/mpi --enable-orterun-prefix-by-default --with-sge ${MPI_OPTS} \
+            --prefix=/opt/mpi --enable-orterun-prefix-by-default --with-sge \
             CC=gcc \
             CXX=g++ \
             F77=gfortran \

--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -47,7 +47,7 @@ COPY hpcx-ompi-etc.patch /tmp/hpcx-ompi-etc.patch
 RUN if [ $(echo "${MPI}" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }') -gt 30106 ]; then \
         mkdir /opt/mpi \
         && cd /opt/mpi \
-        && curl -LO http://www.mellanox.com/downloads/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl2.12-x86_64.tbz \
+        && curl ${CURL_OPTS} -LO http://www.mellanox.com/downloads/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-ubuntu18.04-cuda11-gdrcopy2-nccl2.12-x86_64.tbz \
         && tar -xvf hpcx*.tbz \
         && rm -f hpcx*.tbz \
         && mv hpcx* hpcx-v2.12 \

--- a/docker/release/Dockerfile.cuda-mpi
+++ b/docker/release/Dockerfile.cuda-mpi
@@ -25,6 +25,7 @@ ARG CURL_OPTS
 ARG WGET_OPTS
 ARG APT_OPTS
 ARG MPI
+ARG HPCX_URL_ubuntu
 
 RUN eval ${APT_OPTS} \
     && apt-get update \
@@ -46,7 +47,7 @@ COPY hpcx-ompi-etc.patch /tmp/hpcx-ompi-etc.patch
 RUN if [ $(echo "${MPI}" | awk -F. '{ printf("%d%02d%02d\n", $1,$2,$3); }') -gt 30106 ]; then \
         mkdir /opt/mpi \
         && cd /opt/mpi \
-        && curl ${CURL_OPTS} -LO http://www.mellanox.com/downloads/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-ubuntu18.04-cuda11-gdrcopy2-nccl2.12-x86_64.tbz \
+        && curl ${CURL_OPTS} -LO ${HPCX_URL_ubuntu} \
         && tar -xvf hpcx*.tbz \
         && rm -f hpcx*.tbz \
         && mv hpcx* hpcx \

--- a/docker/release/hpcx-init.patch
+++ b/docker/release/hpcx-init.patch
@@ -3,7 +3,7 @@
 @@ -1,5 +1,5 @@
  #!/bin/bash
 -mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-+mydir="/opt/mpi/hpcx-v2.12"
++mydir="/opt/mpi/hpcx"
  
  export HPCX_DIR=$mydir
  export HPCX_UCX_DIR=${HPCX_DIR}/ucx


### PR DESCRIPTION
Now we support HPC-X by https://github.com/sony/nnabla-ext-cuda/pull/471 .
This PR changes to use hpcx2.12 instead of openmpi4.1.3 on our CI. (hpcx2.12 includes openmpi4.1.5)
