### PR TITLE
Remove cpplib compiler warnings

### DIFF
--- a/build-tools/cmake/select_compute_arch.cmake
+++ b/build-tools/cmake/select_compute_arch.cmake
@@ -77,44 +77,26 @@ if(CMAKE_CUDA_COMPILER_LOADED) # CUDA as a language
 endif()
 
 # See: https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#gpu-feature-list
+# Additions, deprecations, and removals can be found in the release notes:
+# https://developer.nvidia.com/cuda-toolkit-archive
 
-# This list will be used for CUDA_ARCH_NAME = All option
-set(CUDA_KNOWN_GPU_ARCHITECTURES  "Fermi" "Kepler" "Maxwell")
+# The initial status here is for CUDA 7.0
+set(CUDA_KNOWN_GPU_ARCHITECTURES  "Fermi" "Kepler" "Maxwell" "Kepler+Tegra" "Kepler+Tesla" "Maxwell+Tegra")
+set(CUDA_COMMON_GPU_ARCHITECTURES "2.0" "2.1" "3.0" "3.5" "5.0" "5.3")
+set(CUDA_LIMIT_GPU_ARCHITECTURE "6.0")
+set(CUDA_ALL_GPU_ARCHITECTURES "2.0" "2.1" "3.0" "3.2" "3.5" "3.7" "5.0" "5.2" "5.3")
+set(_CUDA_MAX_COMMON_ARCHITECTURE "5.2+PTX")
 
-# This list will be used for CUDA_ARCH_NAME = Common option (enabled by default)
-set(CUDA_COMMON_GPU_ARCHITECTURES "3.5" "5.0")
-# 3.0 is removed in CUDA 11, see:
-# https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#deprecated-features
-if(CUDA_VERSION VERSION_LESS "11.0")
-  list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "3.0")
-endif()
-
-if(CUDA_VERSION VERSION_LESS "7.0")
-  set(CUDA_LIMIT_GPU_ARCHITECTURE "5.2")
-endif()
-
-# This list is used to filter CUDA archs when autodetecting
-set(CUDA_ALL_GPU_ARCHITECTURES "3.0" "3.2" "3.5" "5.0")
-
-if(CUDA_VERSION VERSION_GREATER_EQUAL "7.0")
-  list(APPEND CUDA_KNOWN_GPU_ARCHITECTURES "Kepler+Tegra" "Kepler+Tesla" "Maxwell+Tegra")
-  list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "5.2")
-
-  if(CUDA_VERSION VERSION_LESS "8.0")
-    list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "5.2+PTX")
-    set(CUDA_LIMIT_GPU_ARCHITECTURE "6.0")
-  endif()
-endif()
 
 if(CUDA_VERSION VERSION_GREATER_EQUAL "8.0")
   list(APPEND CUDA_KNOWN_GPU_ARCHITECTURES "Pascal")
   list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "6.0" "6.1")
   list(APPEND CUDA_ALL_GPU_ARCHITECTURES "6.0" "6.1" "6.2")
 
-  if(CUDA_VERSION VERSION_LESS "9.0")
-    list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "6.2+PTX")
-    set(CUDA_LIMIT_GPU_ARCHITECTURE "7.0")
-  endif()
+  set(_CUDA_MAX_COMMON_ARCHITECTURE "6.2+PTX")
+  set(CUDA_LIMIT_GPU_ARCHITECTURE "7.0")
+
+  list(REMOVE_ITEM CUDA_COMMON_GPU_ARCHITECTURES "2.0" "2.1")
 endif ()
 
 if(CUDA_VERSION VERSION_GREATER_EQUAL "9.0")
@@ -122,10 +104,11 @@ if(CUDA_VERSION VERSION_GREATER_EQUAL "9.0")
   list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "7.0")
   list(APPEND CUDA_ALL_GPU_ARCHITECTURES "7.0" "7.2")
 
-  if(CUDA_VERSION VERSION_LESS "10.0")
-    list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "7.2+PTX")
-    set(CUDA_LIMIT_GPU_ARCHITECTURE "8.0")
-  endif()
+  set(_CUDA_MAX_COMMON_ARCHITECTURE "7.2+PTX")
+  set(CUDA_LIMIT_GPU_ARCHITECTURE "8.0")
+
+  list(REMOVE_ITEM CUDA_KNOWN_GPU_ARCHITECTURES "Fermi")
+  list(REMOVE_ITEM CUDA_ALL_GPU_ARCHITECTURES "2.0" "2.1")
 endif()
 
 if(CUDA_VERSION VERSION_GREATER_EQUAL "10.0")
@@ -133,31 +116,45 @@ if(CUDA_VERSION VERSION_GREATER_EQUAL "10.0")
   list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "7.5")
   list(APPEND CUDA_ALL_GPU_ARCHITECTURES "7.5")
 
-  if(CUDA_VERSION VERSION_LESS "11.0")
-    list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "7.5+PTX")
-    set(CUDA_LIMIT_GPU_ARCHITECTURE "8.0")
-  endif()
+  set(_CUDA_MAX_COMMON_ARCHITECTURE "7.5+PTX")
+  set(CUDA_LIMIT_GPU_ARCHITECTURE "8.0")
+
+  list(REMOVE_ITEM CUDA_COMMON_GPU_ARCHITECTURES "3.0")
 endif()
 
+# https://docs.nvidia.com/cuda/archive/11.0/cuda-toolkit-release-notes/index.html#cuda-general-new-features
+# https://docs.nvidia.com/cuda/archive/11.0/cuda-toolkit-release-notes/index.html#deprecated-features
 if(CUDA_VERSION VERSION_GREATER_EQUAL "11.0")
   list(APPEND CUDA_KNOWN_GPU_ARCHITECTURES "Ampere")
   list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "8.0")
   list(APPEND CUDA_ALL_GPU_ARCHITECTURES "8.0")
 
-  if(CUDA_VERSION VERSION_LESS "11.1")
-    list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "8.0+PTX")
-    set(CUDA_LIMIT_GPU_ARCHITECTURE "8.6")
-  endif()
+  set(_CUDA_MAX_COMMON_ARCHITECTURE "8.0+PTX")
+  set(CUDA_LIMIT_GPU_ARCHITECTURE "8.6")
+
+  list(REMOVE_ITEM CUDA_COMMON_GPU_ARCHITECTURES "3.5" "5.0")
+  list(REMOVE_ITEM CUDA_ALL_GPU_ARCHITECTURES "3.0" "3.2")
 endif()
 
 if(CUDA_VERSION VERSION_GREATER_EQUAL "11.1")
-  list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "8.6" "8.6+PTX")
+  list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "8.6")
   list(APPEND CUDA_ALL_GPU_ARCHITECTURES "8.6")
 
-  if(CUDA_VERSION VERSION_LESS "12.0")
-    set(CUDA_LIMIT_GPU_ARCHITECTURE "9.0")
-  endif()
+  set(_CUDA_MAX_COMMON_ARCHITECTURE "8.6+PTX")
+  set(CUDA_LIMIT_GPU_ARCHITECTURE "9.0")
 endif()
+
+list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "${_CUDA_MAX_COMMON_ARCHITECTURE}")
+
+# Check with: cmake -DCUDA_VERSION=7.0 -P select_compute_arch.cmake
+if(DEFINED CMAKE_SCRIPT_MODE_FILE)
+  include(CMakePrintHelpers)
+  cmake_print_variables(CUDA_KNOWN_GPU_ARCHITECTURES)
+  cmake_print_variables(CUDA_COMMON_GPU_ARCHITECTURES)
+  cmake_print_variables(CUDA_LIMIT_GPU_ARCHITECTURE)
+  cmake_print_variables(CUDA_ALL_GPU_ARCHITECTURES)
+endif()
+
 
 ################################################################################################
 # A function for automatic detection of GPUs installed  (if autodetection is enabled)
@@ -190,10 +187,10 @@ function(CUDA_DETECT_INSTALLED_GPUS OUT_VARIABLE)
       "}\n")
 
     if(CMAKE_CUDA_COMPILER_LOADED) # CUDA as a language
-      try_run(run_result compile_result ${PROJECT_BINARY_DIR} ${file}
+      try_run(run_result compile_result SOURCES ${file}
               RUN_OUTPUT_VARIABLE compute_capabilities)
     else()
-      try_run(run_result compile_result ${PROJECT_BINARY_DIR} ${file}
+      try_run(run_result compile_result SOURCES ${file}
               CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${CUDA_INCLUDE_DIRS}"
               LINK_LIBRARIES ${CUDA_LIBRARIES}
               RUN_OUTPUT_VARIABLE compute_capabilities)

--- a/build-tools/msvc/tools/get_cutensor.bat
+++ b/build-tools/msvc/tools/get_cutensor.bat
@@ -23,13 +23,13 @@ SET CUDAVER=11
 
 :LIB_VER_SET
 
-SET cutensor_folder=%third_party_folder%\libcutensor-windows-x86_64-1.5.0.3-archive
+SET cutensor_folder=%third_party_folder%\libcutensor-windows-x86_64-1.7.0.1-archive
 SET cutensor_library_dir=%cutensor_folder%\lib\%CUDAVER%
 SET cutensor_dll=%cutensor_folder%\lib\%CUDAVER%\cutensor.dll
 SET cutensor_include_dir=%cutensor_folder%\include
 
 if NOT EXIST %cutensor_folder%.zip (
-    powershell "%nnabla_iwr_script%; iwr %nnabla_iwr_options% -Uri https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/windows-x86_64/libcutensor-windows-x86_64-1.5.0.3-archive.zip -OutFile %cutensor_folder%.zip" || GOTO :error
+    powershell "%nnabla_iwr_script%; iwr %nnabla_iwr_options% -Uri https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/windows-x86_64/libcutensor-windows-x86_64-1.7.0.1-archive.zip -OutFile %cutensor_folder%.zip" || GOTO :error
 )
 
 IF EXIST %cutensor_library_dir% (

--- a/include/nbla/cuda/common.hpp
+++ b/include/nbla/cuda/common.hpp
@@ -131,6 +131,20 @@ inline string cublas_status_to_string(cublasStatus_t status) {
     }                                                                          \
   }
 
+#define NBLA_CUBLAS_FORCE_ASSERT(condition)                                    \
+  {                                                                            \
+    cublasStatus_t status = condition;                                         \
+    cudaGetLastError();                                                        \
+    if (status != CUBLAS_STATUS_SUCCESS) {                                     \
+      NBLA_FORCE_ASSERT(                                                       \
+          status != CUBLAS_STATUS_SUCCESS,                                     \
+          string("CUBLAS_STATUS_") + cublas_status_to_string(status) +         \
+              string(                                                          \
+                  " occured in `" #condition                                   \
+                  "`. Please see CUBLAS API documentation for the cause."));   \
+    }                                                                          \
+  }
+
 inline string cusolver_status_to_string(cusolverStatus_t status) {
 #define CASE_CUSOLVER_STATUS(NAME)                                             \
   case CUSOLVER_STATUS_##NAME:                                                 \

--- a/include/nbla/cuda/common.hpp
+++ b/include/nbla/cuda/common.hpp
@@ -198,6 +198,19 @@ inline string cusolver_status_to_string(cusolverStatus_t status) {
     }                                                                          \
   }
 
+#define NBLA_CUSOLVER_FORCE_ASSERT(condition)                                  \
+  {                                                                            \
+    cusolverStatus_t status = condition;                                       \
+    if (status != CUSOLVER_STATUS_SUCCESS) {                                   \
+      NBLA_FORCE_ASSERT(                                                       \
+          status != CUSOLVER_STATUS_SUCCESS,                                   \
+          string("CUSOLVER_STATUS_") + cusolver_status_to_string(status) +     \
+              string(                                                          \
+                  " occured in `" #condition                                   \
+                  "`. Please see CUSOLVER API documentation for the cause.")); \
+    }                                                                          \
+  }
+
 inline string curand_status_to_string(curandStatus_t status) {
 #define CASE_CURAND_STATUS(NAME)                                               \
   case CURAND_STATUS_##NAME:                                                   \

--- a/include/nbla/cuda/common.hpp
+++ b/include/nbla/cuda/common.hpp
@@ -90,6 +90,19 @@ Check CUDA driver error.
     }                                                                          \
   }
 
+#define NBLA_CUDA_DRIVER_FORCE_ASSERT(condition)                               \
+  {                                                                            \
+    CUresult status = (condition);                                             \
+    if (status != CUDA_SUCCESS) {                                              \
+      const char *err_name, *err_str;                                          \
+      cuGetErrorName(status, &err_name);                                       \
+      cuGetErrorString(status, &err_str);                                      \
+      NBLA_FORCE_ASSERT(status != CUDA_SUCCESS,                                \
+                        "(%s) failed with \"%s\" (%s).",                       \
+                        #condition, err_str, err_name);                        \
+    }                                                                          \
+  }
+
 inline string cublas_status_to_string(cublasStatus_t status) {
 #define CASE_CUBLAS_STATUS(NAME)                                               \
   case CUBLAS_STATUS_##NAME:                                                   \

--- a/include/nbla/cuda/common.hpp
+++ b/include/nbla/cuda/common.hpp
@@ -39,6 +39,27 @@
 
 namespace nbla {
 
+#define STRINGIFY(str) #str
+#if CUDA_VERSION >= 11010
+  #ifndef _MSC_VER
+    #define NBLA_DIAG_SUPPRESS(warn) _Pragma(STRINGIFY(nv_diag_suppress warn))
+    #define NBLA_DIAG_DEFAULT(warn)  _Pragma(STRINGIFY(nv_diag_default warn))
+  #else
+    #define NBLA_DIAG_SUPPRESS(warn)
+    #define NBLA_DIAG_DEFAULT(warn)
+  #endif
+  #define inline_qualifier_ignored 20050
+#else
+  #ifndef _MSC_VER
+    #define NBLA_DIAG_SUPPRESS(warn) _Pragma(STRINGIFY(diag_suppress warn))
+    #define NBLA_DIAG_DEFAULT(warn)  _Pragma(STRINGIFY(diag_default warn))
+  #else
+    #define NBLA_DIAG_SUPPRESS(warn)
+    #define NBLA_DIAG_DEFAULT(warn)
+  #endif
+  #define inline_qualifier_ignored 3095
+#endif
+
 namespace cuda {
 typedef int Index_t;
 }

--- a/include/nbla/cuda/common.hpp
+++ b/include/nbla/cuda/common.hpp
@@ -63,6 +63,18 @@ cudaGetLastError is used to clear previous error happening at "condition".
     }                                                                          \
   }
 
+#define NBLA_CUDA_FORCE_ASSERT(condition)                                      \
+  {                                                                            \
+    cudaError_t error = condition;                                             \
+    if (error != cudaSuccess) {                                                \
+      cudaGetLastError();                                                      \
+      NBLA_FORCE_ASSERT(error != cudaSuccess,                                  \
+                        "(%s) failed with \"%s\" (%s).",                       \
+                        #condition, cudaGetErrorString(error),                 \
+                        cudaGetErrorName(error))                               \
+    }                                                                          \
+  }
+
 /**
 Check CUDA driver error.
 */

--- a/include/nbla/cuda/cudnn/cudnn.hpp
+++ b/include/nbla/cuda/cudnn/cudnn.hpp
@@ -145,6 +145,18 @@ inline string cudnn_status_to_string(cudnnStatus_t status) {
     }                                                                          \
   }
 
+#define NBLA_CUDNN_FORCE_ASSERT(condition)                                     \
+  {                                                                            \
+    cudnnStatus_t status = condition;                                          \
+    if (status != CUDNN_STATUS_SUCCESS) {                                      \
+      NBLA_FORCE_ASSERT(                                                       \
+          status != CUDNN_STATUS_SUCCESS,                                      \
+          string("CUDNN_STATUS_") + cudnn_status_to_string(status) +           \
+              string(" occured in `" #condition                                \
+                     "`. Please see CUDNN API documentation for the cause.")); \
+    }                                                                          \
+  }
+
 /** Wrapper function of cudnnSetTensorNdDescriptor with ensuring least dims.
 
 http://docs.nvidia.com/deeplearning/sdk/cudnn-developer-guide/index.html#cudnnSetTensorNdDescriptor

--- a/include/nbla/cuda/cudnn/function/add2.hpp
+++ b/include/nbla/cuda/cudnn/function/add2.hpp
@@ -29,12 +29,12 @@ public:
 
   explicit Add2CudaCudnn(const Context &ctx, bool inplace)
       : Add2Cuda<T>(ctx, inplace), device_(std::stoi(ctx.device_id)) {
-    NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&input_desc_));
-    NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&output_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&input_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&output_desc_));
   }
   virtual ~Add2CudaCudnn() {
-    NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(input_desc_));
-    NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(output_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(input_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(output_desc_));
   }
   virtual string name() { return "Add2CudaCudnn"; }
   virtual vector<string> allowed_array_classes() {

--- a/include/nbla/cuda/cudnn/function/affine_grid.hpp
+++ b/include/nbla/cuda/cudnn/function/affine_grid.hpp
@@ -38,13 +38,13 @@ public:
         device_(std::stoi(ctx.device_id)) {
     if (affine_grid::cudnn_condition(this->size_.size(),
                                      this->align_corners_)) {
-      NBLA_CUDNN_CHECK(cudnnCreateSpatialTransformerDescriptor(&theta_desc_));
+      NBLA_CUDNN_FORCE_ASSERT(cudnnCreateSpatialTransformerDescriptor(&theta_desc_));
     }
   }
   virtual ~AffineGridCudaCudnn() {
     if (affine_grid::cudnn_condition(this->size_.size(),
                                      this->align_corners_)) {
-      NBLA_CUDNN_CHECK(cudnnDestroySpatialTransformerDescriptor(theta_desc_));
+      NBLA_CUDNN_FORCE_ASSERT(cudnnDestroySpatialTransformerDescriptor(theta_desc_));
     }
   }
   virtual string name() { return "AffineGridCudaCudnn"; }

--- a/include/nbla/cuda/cudnn/function/mean.hpp
+++ b/include/nbla/cuda/cudnn/function/mean.hpp
@@ -29,18 +29,18 @@ public:
                          bool keep_dims)
       : MeanCuda<T>(ctx, axes, keep_dims) {
 #if CUDNN_VERSION >= 6000
-    NBLA_CUDNN_CHECK(cudnnCreateReduceTensorDescriptor(&reduce_desc_));
-    NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&x_desc_));
-    NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&y_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateReduceTensorDescriptor(&reduce_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&x_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&y_desc_));
 #else
     this->fall_back_func_ = make_shared<MeanCuda<T>>(ctx, axes, keep_dims);
 #endif
   }
   virtual ~MeanCudaCudnn() {
 #if CUDNN_VERSION >= 6000
-    NBLA_CUDNN_CHECK(cudnnDestroyReduceTensorDescriptor(reduce_desc_));
-    NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(x_desc_));
-    NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(y_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyReduceTensorDescriptor(reduce_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(x_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(y_desc_));
 #endif
   }
   virtual string name() { return "MeanCudaCudnn"; }

--- a/include/nbla/cuda/cudnn/function/prod.hpp
+++ b/include/nbla/cuda/cudnn/function/prod.hpp
@@ -29,18 +29,18 @@ public:
                          bool keep_dims)
       : ProdCuda<T>(ctx, axes, keep_dims) {
 #if CUDNN_VERSION >= 6000
-    NBLA_CUDNN_CHECK(cudnnCreateReduceTensorDescriptor(&reduce_desc_));
-    NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&x_desc_));
-    NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&y_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateReduceTensorDescriptor(&reduce_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&x_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&y_desc_));
 #else
     this->fall_back_func_ = make_shared<ProdCuda<T>>(ctx, axes, keep_dims);
 #endif
   }
   virtual ~ProdCudaCudnn() {
 #if CUDNN_VERSION >= 6000
-    NBLA_CUDNN_CHECK(cudnnDestroyReduceTensorDescriptor(reduce_desc_));
-    NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(x_desc_));
-    NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(y_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyReduceTensorDescriptor(reduce_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(x_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(y_desc_));
 #endif
   }
   virtual string name() { return "ProdCudaCudnn"; }

--- a/include/nbla/cuda/cudnn/function/rnn.hpp
+++ b/include/nbla/cuda/cudnn/function/rnn.hpp
@@ -42,14 +42,14 @@ public:
 
   WCudnnTensorDescArray(size_t size) : initialized_(true), desc_array_(size) {
     for (auto &desc : desc_array_) {
-      NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&desc));
+      NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&desc));
     }
   }
 
   ~WCudnnTensorDescArray() {
     if (initialized_) {
       for (auto &desc : desc_array_) {
-        NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(desc));
+        NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(desc));
       }
     }
   }
@@ -57,28 +57,28 @@ public:
 };
 struct WCudnnTensorDesc {
   cudnnTensorDescriptor_t desc;
-  WCudnnTensorDesc() { NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&desc)); }
-  ~WCudnnTensorDesc() { NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(desc)); }
+  WCudnnTensorDesc() { NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&desc)); }
+  ~WCudnnTensorDesc() { NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(desc)); }
 };
 
 struct WCudnnFilterDesc {
   cudnnFilterDescriptor_t desc;
-  WCudnnFilterDesc() { NBLA_CUDNN_CHECK(cudnnCreateFilterDescriptor(&desc)); }
-  ~WCudnnFilterDesc() { NBLA_CUDNN_CHECK(cudnnDestroyFilterDescriptor(desc)); }
+  WCudnnFilterDesc() { NBLA_CUDNN_FORCE_ASSERT(cudnnCreateFilterDescriptor(&desc)); }
+  ~WCudnnFilterDesc() { NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyFilterDescriptor(desc)); }
 };
 
 struct WCudnnDropoutDesc {
   cudnnDropoutDescriptor_t desc;
-  WCudnnDropoutDesc() { NBLA_CUDNN_CHECK(cudnnCreateDropoutDescriptor(&desc)); }
+  WCudnnDropoutDesc() { NBLA_CUDNN_FORCE_ASSERT(cudnnCreateDropoutDescriptor(&desc)); }
   ~WCudnnDropoutDesc() {
-    NBLA_CUDNN_CHECK(cudnnDestroyDropoutDescriptor(desc));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyDropoutDescriptor(desc));
   }
 };
 
 struct WCudnnRNNDesc {
   cudnnRNNDescriptor_t desc;
-  WCudnnRNNDesc() { NBLA_CUDNN_CHECK(cudnnCreateRNNDescriptor(&desc)); }
-  ~WCudnnRNNDesc() { NBLA_CUDNN_CHECK(cudnnDestroyRNNDescriptor(desc)); }
+  WCudnnRNNDesc() { NBLA_CUDNN_FORCE_ASSERT(cudnnCreateRNNDescriptor(&desc)); }
+  ~WCudnnRNNDesc() { NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyRNNDescriptor(desc)); }
 };
 
 template <typename T> class RNNCudaCudnn : public RNN<T> {

--- a/include/nbla/cuda/cudnn/function/tanh.hpp
+++ b/include/nbla/cuda/cudnn/function/tanh.hpp
@@ -42,16 +42,16 @@ public:
 
   TanhCudaCudnn(const Context &ctx)
       : Tanh<T>(ctx), device_(std::stoi(ctx.device_id)) {
-    NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&input_desc_));
-    NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&output_desc_));
-    NBLA_CUDNN_CHECK(cudnnCreateActivationDescriptor(&activation_desc_));
-    NBLA_CUDNN_CHECK(cudnnSetActivationDescriptor(
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&input_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&output_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateActivationDescriptor(&activation_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnSetActivationDescriptor(
         activation_desc_, CUDNN_ACTIVATION_TANH, CUDNN_PROPAGATE_NAN, T(0)));
   }
   virtual ~TanhCudaCudnn() {
-    NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(input_desc_));
-    NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(output_desc_));
-    NBLA_CUDNN_CHECK(cudnnDestroyActivationDescriptor(activation_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(input_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(output_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyActivationDescriptor(activation_desc_));
   }
   virtual string name() { return "TanhCudaCudnn"; }
   virtual vector<string> allowed_array_classes() {

--- a/include/nbla/cuda/cudnn/function/warp_by_grid.hpp
+++ b/include/nbla/cuda/cudnn/function/warp_by_grid.hpp
@@ -43,17 +43,17 @@ public:
                                bool channel_last)
       : WarpByGridCuda<T>(ctx, mode, padding_mode, align_corners, channel_last),
         device_(std::stoi(ctx.device_id)) {
-    NBLA_CUDNN_CHECK(
+    NBLA_CUDNN_FORCE_ASSERT(
         cudnnCreateSpatialTransformerDescriptor(&spatial_tf_desc_));
-    NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&x_desc_));
-    NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&y_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&x_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&y_desc_));
   }
 
   virtual ~WarpByGridCudaCudnn() {
-    NBLA_CUDNN_CHECK(
+    NBLA_CUDNN_FORCE_ASSERT(
         cudnnDestroySpatialTransformerDescriptor(spatial_tf_desc_));
-    NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(x_desc_));
-    NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(y_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(x_desc_));
+    NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(y_desc_));
   }
   virtual string name() { return "WarpByGridCudaCudnn"; }
   virtual vector<string> allowed_array_classes() {

--- a/include/nbla/cuda/utils/im2col.hpp
+++ b/include/nbla/cuda/utils/im2col.hpp
@@ -69,6 +69,8 @@ im2col_kernel(const int col_size, const T *img, const int height,
 #endif
   }
 }
+
+NBLA_DIAG_SUPPRESS(inline_qualifier_ignored);
 template <>
 inline __global__ void
 im2col_kernel(const int col_size, const HalfCuda *img, const int height,
@@ -91,4 +93,5 @@ im2col_kernel(const int col_size, const HalfCuda *img, const int height,
                    : (HalfCuda)0;
   }
 }
+NBLA_DIAG_DEFAULT(inline_qualifier_ignored);
 } // namespace nbla

--- a/include/nbla/cuda/utils/relu.cuh
+++ b/include/nbla/cuda/utils/relu.cuh
@@ -27,6 +27,8 @@
 
 namespace nbla {
 
+NBLA_DIAG_SUPPRESS(inline_qualifier_ignored);
+
 template <class T> inline Size_t interpret_size(const Size_t size) {
   return size; // interpreted as half type
 }
@@ -161,6 +163,9 @@ kernel_relu_backward<false>(const Size_t size2, const Size_t size, HalfCuda *dx,
                             const HalfCuda *y, const HalfCuda *dy) {
   kernel_relu_backward_half2<false>(size2, size, dx, y, dy);
 }
+
+NBLA_DIAG_DEFAULT(inline_qualifier_ignored);
+
 } // namespace nbla
 
 #endif

--- a/src/nbla/cuda/communicator/data_parallel_communicator.cu
+++ b/src/nbla/cuda/communicator/data_parallel_communicator.cu
@@ -40,7 +40,7 @@ DataParallelCommunicatorNccl<T>::~DataParallelCommunicatorNccl() {
   if (this->initialized_) {
     for (int i = 0; i < device_ids_.size(); ++i) {
       ncclCommDestroy(comms_[i]);
-      NBLA_CUDA_CHECK(cudaStreamDestroy(streams_[i]));
+      NBLA_CUDA_FORCE_ASSERT(cudaStreamDestroy(streams_[i]));
     }
   }
 }

--- a/src/nbla/cuda/communicator/multi_process_data_parallel_communicator.cu
+++ b/src/nbla/cuda/communicator/multi_process_data_parallel_communicator.cu
@@ -55,6 +55,17 @@ std::string get_mpi_error_string(int error) {
     }                                                                          \
   }
 
+#define NBLA_MPI_FORCE_ASSERT(condition)                                       \
+  {                                                                            \
+    int error = condition;                                                     \
+    if (error != MPI_SUCCESS) {                                                \
+      auto estring = get_mpi_error_string(error);                              \
+      NBLA_FORCE_ASSERT(error != MPI_SUCCESS,                                  \
+                        "`" #condition "` failed by `%s`.",                    \
+                        estring.c_str());                                      \
+    }                                                                          \
+  }
+
 /**
    MPI singleton class that manages lifetime of MPI.
 
@@ -92,8 +103,8 @@ public:
        */
       return;
     }
-    NBLA_MPI_CHECK(MPI_Group_free(&world_group_));
-    NBLA_MPI_CHECK(MPI_Finalize());
+    NBLA_MPI_FORCE_ASSERT(MPI_Group_free(&world_group_));
+    NBLA_MPI_FORCE_ASSERT(MPI_Finalize());
   }
 
   /**

--- a/src/nbla/cuda/communicator/multi_process_data_parallel_communicator.cu
+++ b/src/nbla/cuda/communicator/multi_process_data_parallel_communicator.cu
@@ -345,13 +345,13 @@ MultiProcessDataParallelCommunicatorNccl<
     T>::~MultiProcessDataParallelCommunicatorNccl() {
   if (this->initialized_) {
     for (int i = 0; i < streams_.size(); ++i) {
-      NBLA_CUDA_CHECK(cudaStreamDestroy(streams_[i]));
+      NBLA_CUDA_FORCE_ASSERT(cudaStreamDestroy(streams_[i]));
     }
     for (auto e : this->comms_) {
       ncclCommDestroy(e.second);
     }
     for (auto &stream : this->nonblocking_streams_) {
-      NBLA_CUDA_CHECK(cudaStreamDestroy(stream));
+      NBLA_CUDA_FORCE_ASSERT(cudaStreamDestroy(stream));
     }
   }
 }

--- a/src/nbla/cuda/cuda.cpp
+++ b/src/nbla/cuda/cuda.cpp
@@ -142,10 +142,10 @@ cutensorHandle_t Cuda::cutensor_handle(int device) {
   auto it = this->cutensor_handles_.find(device);
   // Create a new one
   if (it == this->cutensor_handles_.end()) {
-    cutensorHandle_t handle;
-    NBLA_CUTENSOR_CHECK(cutensorInit(&handle));
-    this->cutensor_handles_.insert({device, handle});
-    return handle;
+    cutensorHandle_t* handle;
+    NBLA_CUTENSOR_CHECK(cutensorCreate(&handle));
+    this->cutensor_handles_.insert({device, *handle});
+    return *handle;
   }
   return it->second;
 }

--- a/src/nbla/cuda/cuda.cpp
+++ b/src/nbla/cuda/cuda.cpp
@@ -51,7 +51,7 @@ Cuda::~Cuda() {
     }
   }
   for (auto handle : this->cusolverdn_handles_) {
-    NBLA_CUSOLVER_CHECK(cusolverDnDestroy(handle.second));
+    NBLA_CUSOLVER_FORCE_ASSERT(cusolverDnDestroy(handle.second));
   }
   for (auto gen : this->curand_generators_) {
     curand_destroy_generator(gen.second);

--- a/src/nbla/cuda/cuda.cpp
+++ b/src/nbla/cuda/cuda.cpp
@@ -47,7 +47,7 @@ Cuda::Cuda()
 Cuda::~Cuda() {
   for (auto &tid_handles : this->cublas_handles_) {
     for (auto &handle : tid_handles.second) {
-      NBLA_CUBLAS_CHECK(cublasDestroy(handle.second));
+      NBLA_CUBLAS_FORCE_ASSERT(cublasDestroy(handle.second));
     }
   }
   for (auto handle : this->cusolverdn_handles_) {

--- a/src/nbla/cuda/cuda.cpp
+++ b/src/nbla/cuda/cuda.cpp
@@ -59,7 +59,7 @@ Cuda::~Cuda() {
   for (auto &all_events : this->cuda_unused_events_) {
     for (auto &events : all_events.second) {
       for (auto &event : events.second) {
-        NBLA_CUDA_CHECK(cudaEventDestroy(event));
+        NBLA_CUDA_FORCE_ASSERT(cudaEventDestroy(event));
       }
     }
   }
@@ -67,17 +67,17 @@ Cuda::~Cuda() {
   for (auto &all_streams : this->streams_) {
     for (auto &tid_stream : all_streams.second) {
       for (auto &stream : tid_stream.second) {
-        NBLA_CUDA_CHECK(cudaStreamDestroy(*(stream.second)));
+        NBLA_CUDA_FORCE_ASSERT(cudaStreamDestroy(*(stream.second)));
       }
     }
   }
 
   if (stream_HtoD != 0) {
-    NBLA_CUDA_CHECK(cudaStreamDestroy(stream_HtoD));
+    NBLA_CUDA_FORCE_ASSERT(cudaStreamDestroy(stream_HtoD));
   }
 
   if (stream_DtoH != 0) {
-    NBLA_CUDA_CHECK(cudaStreamDestroy(stream_DtoH));
+    NBLA_CUDA_FORCE_ASSERT(cudaStreamDestroy(stream_DtoH));
   }
 }
 

--- a/src/nbla/cuda/cudnn/cudnn.cpp
+++ b/src/nbla/cuda/cudnn/cudnn.cpp
@@ -218,11 +218,11 @@ CudnnConvResource::CudnnConvResource(const CudnnConvDesc &desc) {
 
 CudnnConvResource::~CudnnConvResource() {
 
-  NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(x_desc));
-  NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(y_desc));
-  NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(b_desc));
-  NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(b_desc_deconv));
-  NBLA_CUDNN_CHECK(cudnnDestroyFilterDescriptor(w_desc));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(x_desc));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(y_desc));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(b_desc));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(b_desc_deconv));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyFilterDescriptor(w_desc));
 }
 
 inline bool check_workspace_limit(Size_t workspace_limit, size_t used_memory) {
@@ -564,40 +564,40 @@ size_t CudnnConvResource::bwd_data_workspace_size() const {
 // Cudnn Convolution Wrapper
 ////////////////////////////////////////
 CudnnConvolutionDescriptor::CudnnConvolutionDescriptor() {
-  NBLA_CUDNN_CHECK(cudnnCreateConvolutionDescriptor(&desc));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnCreateConvolutionDescriptor(&desc));
 }
 CudnnConvolutionDescriptor::~CudnnConvolutionDescriptor() {
-  NBLA_CUDNN_CHECK(cudnnDestroyConvolutionDescriptor(desc));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyConvolutionDescriptor(desc));
 }
 
 ////////////////////////////////////////
 // Cudnn activation descriptor Wrapper
 ////////////////////////////////////////
 CudnnActivationDescriptor::CudnnActivationDescriptor() {
-  NBLA_CUDNN_CHECK(cudnnCreateActivationDescriptor(&desc));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnCreateActivationDescriptor(&desc));
 }
 CudnnActivationDescriptor::~CudnnActivationDescriptor() {
-  NBLA_CUDNN_CHECK(cudnnDestroyActivationDescriptor(desc));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyActivationDescriptor(desc));
 }
 
 ////////////////////////////////////////
 // Cudnn Tensor Descriptor Wrapper
 ////////////////////////////////////////
 CudnnTensorDescriptor::CudnnTensorDescriptor() {
-  NBLA_CUDNN_CHECK(cudnnCreateTensorDescriptor(&desc));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnCreateTensorDescriptor(&desc));
 }
 CudnnTensorDescriptor::~CudnnTensorDescriptor() {
-  NBLA_CUDNN_CHECK(cudnnDestroyTensorDescriptor(desc));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyTensorDescriptor(desc));
 }
 
 ////////////////////////////////////////
 // Cudnn Pooling Wrapper
 ////////////////////////////////////////
 CudnnPoolingDescriptor::CudnnPoolingDescriptor() {
-  NBLA_CUDNN_CHECK(cudnnCreatePoolingDescriptor(&desc));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnCreatePoolingDescriptor(&desc));
 }
 CudnnPoolingDescriptor::~CudnnPoolingDescriptor() {
-  NBLA_CUDNN_CHECK(cudnnDestroyPoolingDescriptor(desc));
+  NBLA_CUDNN_FORCE_ASSERT(cudnnDestroyPoolingDescriptor(desc));
 }
 
 CudnnPooling::Ptr
@@ -625,13 +625,16 @@ CudnnPooling::CudnnPooling(const vector<int> &inshape,
 
 // Create pooling descriptor.
 #if CUDNN_VERSION >= 5000
-  NBLA_CUDNN_CHECK(cudnnSetPoolingNdDescriptor(
-      pooling_desc_.desc, mode, CUDNN_NOT_PROPAGATE_NAN, cfg.kernel.size(),
-      cfg.kernel.data(), cfg.pad.data(), cfg.stride.data()));
+  NBLA_CUDNN_FORCE_ASSERT(
+    cudnnSetPoolingNdDescriptor(pooling_desc_.desc, mode,
+                                CUDNN_NOT_PROPAGATE_NAN, cfg.kernel.size(),
+                                cfg.kernel.data(), cfg.pad.data(),
+                                cfg.stride.data()));
 #else
-  NBLA_CUDNN_CHECK(cudnnSetPoolingNdDescriptor(
-      pooling_desc_.desc, mode, cfg.kernel.size(), cfg.kernel.data(),
-      cfg.pad.data(), cfg.stride.data()));
+  NBLA_CUDNN_FORCE_ASSERT(
+    cudnnSetPoolingNdDescriptor(pooling_desc_.desc, mode,
+                                cfg.kernel.size(), cfg.kernel.data(),
+                                cfg.pad.data(), cfg.stride.data()));
 #endif
 
   // Create input and output descriptor.
@@ -684,12 +687,14 @@ CudnnSoftmax::CudnnSoftmax(const Shape_t &inshape, int axis,
   if (stride_c == 1) {
     mode_ = CUDNN_SOFTMAX_MODE_INSTANCE;
   }
-  NBLA_CUDNN_CHECK(cudnnSetTensor4dDescriptorEx(input_desc_.desc, dtype, N, C,
-                                                H, W, stride_n, stride_c,
-                                                stride_h, stride_w));
-  NBLA_CUDNN_CHECK(cudnnSetTensor4dDescriptorEx(output_desc_.desc, dtype, N, C,
-                                                H, W, stride_n, stride_c,
-                                                stride_h, stride_w));
+  NBLA_CUDNN_FORCE_ASSERT(
+    cudnnSetTensor4dDescriptorEx(input_desc_.desc, dtype, N, C,
+                                 H, W, stride_n, stride_c,
+                                 stride_h, stride_w));
+  NBLA_CUDNN_FORCE_ASSERT(
+    cudnnSetTensor4dDescriptorEx(output_desc_.desc, dtype, N, C,
+                                 H, W, stride_n, stride_c,
+                                 stride_h, stride_w));
 }
 CudnnSoftmax::Ptr CudnnSoftmax::create(const Shape_t &inshape, int axis,
                                        cudnnSoftmaxAlgorithm_t algo,
@@ -721,7 +726,7 @@ CudnnHandleManager::~CudnnHandleManager() {
     for (auto thread : device.second) {
       for (auto stream : thread.second) {
         cudnnHandle_t handle = *stream.second;
-        NBLA_CUDNN_CHECK(cudnnDestroy(handle));
+        NBLA_CUDNN_FORCE_ASSERT(cudnnDestroy(handle));
       }
     }
   }

--- a/src/nbla/cuda/function/generic/fused_batch_normalization.cu
+++ b/src/nbla/cuda/function/generic/fused_batch_normalization.cu
@@ -26,8 +26,10 @@ namespace fused_batch_normalization_cuda {
 template <typename T>
 void relu_backward(const Size_t size, T *dx, const T *dy, const T *y) {
   const Size_t size2 = interpret_size<T>(size);
+  NBLA_DIAG_SUPPRESS(inline_qualifier_ignored);
   NBLA_CUDA_LAUNCH_KERNEL_SIMPLE_SIZE_T((kernel_relu_backward<false>), size2,
                                         size, dx, y, dy);
+  NBLA_DIAG_DEFAULT(inline_qualifier_ignored);
 }
 
 template <typename T>

--- a/src/nbla/cuda/function/generic/relu.cu
+++ b/src/nbla/cuda/function/generic/relu.cu
@@ -35,7 +35,10 @@ void ReLUCuda<T>::forward_impl(const Variables &inputs,
   Tc *y = outputs[0]->cast_data_and_get_pointer<Tc>(this->ctx_, true);
   const Size_t size = inputs[0]->size();
   const Size_t size2 = interpret_size<T>(size);
+
+  NBLA_DIAG_SUPPRESS(inline_qualifier_ignored);
   NBLA_CUDA_LAUNCH_KERNEL_SIMPLE_SIZE_T(kernel_relu_forward, size2, size, y, x);
+  NBLA_DIAG_DEFAULT(inline_qualifier_ignored);
 }
 
 template <class T>
@@ -54,6 +57,7 @@ void ReLUCuda<T>::backward_impl(const Variables &inputs,
   const Size_t size = inputs[0]->size();
   const Size_t size2 = interpret_size<T>(size);
 
+  NBLA_DIAG_SUPPRESS(inline_qualifier_ignored);
   if (dx != dy && accum[0]) {
     NBLA_CUDA_LAUNCH_KERNEL_SIMPLE_SIZE_T((kernel_relu_backward<true>), size2,
                                           size, dx, y, dy);
@@ -61,5 +65,6 @@ void ReLUCuda<T>::backward_impl(const Variables &inputs,
     NBLA_CUDA_LAUNCH_KERNEL_SIMPLE_SIZE_T((kernel_relu_backward<false>), size2,
                                           size, dx, y, dy);
   }
+  NBLA_DIAG_DEFAULT(inline_qualifier_ignored);
 }
 } // namespace nbla

--- a/src/nbla/cuda/memory/cuda_memory.cpp
+++ b/src/nbla/cuda/memory/cuda_memory.cpp
@@ -45,7 +45,7 @@ CudaMemory::~CudaMemory() {
                     "byl another memory and split previously).");
   DEBUG_LOG("%s: %zu at %p\n", __func__, this->bytes(), ptr_);
   cuda_set_device(device_num_);
-  NBLA_CUDA_CHECK(cudaFree(ptr_));
+  NBLA_CUDA_FORCE_ASSERT(cudaFree(ptr_));
 }
 
 bool CudaMemory::alloc_impl() {
@@ -131,7 +131,7 @@ CudaPinnedHostMemory::~CudaPinnedHostMemory() {
                     "Trying to free memory which has a prev (allocated "
                     "by another memory and split previously).");
   DEBUG_LOG("%s: %zu at %p\n", __func__, this->bytes(), ptr_);
-  NBLA_CUDA_CHECK(cudaFreeHost(ptr_));
+  NBLA_CUDA_FORCE_ASSERT(cudaFreeHost(ptr_));
   ptr_ = nullptr; // To avoid double free
 }
 

--- a/src/nbla/cuda/memory/cuda_virtual_memory.cpp
+++ b/src/nbla/cuda/memory/cuda_virtual_memory.cpp
@@ -101,7 +101,7 @@ size_t round_up_by_chunk(size_t x, int device_id) {
 // ----------------------------------------------------------------------
 CudaPhysicalMemory::~CudaPhysicalMemory() {
   if (allocated_)
-    NBLA_CUDA_DRIVER_CHECK(cuMemRelease(handle_));
+    NBLA_CUDA_DRIVER_FORCE_ASSERT(cuMemRelease(handle_));
 }
 
 size_t CudaPhysicalMemory::alloc() {


### PR DESCRIPTION
This PR fixes many cpplib build warnings.

Here is the list of removed warnings:
* deprecated nvcc compute arch 3.5, 5.0
* Throw exception in ctor/dtor from NBLA_CUDA_CHECK
* Throw exception in ctor/dtor from NBLA_CUDNN_CHECK
* Throw exception in ctor/dtor from NBLA_CUBLAS_CHECK
* Throw exception in ctor/dtor from NBLA_CUSOLVER_CHECK
* Throw exception in ctor/dtor from NBLA_CUDA_DRIVER_CHECK
* deprecated cutensorInit(...)
* Suppress inline_qaulifier_ignored warning since it could not be avoided
* non-void function return-type warning
