### PR TITLE
drop python3.8 and cuda11.0 support

### DIFF
--- a/build-tools/msvc/build_cpplib.bat
+++ b/build-tools/msvc/build_cpplib.bat
@@ -18,7 +18,7 @@ REM
 SETLOCAL
 
 REM Environment
-CALL %~dp0tools\env.bat 3.9 %1 %2 || GOTO :error
+CALL %~dp0tools\env.bat 3.10 %1 %2 || GOTO :error
 
 IF NOT EXIST %nnabla_build_folder% (
    ECHO nnabla_build_folder ^(%nnabla_build_folder%^) does not exist.

--- a/build-tools/msvc/build_cpplib.bat
+++ b/build-tools/msvc/build_cpplib.bat
@@ -18,7 +18,7 @@ REM
 SETLOCAL
 
 REM Environment
-CALL %~dp0tools\env.bat 3.8 %1 %2 || GOTO :error
+CALL %~dp0tools\env.bat 3.9 %1 %2 || GOTO :error
 
 IF NOT EXIST %nnabla_build_folder% (
    ECHO nnabla_build_folder ^(%nnabla_build_folder%^) does not exist.

--- a/doc/build/build_windows.md
+++ b/doc/build/build_windows.md
@@ -46,11 +46,11 @@ build-tools\msvc\build_wheel.bat PYTHON_VERSION CUDA_VERSION CUDNN_VERSION
 For examples:
 
 ```
-build-tools\msvc\build_wheel.bat 3.9 11.6 8
+build-tools\msvc\build_wheel.bat 3.10 11.6 8
 ```
 or:
 ```
-build-tools\msvc\build_wheel.bat 3.9 12.0 8
+build-tools\msvc\build_wheel.bat 3.10 12.0 8
 ```
 
 Tested version

--- a/doc/build/build_windows.md
+++ b/doc/build/build_windows.md
@@ -4,7 +4,7 @@
 
 At first, clone [nnabla](https://github.com/sony/nnabla) and [nnabla-ext-cuda](https://github.com/sony/nnabla-ext-cuda) into same folder.
 
-Then, install CUDA11.0/cuDNN8.0 or CUDA11.6/cuDNN8.4 or CUDA12.0/cuDNN8.8 from following site.
+Then, install CUDA11.6/cuDNN8.4 or CUDA12.0/cuDNN8.8 from following site.
 - CUDA
  - https://developer.nvidia.com/cuda-toolkit-archive
 
@@ -27,10 +27,6 @@ build-tools\msvc\build_cpplib.bat CUDA_VERSION CUDNN_VERSION
 For examples:
 
 ```
-build-tools\msvc\build_cpplib.bat 11.0 8
-```
-or:
-```
 build-tools\msvc\build_cpplib.bat 11.6 8
 ```
 or:
@@ -40,7 +36,7 @@ build-tools\msvc\build_cpplib.bat 12.0 8
 
 Tested version
 
-    CUDA/cuDNN: 11.0/8.0 11.6/8.4 12.0/8.8
+    CUDA/cuDNN: 11.6/8.4 12.0/8.8
 
 ### Build wheel
 Note: parameters `PYTHON_VERSION`, `CUDA_VERSION` and `CUDNN_VERSION` are options of python, cuda and cudnn versions.
@@ -50,18 +46,14 @@ build-tools\msvc\build_wheel.bat PYTHON_VERSION CUDA_VERSION CUDNN_VERSION
 For examples:
 
 ```
-build-tools\msvc\build_wheel.bat 3.8 11.0 8
+build-tools\msvc\build_wheel.bat 3.9 11.6 8
 ```
 or:
 ```
-build-tools\msvc\build_wheel.bat 3.8 11.6 8
-```
-or:
-```
-build-tools\msvc\build_wheel.bat 3.8 12.0 8
+build-tools\msvc\build_wheel.bat 3.9 12.0 8
 ```
 
 Tested version
 
-    PYTHON: 3.8 3.9 3.10
-    CUDA/cuDNN: 11.0/8.0 11.6/8.4 12.0/8.8
+    PYTHON: 3.9 3.10
+    CUDA/cuDNN: 11.6/8.4 12.0/8.8

--- a/doc/build/quick_build_tools.md
+++ b/doc/build/quick_build_tools.md
@@ -27,7 +27,7 @@ $ make bwd-cpplib
 Prepare to specify CUDA, cuDNN, and python version.
 ```
 $ export PYTHON_VERSION_MAJOR=3
-$ export PYTHON_VERSION_MINOR=9
+$ export PYTHON_VERSION_MINOR=10
 $ export CUDA_VERSION_MAJOR=11
 $ export CUDA_VERSION_MINOR=6.2
 $ export CUDNN_VERSION=8
@@ -42,7 +42,7 @@ $ make all
 Or you can specify every time.
 ```
 $ cd nnabla-ext-cuda
-$ make PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=9 CUDA_VERSION_MAJOR=11 CUDA_VERSION_MINOR=6.2 CUDNN_VERSION=8 all
+$ make PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=10 CUDA_VERSION_MAJOR=11 CUDA_VERSION_MINOR=6.2 CUDNN_VERSION=8 all
 ```
 
 ## Windows

--- a/doc/build/quick_build_tools.md
+++ b/doc/build/quick_build_tools.md
@@ -27,7 +27,7 @@ $ make bwd-cpplib
 Prepare to specify CUDA, cuDNN, and python version.
 ```
 $ export PYTHON_VERSION_MAJOR=3
-$ export PYTHON_VERSION_MINOR=8
+$ export PYTHON_VERSION_MINOR=9
 $ export CUDA_VERSION_MAJOR=11
 $ export CUDA_VERSION_MINOR=6.2
 $ export CUDNN_VERSION=8
@@ -42,7 +42,7 @@ $ make all
 Or you can specify every time.
 ```
 $ cd nnabla-ext-cuda
-$ make PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=8 CUDA_VERSION_MAJOR=11 CUDA_VERSION_MINOR=6.2 CUDNN_VERSION=8 all
+$ make PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=9 CUDA_VERSION_MAJOR=11 CUDA_VERSION_MINOR=6.2 CUDNN_VERSION=8 all
 ```
 
 ## Windows

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -251,7 +251,7 @@ RUN if [ -e /root/openmpi-*.rpm ]; then rpm -i /root/openmpi-*.rpm; fi
 RUN if [ -d /root/hpcx ]; then mkdir /opt/mpi; mv /root/hpcx /opt/mpi/hpcx; fi
 
 ARG PYTHON_VERSION_MAJOR=3
-ARG PYTHON_VERSION_MINOR=8
+ARG PYTHON_VERSION_MINOR=9
 ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
 ############################################################ build python from pyenv

--- a/docker/development/Dockerfile.build-mpi
+++ b/docker/development/Dockerfile.build-mpi
@@ -251,7 +251,7 @@ RUN if [ -e /root/openmpi-*.rpm ]; then rpm -i /root/openmpi-*.rpm; fi
 RUN if [ -d /root/hpcx ]; then mkdir /opt/mpi; mv /root/hpcx /opt/mpi/hpcx; fi
 
 ARG PYTHON_VERSION_MAJOR=3
-ARG PYTHON_VERSION_MINOR=9
+ARG PYTHON_VERSION_MINOR=10
 ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
 ############################################################ build python from pyenv

--- a/python/setup.py
+++ b/python/setup.py
@@ -407,7 +407,6 @@ def get_setup_config(root_dir):
             'License :: OSI Approved :: Apache Software License',
             'Programming Language :: C++',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: Implementation :: CPython',


### PR DESCRIPTION
Python3.8 would be EOL in this October, and many environments now supports real cuda11 and cuda12, so we have decided to end support for python 3.8 and cuda11.0.