### PR TITLE
support cuda12.0.1

### DIFF
--- a/build-tools/cmake/select_compute_arch.cmake
+++ b/build-tools/cmake/select_compute_arch.cmake
@@ -59,7 +59,7 @@
 #      ARCH_AND_PTX : NAME | NUM.NUM | NUM.NUM(NUM.NUM) | NUM.NUM+PTX
 #      NAME: Fermi Kepler Maxwell Kepler+Tegra Kepler+Tesla Maxwell+Tegra Pascal Volta Turing Ampere
 #      NUM: Any number. Only those pairs are currently accepted by NVCC though:
-#            2.0 2.1 3.0 3.2 3.5 3.7 5.0 5.2 5.3 6.0 6.2 7.0 7.2 7.5 8.0 8.6
+#            2.0 2.1 3.0 3.2 3.5 3.7 5.0 5.2 5.3 6.0 6.2 7.0 7.2 7.5 8.0 8.6 8.9 9.0
 #      Returns LIST of flags to be added to CUDA_NVCC_FLAGS in ${out_variable}
 #      Additionally, sets ${out_variable}_readable to the resulting numeric list
 #      Example:
@@ -142,6 +142,19 @@ if(CUDA_VERSION VERSION_GREATER_EQUAL "11.1")
 
   set(_CUDA_MAX_COMMON_ARCHITECTURE "8.6+PTX")
   set(CUDA_LIMIT_GPU_ARCHITECTURE "9.0")
+endif()
+
+if(CUDA_VERSION VERSION_GREATER_EQUAL "12.0")
+  list(APPEND CUDA_KNOWN_GPU_ARCHITECTURES "Ada Lovelace")
+  list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "8.9")
+  list(APPEND CUDA_ALL_GPU_ARCHITECTURES "8.9")
+
+  list(APPEND CUDA_KNOWN_GPU_ARCHITECTURES "Hopper")
+  list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "9.0")
+  list(APPEND CUDA_ALL_GPU_ARCHITECTURES "9.0")
+
+  set(_CUDA_MAX_COMMON_ARCHITECTURE "9.0+PTX")
+  unset(CUDA_LIMIT_GPU_ARCHITECTURE)
 endif()
 
 list(APPEND CUDA_COMMON_GPU_ARCHITECTURES "${_CUDA_MAX_COMMON_ARCHITECTURE}")
@@ -293,6 +306,12 @@ function(CUDA_SELECT_NVCC_ARCH_FLAGS out_variable)
       elseif(${arch_name} STREQUAL "Ampere")
         set(arch_bin 8.0)
         set(arch_ptx 8.0)
+      elseif(${arch_name} STREQUAL "Ada Lovelace")
+        set(arch_bin 8.9)
+        set(arch_ptx 8.9)
+      elseif(${arch_name} STREQUAL "Hopper")
+        set(arch_bin 9.0)
+        set(arch_ptx 9.0)
       else()
         message(SEND_ERROR "Unknown CUDA Architecture Name ${arch_name} in CUDA_SELECT_NVCC_ARCH_FLAGS")
       endif()

--- a/build-tools/make/hpcx_url.mk
+++ b/build-tools/make/hpcx_url.mk
@@ -18,5 +18,5 @@
 
 # Map specific openmpi version to HPCX download url
 
-export HPCX_URL_ubuntu_4.1.5='http://www.mellanox.com/downloads/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl2.12-x86_64.tbz'
+export HPCX_URL_ubuntu_4.1.5='https://content.mellanox.com/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda11-gdrcopy2-nccl2.12-x86_64.tbz'
 export HPCX_URL_centos_4.1.5='https://content.mellanox.com/hpc/hpc-x/v2.12/hpcx-v2.12-gcc-MLNX_OFED_LINUX-5-redhat7-cuda11-gdrcopy2-nccl2.12-x86_64.tbz'

--- a/build-tools/msvc/tools/get_cutensor.bat
+++ b/build-tools/msvc/tools/get_cutensor.bat
@@ -19,7 +19,9 @@ REM Download pre-built cuTENSOR library
 SET CUDAVER=%1
 IF %CUDAVER% == 10.2 GOTO :LIB_VER_SET
 IF %CUDAVER% == 11.0 GOTO :LIB_VER_SET
-SET CUDAVER=11
+for /f "delims=." %%i in ("%CUDAVER%") do (
+    SET CUDAVER=%%i
+)
 
 :LIB_VER_SET
 
@@ -29,7 +31,7 @@ SET cutensor_dll=%cutensor_folder%\lib\%CUDAVER%\cutensor.dll
 SET cutensor_include_dir=%cutensor_folder%\include
 
 if NOT EXIST %cutensor_folder%.zip (
-    powershell "%nnabla_iwr_script%; iwr %nnabla_iwr_options% -Uri https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/windows-x86_64/libcutensor-windows-x86_64-1.7.0.1-archive.zip -OutFile %cutensor_folder%.zip" || GOTO :error
+    powershell -ExecutionPolicy Bypass "%nnabla_iwr_script%; iwr %nnabla_iwr_options% -Uri https://developer.download.nvidia.com/compute/cutensor/redist/libcutensor/windows-x86_64/libcutensor-windows-x86_64-1.7.0.1-archive.zip -OutFile %cutensor_folder%.zip" || GOTO :error
 )
 
 IF EXIST %cutensor_library_dir% (

--- a/include/nbla/cuda/defs.hpp
+++ b/include/nbla/cuda/defs.hpp
@@ -35,7 +35,9 @@
     defined(nnabla_cuda_114_8_EXPORTS) ||                                      \
     defined(nnabla_cuda_114_8_dbg_EXPORTS) ||                                  \
     defined(nnabla_cuda_116_8_EXPORTS) ||                                      \
-    defined(nnabla_cuda_116_8_dbg_EXPORTS)
+    defined(nnabla_cuda_116_8_dbg_EXPORTS) ||                                  \
+    defined(nnabla_cuda_120_8_EXPORTS) ||                                      \
+    defined(nnabla_cuda_120_8_dbg_EXPORTS)
 #define NBLA_CUDA_API __declspec(dllexport)
 #else
 #define NBLA_CUDA_API __declspec(dllimport)


### PR DESCRIPTION
we choose cuda 12.0.1 as a stable version to be the new cuda support for nnabla.
The version of cutensor on Windows is also need upgraded for cuda 12 support.