### PR TITLE
Update nnabla cuda12.0 document

### DIFF
--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -14,6 +14,9 @@ Download and install CUDA and cuDNN library (both runtime library and developmen
 * [CUDA toolkit](https://developer.nvidia.com/cuda-downloads)
 * [cuDNN library](https://developer.nvidia.com/rdp/cudnn-download) (Registration required)
  
+As nnabla-ext-cuda now requires cuTENSOR as an additional library during build time, please follow the instruction in the document provided by NVIDIA to install cuTENSOR.
+
+* [cuTENSOR](https://developer.nvidia.com/cutensor-downloads)
 
 ## Build and installation
 
@@ -39,25 +42,32 @@ Then, build. You can optionally turn off the Python package build by `-DBUILD_PY
 and also turn on the C++ utils build by `-DBUILD_CPP_UTILS=ON` in `cmake`. But you must [build C++ utility libraries](https://github.com/sony/nnabla/blob/master/doc/build/build_cpp_utils.md) before you turn on the C++ utils build by `-DBUILD_CPP_UTILS=ON` in `cmake`.
 
 ```shell
-cmake -DNNABLA_DIR=../../nnabla -DCPPLIB_LIBRARY=../../nnabla/build/lib/libnnabla.so ..
+cmake -D CUDA_SELECT_NVCC_ARCH_ARG:STRING="Common" -DNNABLA_DIR=../../nnabla -DCPPLIB_LIBRARY=../../nnabla/build/lib/libnnabla.so ..
 make
 ```
 
-Note: If the reported error is "`FATAL_ERROR, python [python] not found`" in `cmake`. Please establish a soft connection `python` to `python3.x`, you can refer to the following command:
+Note:
+If the reported error is `FATAL_ERROR, python [python] not found` in `cmake`. Please establish a soft connection `python` to `python3.x`, you can refer to the following command as an example:
 
 ```shell
 sudo ln -s /usr/bin/python3.x /usr/bin/python
+```
+
+If the reported error is `fatal error: Python.h: No such file or directory` in `make`. Please install corresponding python development package, you can refer to the following command as an example:
+
+```shell
+sudo apt-get install python3-dev
 ```
 
 To install the Python package:
 
 ```shell
 cd dist
-pip uninstall -y nnabla-ext-cuda
+pip uninstall -y nnabla-ext-cuda116
 pip install nnabla_ext_cuda-{{version}}-{{arch}}.whl
 ```
 
-(Optional for C++ standalone application with [C++ utility](https://github.com/sony/nnabla/tree/master/doc/build/build_cpp_utils.md) To install C++ library on your system:
+(Optional for C++ standalone application with [C++ utility](https://github.com/sony/nnabla/tree/master/doc/build/build_cpp_utils.md)) To install C++ library on your system:
 
 ```shell
 sudo make install  # Set `CMAKE_INSTALL_PREFIX` to install in other place than your system (recommended).

--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -1,6 +1,6 @@
 # Build CUDA Extension
 
-This document shows how to install CUDA extension on Ubuntu 20.04 LTS. We actually only tested on version: Ubuntu 20.04 LTS, cuda11.4.1, cudnn8.2.4, Python 3.8.10. This procedure should work on other Linux distributions. For a build instruction on Windows, go to:
+This document shows how to install CUDA extension on Ubuntu 20.04 LTS. We actually only tested on version: Ubuntu 20.04 LTS, cuda11.6.2, cudnn8.4.0, Python 3.8.10. This procedure should work on other Linux distributions. For a build instruction on Windows, go to:
 
 * [Build on Windows](build_windows.md)
 

--- a/doc/build/build_distributed.md
+++ b/doc/build/build_distributed.md
@@ -1,6 +1,6 @@
 # Build Python Package with distributed execution support powered by NCCL
 
-Distributed execution is only supported on Linux. We tested it on Ubuntu 20.04 LTS, cuda11.4.1, cudnn8.2.4.
+Distributed execution is only supported on Linux. We tested it on Ubuntu 20.04 LTS, cuda11.6.2, cudnn8.4.0.
 
 ## Prerequisites
 
@@ -19,9 +19,10 @@ Download [NCCL](https://developer.nvidia.com/nccl) according to your environment
 then install it manually in case of ubuntu20.04,
 
 ```shell
-sudo dpkg -i nccl-local-repo-ubuntu2004-2.11.4-cuda11.4_1.0-1_amd64.deb
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+sudo dpkg -i cuda-keyring_1.0-1_all.deb
 sudo apt-get update
-sudo apt-get install libnccl2=2.10.3-1+cuda11.4 libnccl-dev=2.10.3-1+cuda11.4
+sudo apt-get install libnccl2=2.12.12-1+cuda11.6 libnccl-dev=2.12.12-1+cuda11.6
 ```
 
 For developer, if you want to use another nccl not publicly distributed,

--- a/doc/build/build_distributed.md
+++ b/doc/build/build_distributed.md
@@ -51,7 +51,7 @@ sudo apt-get install libopenmpi-dev
 Follow [Build CUDA extension](build.md) with a little modification in CMake's option (`-DWITH_NCCL=ON`).
 
 ```shell
-cmake -DNNABLA_DIR=../../nnabla -DCPPLIB_LIBRARY=../../nnabla/build/lib/libnnabla.so -DWITH_NCCL=ON ..
+cmake -D CUDA_SELECT_NVCC_ARCH_ARG:STRING="Common" -DNNABLA_DIR=../../nnabla -DCPPLIB_LIBRARY=../../nnabla/build/lib/libnnabla.so -DWITH_NCCL=ON ..
 ```
 
 Note: If the reported error is "`FATAL_ERROR, python [python] not found`" in `cmake`. Please establish a soft connection `python` to `python3.x`, you can refer to the following command:

--- a/doc/build/build_windows.md
+++ b/doc/build/build_windows.md
@@ -4,7 +4,7 @@
 
 At first, clone [nnabla](https://github.com/sony/nnabla) and [nnabla-ext-cuda](https://github.com/sony/nnabla-ext-cuda) into same folder.
 
-Then, install CUDA11.0/cuDNN8.0 or CUDA11.4/cuDNN8.2 from following site.
+Then, install CUDA11.0/cuDNN8.0 or CUDA11.6/cuDNN8.4 or CUDA12.0/cuDNN8.8 from following site.
 - CUDA
  - https://developer.nvidia.com/cuda-toolkit-archive
 
@@ -31,12 +31,16 @@ build-tools\msvc\build_cpplib.bat 11.0 8
 ```
 or:
 ```
-build-tools\msvc\build_cpplib.bat 11.4 8
+build-tools\msvc\build_cpplib.bat 11.6 8
+```
+or:
+```
+build-tools\msvc\build_cpplib.bat 12.0 8
 ```
 
 Tested version
 
-    CUDA/cuDNN: 11.0/8.0 11.4/8.2
+    CUDA/cuDNN: 11.0/8.0 11.6/8.4 12.0/8.8
 
 ### Build wheel
 Note: parameters `PYTHON_VERSION`, `CUDA_VERSION` and `CUDNN_VERSION` are options of python, cuda and cudnn versions.
@@ -50,10 +54,14 @@ build-tools\msvc\build_wheel.bat 3.8 11.0 8
 ```
 or:
 ```
-build-tools\msvc\build_wheel.bat 3.8 11.4 8
+build-tools\msvc\build_wheel.bat 3.8 11.6 8
+```
+or:
+```
+build-tools\msvc\build_wheel.bat 3.8 12.0 8
 ```
 
 Tested version
 
     PYTHON: 3.8 3.9 3.10
-    CUDA/cuDNN: 11.0/8.0 11.4/8.2
+    CUDA/cuDNN: 11.0/8.0 11.6/8.4 12.0/8.8

--- a/doc/build/quick_build_tools.md
+++ b/doc/build/quick_build_tools.md
@@ -29,7 +29,7 @@ Prepare to specify CUDA, cuDNN, and python version.
 $ export PYTHON_VERSION_MAJOR=3
 $ export PYTHON_VERSION_MINOR=8
 $ export CUDA_VERSION_MAJOR=11
-$ export CUDA_VERSION_MINOR=4.3
+$ export CUDA_VERSION_MINOR=6.2
 $ export CUDNN_VERSION=8
 ```
 
@@ -42,7 +42,7 @@ $ make all
 Or you can specify every time.
 ```
 $ cd nnabla-ext-cuda
-$ make PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=8 CUDA_VERSION_MAJOR=11 CUDA_VERSION_MINOR=4.3 CUDNN_VERSION=8 all
+$ make PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=8 CUDA_VERSION_MAJOR=11 CUDA_VERSION_MINOR=6.2 CUDNN_VERSION=8 all
 ```
 
 ## Windows

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -137,7 +137,7 @@ RUN eval ${DNF_OPTS} \
        nsight-systems-2023.2.3 \
        libsndfile \
        zlib-devel \
-       bzip2 bzip2-devel \
+       bzip2 \
        readline-devel \
        sqlite \
        sqlite-devel \


### PR DESCRIPTION
This PRs update the instruction document to reflect support for cuda 12.0 and the change in the version of protobuf to be used.

The nnabla part is available here: https://github.com/sony/nnabla/pull/1243
